### PR TITLE
Include 'main' branch in CodeQL and CI workflow triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -97,6 +97,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "staging" ]
+    branches: [ "main", "staging" ]
   pull_request:
-    branches: [ "staging" ]
+    branches: [ "main", "staging" ]
   schedule:
     - cron: '23 22 * * 2'
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,9 +2,9 @@ name: Progress RPG CI/CD
 
 on:
   push:
-    branches: [ "staging" ]
+    branches: [ "main", "staging" ]
   pull_request:
-    branches: [ "staging" ]
+    branches: [ "main", "staging" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
### Motivation
- The repository default branch was switched to `main`, so workflow triggers must include `main` to run scans and CI on pushes and pull requests targeting the new default.

### Description
- Updated `.github/workflows/codeql.yml` and `.github/workflows/main.yaml` to include `main` alongside `staging` for both `push` and `pull_request` triggers, while `type-check.yml` already included `main` and was left unchanged.

### Testing
- Ran `git diff --check` and used `rg` to verify the `branches:` lines in both modified workflow files, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca89c7c2888322a973c8b641634e19)