### PR TITLE
fix: repair homepage Mailchimp signup flow

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,7 @@ import { WebSocketProvider } from './context/WebSocketContext';
 import MaintenanceWatcher from './components/MaintenanceWatcher';
 import AppContent from "./AppContent";
 
-import { initGA, logPageView } from '../utils/analytics';
+import { initGA, logPageView } from './utils/analytics';
 
 function RouteChangeTracker() {
   const location = useLocation();

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,6 +8,23 @@ import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import './styles/main.scss';
 
+function canRenderReactQueryDevtools() {
+  if (!import.meta.env.DEV || typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const locale = navigator.language || navigator.userLanguage;
+  if (!locale || typeof Intl?.Locale !== 'function') {
+    return true;
+  }
+
+  try {
+    new Intl.Locale(locale);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -25,7 +42,7 @@ root.render(
     <AuthProvider>
       <App />
     </AuthProvider>
-    {process.env.NODE_ENV === "development" && (
+    {canRenderReactQueryDevtools() && (
       <ReactQueryDevtools initialIsOpen={false} />
     )}
   </QueryClientProvider>

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -5,6 +5,7 @@ import BackToTopButton from '../../components/BackToTopButton/BackToTopButton';
 import Button from '../../components/Button/Button';
 import Seo from '../../components/Seo/Seo';
 import styles from './Home.module.scss';
+import { trackEvent } from '../../utils/analytics';
 
 const MAILCHIMP_ACTION_URL =
   import.meta.env.VITE_MAILCHIMP_ACTION_URL ||
@@ -14,6 +15,9 @@ const MAILCHIMP_HONEYPOT_NAME =
   'b_ca98ca16970fc3d18b18a655b_4d402738e3';
 const MAILCHIMP_TAGS_VALUE =
   import.meta.env.VITE_MAILCHIMP_TAGS_VALUE || '1560484';
+const MAILCHIMP_HOSTED_FORM_URL =
+  import.meta.env.VITE_MAILCHIMP_HOSTED_FORM_URL ||
+  'https://progressrpg.us13.list-manage.com/subscribe?u=ca98ca16970fc3d18b18a655b&id=4d402738e3&f_id=0050ede1f0';
 const HOME_URL = 'https://progressrpg.com/';
 const HOME_TITLE = 'Progress RPG | ADHD-Friendly Productivity Support Game';
 const HOME_DESCRIPTION =
@@ -43,9 +47,8 @@ const heroHighlights = [
   'Watch your effort build into progress you can return to tomorrow.',
 ];
 
-// Time (ms) to leave the hidden iframe alive so Mailchimp can finish processing
-// the POST before we clean it up from the DOM.
-const MAILCHIMP_CLEANUP_DELAY_MS = 3000;
+// Time (ms) to leave the request alive before we treat it as failed.
+const MAILCHIMP_REQUEST_TIMEOUT_MS = 10000;
 
 function getEmailValidationMessage(value) {
   const trimmedValue = value.trim();
@@ -61,13 +64,103 @@ function getEmailValidationMessage(value) {
   return '';
 }
 
+function getMailchimpJsonpUrl(actionUrl) {
+  const url = new URL(actionUrl, window.location.origin);
+  url.pathname = url.pathname.replace(/\/post$/, '/post-json');
+  return url;
+}
+
+function getMailchimpResponseMessage(message, fallbackMessage) {
+  if (!message) {
+    return fallbackMessage;
+  }
+
+  const parsedMessage = document.createElement('div');
+  parsedMessage.innerHTML = message;
+
+  return parsedMessage.textContent?.trim() || fallbackMessage;
+}
+
+function isAlreadySubscribedMessage(message) {
+  return /already subscribed/i.test(message);
+}
+
+function isCaptchaRedirectResponse(response, message) {
+  return response?.result === 'redirect' && /captcha/i.test(message);
+}
+
+function getMailchimpHostedSignupUrl(email) {
+  const url = new URL(MAILCHIMP_HOSTED_FORM_URL, window.location.origin);
+
+  if (email.trim()) {
+    url.searchParams.set('EMAIL', email.trim());
+  }
+
+  return url.toString();
+}
+
+function subscribeToMailchimp({ actionUrl, email, tagsValue, honeypotName }) {
+  return new Promise((resolve, reject) => {
+    const callbackName = `mailchimpSignupCallback_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    const url = getMailchimpJsonpUrl(actionUrl);
+    const script = document.createElement('script');
+    const timeoutId = window.setTimeout(() => {
+      cleanup();
+      reject(new Error('Signup is temporarily unavailable. Please try again later.'));
+    }, MAILCHIMP_REQUEST_TIMEOUT_MS);
+
+    function cleanup() {
+      window.clearTimeout(timeoutId);
+      delete window[callbackName];
+      script.remove();
+    }
+
+    url.searchParams.set('EMAIL', email.trim());
+    url.searchParams.set('c', callbackName);
+
+    if (tagsValue) {
+      url.searchParams.set('tags', tagsValue);
+    }
+
+    if (honeypotName) {
+      url.searchParams.set(honeypotName, '');
+    }
+
+    script.src = url.toString();
+    script.async = true;
+
+    window[callbackName] = (response) => {
+      cleanup();
+      resolve(response);
+    };
+
+    script.onerror = () => {
+      cleanup();
+      reject(new Error('Signup is temporarily unavailable. Please try again later.'));
+    };
+
+    document.body.appendChild(script);
+  });
+}
+
 function MailchimpSignupForm() {
   const [email, setEmail] = useState('');
-  const [status, setStatus] = useState('idle'); // 'idle' | 'submitting' | 'success' | 'error'
+  const [status, setStatus] = useState('idle'); // 'idle' | 'submitting' | 'success' | 'error' | 'captcha'
   const [errorMsg, setErrorMsg] = useState('');
+  const [successMsg, setSuccessMsg] = useState('🎉 You’re on the list! We’ll be in touch soon.');
+  const [captchaUrl, setCaptchaUrl] = useState('');
   const emailInputId = useId();
   const emailHelpId = useId();
   const emailErrorId = useId();
+
+  useEffect(() => {
+    if (status === 'success') {
+      trackEvent('waitlist_signup_submitted', {
+        form_name: 'mailchimp_waitlist',
+        page: 'home',
+      });
+    }
+  }, [status]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -81,6 +174,8 @@ function MailchimpSignupForm() {
 
     setStatus('submitting');
     setErrorMsg('');
+    setSuccessMsg('🎉 You’re on the list! We’ll be in touch soon.');
+    setCaptchaUrl('');
 
     if (!MAILCHIMP_ACTION_URL) {
       // Graceful degradation when not configured
@@ -90,53 +185,64 @@ function MailchimpSignupForm() {
     }
 
     try {
-      // Use a hidden iframe to avoid CORS issues with Mailchimp
-      const form = e.target;
-      const data = new FormData(form);
-      const iframeName = `mc-submission-frame-${Date.now()}`;
+      const response = await subscribeToMailchimp({
+        actionUrl: MAILCHIMP_ACTION_URL,
+        email,
+        tagsValue: MAILCHIMP_TAGS_VALUE,
+        honeypotName: MAILCHIMP_HONEYPOT_NAME,
+      });
+      const message = getMailchimpResponseMessage(
+        response?.msg,
+        'Something went wrong. Please try again.'
+      );
 
-      const iframe = document.createElement('iframe');
-      iframe.style.display = 'none';
-      iframe.name = iframeName;
-      document.body.appendChild(iframe);
+      if (response?.result !== 'success') {
+        if (isAlreadySubscribedMessage(message)) {
+          setStatus('success');
+          setSuccessMsg('You’re already on the list with that email address.');
+          setEmail('');
+          return;
+        }
 
-      const hiddenForm = document.createElement('form');
-      hiddenForm.method = 'POST';
-      hiddenForm.action = MAILCHIMP_ACTION_URL;
-      hiddenForm.target = iframeName;
+        if (isCaptchaRedirectResponse(response, message)) {
+          setStatus('captcha');
+          setCaptchaUrl(getMailchimpHostedSignupUrl(email));
+          return;
+        }
 
-      for (const [key, value] of data.entries()) {
-        const input = document.createElement('input');
-        input.type = 'hidden';
-        input.name = key;
-        input.value = value;
-        hiddenForm.appendChild(input);
+        setStatus('error');
+        setErrorMsg(message);
+        return;
       }
 
-      document.body.appendChild(hiddenForm);
-      hiddenForm.submit();
-
-      setTimeout(() => {
-        if (document.body.contains(iframe)) {
-          document.body.removeChild(iframe);
-        }
-        if (document.body.contains(hiddenForm)) {
-          document.body.removeChild(hiddenForm);
-        }
-      }, MAILCHIMP_CLEANUP_DELAY_MS);
-
       setStatus('success');
+      setSuccessMsg('🎉 You’re on the list! We’ll be in touch soon.');
       setEmail('');
-    } catch {
+    } catch (error) {
       setStatus('error');
-      setErrorMsg('Something went wrong. Please try again.');
+      setErrorMsg(
+        error instanceof Error ? error.message : 'Something went wrong. Please try again.'
+      );
     }
   };
 
   if (status === 'success') {
     return (
       <div className={styles.signupSuccess} role="status" aria-live="polite">
-        <p>🎉 You&rsquo;re on the list! We&rsquo;ll be in touch soon.</p>
+        <p>{successMsg}</p>
+      </div>
+    );
+  }
+
+  if (status === 'captcha') {
+    return (
+      <div className={styles.signupSuccess} role="status" aria-live="polite">
+        <p>Mailchimp needs one extra verification step to complete your signup.</p>
+        <p>
+          <a href={captchaUrl || getMailchimpHostedSignupUrl(email)} target="_blank" rel="noreferrer">
+            Continue to the secure signup form
+          </a>
+        </p>
       </div>
     );
   }

--- a/frontend/src/pages/Home/Home.test.jsx
+++ b/frontend/src/pages/Home/Home.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -8,9 +8,14 @@ import Home from './Home';
 
 const mockNavigate = vi.fn();
 const mockUseAuth = vi.fn();
+const mockTrackEvent = vi.fn();
 
 vi.mock('../../context/AuthContext', () => ({
   useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('../../utils/analytics', () => ({
+  trackEvent: (...args) => mockTrackEvent(...args),
 }));
 
 vi.mock('react-router-dom', async () => {
@@ -30,9 +35,25 @@ function renderHome() {
 }
 
 describe('Home', () => {
+  let appendChildSpy;
+
   beforeEach(() => {
     mockNavigate.mockReset();
     mockUseAuth.mockReset();
+    mockTrackEvent.mockReset();
+
+    const originalAppendChild = document.body.appendChild.bind(document.body);
+    appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => {
+      if (node instanceof HTMLScriptElement) {
+        return node;
+      }
+
+      return originalAppendChild(node);
+    });
+  });
+
+  afterEach(() => {
+    appendChildSpy?.mockRestore();
   });
 
   it('renders the logged-out landing page', () => {
@@ -71,6 +92,127 @@ describe('Home', () => {
     await user.click(screen.getByRole('button', { name: 'Join the waitlist' }));
 
     expect(screen.getByRole('alert')).toHaveTextContent('Enter a valid email address, like name@example.com.');
+  });
+
+  it('only shows success after Mailchimp confirms the signup', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+    const user = userEvent.setup();
+    const windowKeysBefore = new Set(Object.keys(window));
+
+    renderHome();
+
+    await user.type(screen.getByLabelText('Email address'), 'newperson@example.com');
+    await user.click(screen.getByRole('button', { name: 'Join the waitlist' }));
+
+    expect(screen.queryByText(/you’re on the list/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Submitting your email' })).toBeDisabled();
+
+    const callbackName = Object.keys(window).find(
+      (key) => !windowKeysBefore.has(key) && key.startsWith('mailchimpSignupCallback_')
+    );
+
+    expect(callbackName).toBeTruthy();
+
+    window[callbackName]({
+      result: 'success',
+      msg: 'Thanks for subscribing!',
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent('🎉 You’re on the list! We’ll be in touch soon.');
+    expect(mockTrackEvent).toHaveBeenCalledWith('waitlist_signup_submitted', {
+      form_name: 'mailchimp_waitlist',
+      page: 'home',
+    });
+  });
+
+  it('shows a Mailchimp error instead of a false success message', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+    const user = userEvent.setup();
+    const windowKeysBefore = new Set(Object.keys(window));
+
+    renderHome();
+
+    await user.type(screen.getByLabelText('Email address'), 'existing@example.com');
+    await user.click(screen.getByRole('button', { name: 'Join the waitlist' }));
+
+    const callbackName = Object.keys(window).find(
+      (key) => !windowKeysBefore.has(key) && key.startsWith('mailchimpSignupCallback_')
+    );
+
+    expect(callbackName).toBeTruthy();
+
+    window[callbackName]({
+      result: 'error',
+      msg: '0 - Please enter a value',
+    });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('0 - Please enter a value');
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('treats already subscribed responses as a successful waitlist state', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+    const user = userEvent.setup();
+    const windowKeysBefore = new Set(Object.keys(window));
+
+    renderHome();
+
+    await user.type(screen.getByLabelText('Email address'), 'existing@example.com');
+    await user.click(screen.getByRole('button', { name: 'Join the waitlist' }));
+
+    const callbackName = Object.keys(window).find(
+      (key) => !windowKeysBefore.has(key) && key.startsWith('mailchimpSignupCallback_')
+    );
+
+    expect(callbackName).toBeTruthy();
+
+    window[callbackName]({
+      result: 'error',
+      msg: '0 - existing@example.com is already subscribed to list Progress RPG.',
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'You’re already on the list with that email address.'
+    );
+    expect(mockTrackEvent).toHaveBeenCalledWith('waitlist_signup_submitted', {
+      form_name: 'mailchimp_waitlist',
+      page: 'home',
+    });
+  });
+
+  it('shows a hosted Mailchimp fallback when captcha verification is required', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+    const user = userEvent.setup();
+    const windowKeysBefore = new Set(Object.keys(window));
+
+    renderHome();
+
+    await user.type(screen.getByLabelText('Email address'), 'person@gmail.com');
+    await user.click(screen.getByRole('button', { name: 'Join the waitlist' }));
+
+    const callbackName = Object.keys(window).find(
+      (key) => !windowKeysBefore.has(key) && key.startsWith('mailchimpSignupCallback_')
+    );
+
+    expect(callbackName).toBeTruthy();
+
+    window[callbackName]({
+      result: 'redirect',
+      msg: 'captcha',
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'Mailchimp needs one extra verification step to complete your signup.'
+    );
+
+    const hostedLink = screen.getByRole('link', { name: 'Continue to the secure signup form' });
+    expect(hostedLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('https://progressrpg.us13.list-manage.com/subscribe?')
+    );
+    expect(hostedLink).toHaveAttribute('href', expect.stringContaining('EMAIL=person%40gmail.com'));
+    expect(mockTrackEvent).not.toHaveBeenCalled();
   });
 
   it('redirects authenticated users to the game', async () => {

--- a/frontend/src/utils/analytics.js
+++ b/frontend/src/utils/analytics.js
@@ -1,0 +1,25 @@
+import ReactGA from 'react-ga4';
+
+const GA_TRACKING_ID = import.meta.env.VITE_GA_TRACKING_ID;
+const GA_TEST_MODE = import.meta.env.VITE_GA_TEST_MODE === 'true';
+
+export const initGA = () => {
+  if (!import.meta.env.PROD && !GA_TEST_MODE) return;
+  if (!GA_TRACKING_ID) return;
+
+  ReactGA.initialize(GA_TRACKING_ID, { testMode: GA_TEST_MODE });
+};
+
+export const logPageView = (path) => {
+  if (!import.meta.env.PROD && !GA_TEST_MODE) return;
+  if (!GA_TRACKING_ID) return;
+
+  ReactGA.send({ hitType: 'pageview', page: path });
+};
+
+export const trackEvent = (eventName, params = {}) => {
+  if (!import.meta.env.PROD && !GA_TEST_MODE) return;
+  if (!GA_TRACKING_ID) return;
+
+  ReactGA.event(eventName, params);
+};


### PR DESCRIPTION
## Summary
- replace the homepage Mailchimp iframe flow with a response-aware JSONP submission
- show real Mailchimp outcomes, including already-subscribed and captcha-required cases
- keep Vite development stable by avoiding the React Query devtools locale crash and moving analytics under `src/`

## Testing
- `cd frontend && npx vitest run src/pages/Home/Home.test.jsx`
- `cd frontend && npm run build:development`
