### PR TITLE
Fix register page Turnstile validation

### DIFF
--- a/frontend/src/components/Form/Form.jsx
+++ b/frontend/src/components/Form/Form.jsx
@@ -19,26 +19,28 @@ export default function Form({
   const [touched, setTouched] = useState({});
   const titleId = 'form-title-' + Math.random().toString(36).substr(2, 9);
 
-   const handleBlur = (name) => {
+  const handleBlur = (name) => {
     setTouched((prev) => ({ ...prev, [name]: true }));
   };
 
   const getError = (field) => {
+    const fieldValue = field.type === 'checkbox' ? field.checked : field.value;
+
     if (fieldErrors[field.name]?.[0]) {
       return fieldErrors[field.name][0];
     }
 
     if (!touched[field.name]) return '';
-    
-    if (field.required && !field.value) {
+
+    if (field.required && !fieldValue) {
       return 'This field is required';
     }
 
-    if (field.minLength && field.value?.length < field.minLength) {
+    if (field.minLength && fieldValue?.length < field.minLength) {
       return `Must be at least ${field.minLength} characters`;
     }
 
-    if (field.maxLength && field.value?.length > field.maxLength) {
+    if (field.maxLength && fieldValue?.length > field.maxLength) {
       return `Must be no more than ${field.maxLength} characters`;
     }
 
@@ -49,8 +51,8 @@ export default function Form({
     <div className={`${styles.formFrame} ${frameClass || ''}`}>
       {title && <h1 id={titleId} className={styles.formTitle}>{title}</h1>}
 
-      <form 
-        onSubmit={onSubmit} 
+      <form
+        onSubmit={onSubmit}
         className={`${styles.form} ${className || ''}`}
         noValidate
         aria-busy={isSubmitting}
@@ -59,21 +61,24 @@ export default function Form({
 
         <div role="group">
           {fields.map(field => (
-              <Input
-                key={field.name}
-                id={field.id || field.name}
-                label={field.label || field.name}
-                type={field.type}
-                value={field.value}
-                onChange={field.onChange}
-                placeholder={field.placeholder}
-                helpText={field.helpText}
-                required={field.required}
-                autoComplete={field.autoComplete}
-                error={getError(field)}
-                onBlur={() => handleBlur(field.name)}
-                disabled={disabled || isSubmitting}
-              />
+            <Input
+              key={field.name}
+              id={field.id || field.name}
+              label={field.label || field.name}
+              type={field.type}
+              value={field.value}
+              onChange={field.onChange}
+              placeholder={field.placeholder}
+              helpText={field.helpText}
+              required={field.required}
+              autoComplete={field.autoComplete}
+              checked={field.checked}
+              minLength={field.minLength}
+              maxLength={field.maxLength}
+              error={getError(field)}
+              onBlur={() => handleBlur(field.name)}
+              disabled={disabled || isSubmitting}
+            />
           ))}
         </div>
 

--- a/frontend/src/components/Form/Form.test.jsx
+++ b/frontend/src/components/Form/Form.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Form from './Form';
+
+describe('Form', () => {
+  it('does not show a required error for a checked required checkbox', () => {
+    render(
+      <Form
+        title="Register"
+        onSubmit={vi.fn()}
+        fields={[
+          {
+            name: 'agree_to_terms',
+            label: 'Agree to terms',
+            type: 'checkbox',
+            checked: true,
+            onChange: vi.fn(),
+            required: true,
+          },
+        ]}
+      />
+    );
+
+    const checkbox = screen.getByRole('checkbox', { name: /agree to terms/i });
+    fireEvent.blur(checkbox);
+
+    expect(screen.queryByText('This field is required')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/RegisterPage/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.jsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Form from '../../components/Form/Form';
 import useRegister from '../../hooks/useRegister';
 
-const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY;
+const getTurnstileSiteKey = () => import.meta.env.VITE_TURNSTILE_SITE_KEY;
 
 export default function RegisterPage() {
   const [email, setEmail] = useState('');
@@ -18,6 +18,8 @@ export default function RegisterPage() {
   const [agreeToTerms, setAgreeToTerms] = useState(false);
   const location = useLocation();
   const [formState, setFormState] = useState("default");
+  const turnstileContainerRef = useRef(null);
+  const turnstileWidgetIdRef = useRef(null);
 
   useEffect(() => {
     // Reset form or state when location changes (even to the same path)
@@ -25,10 +27,58 @@ export default function RegisterPage() {
   }, [location.key]); // `key` changes on every navigation
 
   useEffect(() => {
-    // Expose a global callback for the Turnstile widget to call
-    window.__turnstileCallback = (token) => setTurnstileToken(token);
-    return () => { delete window.__turnstileCallback; };
-  }, []);
+    const siteKey = getTurnstileSiteKey();
+
+    if (!siteKey || !turnstileContainerRef.current) {
+      return undefined;
+    }
+
+    setTurnstileToken('');
+
+    let cancelled = false;
+    let retryTimeoutId = null;
+
+    const renderTurnstile = () => {
+      if (cancelled || !turnstileContainerRef.current) {
+        return;
+      }
+
+      const turnstile = window.turnstile;
+      if (!turnstile?.render) {
+        retryTimeoutId = window.setTimeout(renderTurnstile, 100);
+        return;
+      }
+
+      turnstileWidgetIdRef.current = turnstile.render(turnstileContainerRef.current, {
+        sitekey: siteKey,
+        callback: (token) => {
+          setTurnstileToken(token);
+          setError((currentError) => (
+            currentError === 'Please complete the security check.' ? '' : currentError
+          ));
+        },
+        'expired-callback': () => setTurnstileToken(''),
+        'error-callback': () => setTurnstileToken(''),
+      });
+    };
+
+    renderTurnstile();
+
+    return () => {
+      cancelled = true;
+
+      if (retryTimeoutId) {
+        window.clearTimeout(retryTimeoutId);
+      }
+
+      const turnstile = window.turnstile;
+      if (turnstile?.remove && turnstileWidgetIdRef.current !== null) {
+        turnstile.remove(turnstileWidgetIdRef.current);
+      }
+
+      turnstileWidgetIdRef.current = null;
+    };
+  }, [location.key]);
 
   const handleRegister = async e => {
     e.preventDefault();
@@ -143,7 +193,7 @@ export default function RegisterPage() {
               ),
               type: 'checkbox',
               checked: agreeToTerms,
-              onChange: e => setAgreeToTerms(e.target.checked),
+              onChange: setAgreeToTerms,
               required: true,
             },
           ]}
@@ -152,11 +202,7 @@ export default function RegisterPage() {
           submitLabel="Create Account"
           fieldErrors={fieldErrors}
         >
-          <div
-            className="cf-turnstile"
-            data-sitekey={TURNSTILE_SITE_KEY}
-            data-callback="__turnstileCallback"
-          />
+          <div ref={turnstileContainerRef} className="cf-turnstile" />
         </Form>
       )}
       {error && <p className="error" role="alert">{error}</p>}

--- a/frontend/src/pages/RegisterPage/RegisterPage.test.jsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.test.jsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import RegisterPage from './RegisterPage';
+
+const mockRegister = vi.fn();
+
+vi.mock('../../hooks/useRegister', () => ({
+  default: () => ({
+    register: mockRegister,
+    characterAvailable: true,
+  }),
+}));
+
+describe('RegisterPage', () => {
+  let turnstileCallbacks;
+
+  beforeEach(() => {
+    vi.stubEnv('VITE_TURNSTILE_SITE_KEY', 'test-site-key');
+    mockRegister.mockReset();
+    mockRegister.mockResolvedValue({
+      success: false,
+      errors: {},
+      errorMessage: 'Registration failed.',
+    });
+
+    turnstileCallbacks = {};
+    window.turnstile = {
+      render: vi.fn((container, options) => {
+        turnstileCallbacks = options;
+        container.dataset.rendered = 'true';
+        return 'widget-id';
+      }),
+      remove: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete window.turnstile;
+  });
+
+  it('renders Turnstile explicitly and submits the token with the form payload', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <RegisterPage />
+      </MemoryRouter>
+    );
+
+    expect(window.turnstile.render).toHaveBeenCalledTimes(1);
+
+    await user.type(screen.getByLabelText(/^Email:/i), 'new@example.com');
+    await user.type(screen.getByLabelText(/^Password:/i), 'password123');
+    await user.type(screen.getByLabelText(/^Confirm password:/i), 'password123');
+    await user.type(screen.getByLabelText(/^Invite Code:/i), 'TESTER');
+    await user.click(screen.getByRole('checkbox'));
+
+    act(() => {
+      turnstileCallbacks.callback('turnstile-token');
+    });
+
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(mockRegister).toHaveBeenCalledWith(
+      'new@example.com',
+      'password123',
+      'password123',
+      'TESTER',
+      true,
+      'turnstile-token',
+      Intl.DateTimeFormat().resolvedOptions().timeZone
+    );
+  });
+});


### PR DESCRIPTION
Fixes #269

## Summary
- explicitly render the Cloudflare Turnstile widget when the register page mounts so SPA navigation reliably initializes the security check
- wire the terms checkbox through the shared form component correctly so required validation uses `checked` state for checkboxes
- add focused frontend tests covering the register flow and checkbox validation

## Validation
- `cd frontend && npx vitest run src/components/Input/Input.test.jsx src/components/Form/Form.test.jsx src/pages/RegisterPage/RegisterPage.test.jsx`
- `cd frontend && npm run build:development`
