### PR TITLE
Queue auth emails and default dev mail to console

### DIFF
--- a/progress_rpg/settings/dev.py
+++ b/progress_rpg/settings/dev.py
@@ -8,6 +8,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 from .base import *
 from .utils import (
+    get_dev_email_backend,
     get_redis_url,
 )
 import sys
@@ -111,8 +112,7 @@ SECRET_KEY_FALLBACKS = [
 DEBUG = os.getenv("DEBUG", "True") == "True"
 
 
-# EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_BACKEND = get_dev_email_backend()
 DEFAULT_FROM_EMAIL = "Progress RPG <noreply@progressrpg.com>"
 print("DEBUG:", DEBUG, file=sys.stderr)
 

--- a/progress_rpg/settings/utils.py
+++ b/progress_rpg/settings/utils.py
@@ -64,6 +64,10 @@ def get_redis_url(default_db="0"):
     return f"{redis_scheme}://{redis_host}:{redis_port}/{redis_db}"
 
 
+def get_dev_email_backend():
+    return os.getenv("EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend")
+
+
 def migrate_and_seed(branch_db_name):
     """
     Run Django migrations and load seed data for the given branch database.

--- a/progress_rpg/tests/test_settings_utils.py
+++ b/progress_rpg/tests/test_settings_utils.py
@@ -1,0 +1,26 @@
+import os
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from progress_rpg.settings.utils import get_dev_email_backend
+
+
+class DevEmailBackendSettingsTest(SimpleTestCase):
+    def test_defaults_to_console_backend(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                get_dev_email_backend(),
+                "django.core.mail.backends.console.EmailBackend",
+            )
+
+    def test_allows_explicit_override(self):
+        with patch.dict(
+            os.environ,
+            {"EMAIL_BACKEND": "django.core.mail.backends.smtp.EmailBackend"},
+            clear=True,
+        ):
+            self.assertEqual(
+                get_dev_email_backend(),
+                "django.core.mail.backends.smtp.EmailBackend",
+            )

--- a/users/adapters.py
+++ b/users/adapters.py
@@ -1,10 +1,46 @@
 from allauth.account.adapter import DefaultAccountAdapter
+from allauth.core import context as allauth_context
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
-from allauth.account.utils import user_email
+
+from users.tasks import send_rendered_email_task
 
 
 class CustomAccountAdapter(DefaultAccountAdapter):
+    def send_mail(self, template_prefix: str, email: str, context: dict) -> None:
+        request = allauth_context.request
+        ctx = {
+            "request": request,
+            "email": email,
+        }
+        if request is not None:
+            ctx["current_site"] = get_current_site(request)
+        ctx.update(context)
+
+        msg = self.render_mail(template_prefix, email, ctx)
+
+        plain_message = ""
+        html_message = ""
+        if getattr(msg, "content_subtype", "plain") == "html":
+            html_message = msg.body
+        else:
+            plain_message = msg.body
+
+        for alternative in getattr(msg, "alternatives", []):
+            content = getattr(alternative, "content", alternative[0])
+            mimetype = getattr(alternative, "mimetype", alternative[1])
+            if mimetype == "text/html":
+                html_message = content
+
+        send_rendered_email_task.delay(
+            recipient_list=msg.to,
+            subject=msg.subject,
+            plain_message=plain_message,
+            html_message=html_message,
+            from_email=msg.from_email,
+            headers=msg.extra_headers or None,
+        )
+
     def send_confirmation_mail(self, request, emailconfirmation, signup):
         activate_url = f"{settings.FRONTEND_URL}/confirm_email/{emailconfirmation.key}"
         ctx = {

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -18,6 +18,29 @@ User = get_user_model()
 logger = logging.getLogger("general")
 
 
+def _send_email_message(
+    *,
+    subject,
+    plain_message,
+    from_email,
+    recipient_list,
+    html_message="",
+    headers=None,
+):
+    email = EmailMultiAlternatives(
+        subject,
+        plain_message,
+        from_email,
+        recipient_list,
+        headers=headers,
+    )
+
+    if html_message:
+        email.attach_alternative(html_message, "text/html")
+
+    email.send()
+
+
 @shared_task
 def perform_account_wipe():
     # Get players marked for deletion
@@ -76,15 +99,48 @@ def send_email_to_users_task(self, emails, subject, template_base, context, cc_a
 
         logger.info(f"[ASYNC SEND EMAIL] Sending '{subject}' to: {emails}")
 
-        email = EmailMultiAlternatives(
-            subject,
-            plain_message,
-            from_email,
-            emails,
+        _send_email_message(
+            subject=subject,
+            plain_message=plain_message,
+            from_email=from_email,
+            recipient_list=emails,
+            html_message=html_message,
         )
-        email.attach_alternative(html_message, "text/html")
-        email.send()
 
     except Exception as exc:
         logger.error(f"[ASYNC SEND EMAIL] Failed: {exc}")
+        raise self.retry(exc=exc)
+
+
+@shared_task(bind=True, retry_backoff=True, max_retries=3)
+def send_rendered_email_task(
+    self,
+    recipient_list,
+    subject,
+    plain_message,
+    html_message="",
+    from_email="",
+    headers=None,
+):
+    """
+    Celery task to send an already-rendered email asynchronously.
+    """
+    try:
+        delivery_from = from_email or settings.DEFAULT_FROM_EMAIL
+
+        logger.info(
+            f"[ASYNC SEND RENDERED EMAIL] Sending '{subject}' to: {recipient_list}"
+        )
+
+        _send_email_message(
+            subject=subject,
+            plain_message=plain_message,
+            from_email=delivery_from,
+            recipient_list=recipient_list,
+            html_message=html_message,
+            headers=headers,
+        )
+
+    except Exception as exc:
+        logger.error(f"[ASYNC SEND RENDERED EMAIL] Failed: {exc}")
         raise self.retry(exc=exc)

--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core import mail
 from django.http import HttpResponse
 from django.test import TestCase, Client, override_settings, tag
 from django.test.client import RequestFactory
@@ -6,17 +7,21 @@ from django.urls import reverse
 from datetime import date, timedelta
 from django.utils import timezone
 from unittest import skip
+from unittest.mock import patch
 import logging
+from types import SimpleNamespace
 
+from allauth.core import context as allauth_context
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from api.views import MeViewSet
 from api.serializers import CustomTokenObtainPairSerializer
 from progress_rpg.middleware.timezone import UserTimezoneMiddleware
+from users.adapters import CustomAccountAdapter
 from users.serializers import PlayerSerializer
 from users.models import Player, UserLogin
 from progression.models import PlayerActivity
-from users.tasks import send_email_to_users_task
+from users.tasks import send_email_to_users_task, send_rendered_email_task
 from users.validators import (
     PLAYER_NAME_MAX_LENGTH,
     PLAYER_NAME_MIN_LENGTH,
@@ -379,26 +384,77 @@ class EmailTaskTest(TestCase):
         emails = ["test@example.com"]
         subject = "Test Email"
         template_base = "emails/email_confirmation_message"
-        context = {"user": {"email": "test@example.com"}}
+        context = {
+            "user": {"email": "test@example.com"},
+            "activate_url": "https://example.com/confirm/test-token",
+        }
         cc_admin = False
 
-        # Run task synchronously
-        send_email_to_users_task(
-            emails=emails,
-            subject=subject,
-            template_base=template_base,
-            context=context,
-            cc_admin=cc_admin,
+        send_email_to_users_task.apply(
+            kwargs={
+                "emails": emails,
+                "subject": subject,
+                "template_base": template_base,
+                "context": context,
+                "cc_admin": cc_admin,
+            }
         )
 
         # Check that the email was sent
-        from django.core.mail import outbox
-
-        self.assertEqual(len(outbox), 1)  # one email was sent
-        email = outbox[0]
+        self.assertEqual(len(mail.outbox), 1)  # one email was sent
+        email = mail.outbox[0]
         self.assertEqual(email.subject, subject)
         self.assertEqual(email.to, emails)
         self.assertIn("test@example.com", email.body)
+
+    def test_send_rendered_email_task(self):
+        send_rendered_email_task.apply(
+            kwargs={
+                "recipient_list": ["rendered@example.com"],
+                "subject": "Rendered Email",
+                "plain_message": "plain body",
+                "html_message": "<p>html body</p>",
+                "from_email": "Progress RPG <noreply@progressrpg.com>",
+                "headers": {"X-Test": "1"},
+            }
+        )
+
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertEqual(email.subject, "Rendered Email")
+        self.assertEqual(email.to, ["rendered@example.com"])
+        self.assertEqual(email.body, "plain body")
+        self.assertEqual(email.extra_headers["X-Test"], "1")
+        alternative = email.alternatives[0]
+        alternative_content = getattr(alternative, "content", alternative[0])
+        self.assertEqual(alternative_content, "<p>html body</p>")
+
+
+class CustomAccountAdapterTest(TestCase):
+    def setUp(self):
+        Character.objects.create(first_name="Jane", can_link=True)
+        self.user = get_user_model().objects.create_user(
+            email="adapter@example.com",
+            password="testpassword123",
+        )
+
+    @patch("users.adapters.send_rendered_email_task.delay")
+    def test_send_confirmation_mail_queues_email_task(self, mock_delay):
+        request = RequestFactory().get("/")
+        adapter = CustomAccountAdapter()
+        emailconfirmation = SimpleNamespace(
+            key="confirm123",
+            email_address=SimpleNamespace(user=self.user, email=self.user.email),
+        )
+
+        with allauth_context.request_context(request):
+            adapter.send_confirmation_mail(request, emailconfirmation, signup=True)
+
+        mock_delay.assert_called_once()
+        kwargs = mock_delay.call_args.kwargs
+        self.assertEqual(kwargs["recipient_list"], [self.user.email])
+        self.assertTrue(kwargs["subject"])
+        self.assertIn("/confirm_email/confirm123", kwargs["plain_message"])
 
 
 class AssignCharacterTest(TestCase):


### PR DESCRIPTION
## Summary
- queue allauth/account emails through Celery-backed delivery instead of sending them synchronously
- add a rendered-email task path so adapter-rendered auth emails can be delivered asynchronously
- default local development to the console email backend, while still allowing an explicit `EMAIL_BACKEND` override
- add focused tests for the adapter queueing path, rendered email task delivery, and the dev email backend helper

## Linked issues
- Refs #151
- Refs #152

## Validation
- `docker compose run --rm web python manage.py test users.tests.tests.EmailTaskTest users.tests.tests.CustomAccountAdapterTest progress_rpg.tests.test_settings_utils`
- `python manage.py check`