### PR TITLE
Add remember me session handling

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -31,6 +31,10 @@ def validate_timezone_name(value: str) -> str:
 
 
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
+    remember_me = serializers.BooleanField(
+        required=False, default=False, write_only=True
+    )
+
     @classmethod
     def get_token(cls, user):
         token = super().get_token(user)
@@ -38,13 +42,23 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
         return token
 
     def validate(self, attrs):
+        remember_me = attrs.pop("remember_me", False)
         attrs["username"] = attrs.get("email")
         data = super().validate(attrs)
         UserLogin.objects.create(user=self.user)
 
+        if not remember_me:
+            return {
+                "access_token": data["access"],
+                "refresh_token": data["refresh"],
+            }
+
+        refresh = self.get_token(self.user)
+        refresh.set_exp(lifetime=settings.LONG_SESSION_REFRESH_TOKEN_LIFETIME)
+
         return {
-            "access_token": data["access"],
-            "refresh_token": data["refresh"],
+            "access_token": str(refresh.access_token),
+            "refresh_token": str(refresh),
         }
 
 

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,10 +1,12 @@
 import hashlib
+from datetime import datetime, timezone
 
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase, APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
 from unittest import skip
 from unittest.mock import patch, MagicMock
 
@@ -40,6 +42,58 @@ class TestMeViewSet(APITestCase):
         res = self.client.get(self.me_url)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.data["email"], self.user.email)
+
+
+class CustomTokenObtainPairViewTests(APITestCase):
+    def setUp(self):
+        self.url = reverse("jwt_create")
+        self.user = User.objects.create_user(
+            email="rememberme@example.com",
+            password="pass12345",
+        )
+
+    def _refresh_expiry(self, refresh_token):
+        exp_timestamp = RefreshToken(refresh_token)["exp"]
+        return datetime.fromtimestamp(exp_timestamp, tz=timezone.utc)
+
+    def test_login_uses_short_session_refresh_lifetime_by_default(self):
+        response = self.client.post(
+            self.url,
+            {"email": self.user.email, "password": "pass12345"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("access_token", response.data)
+        self.assertIn("refresh_token", response.data)
+
+        short_expiry = self._refresh_expiry(response.data["refresh_token"])
+        lifetime = short_expiry - datetime.now(timezone.utc)
+
+        self.assertLess(lifetime.days, 2)
+
+    def test_login_uses_long_session_refresh_lifetime_when_remembered(self):
+        short_response = self.client.post(
+            self.url,
+            {"email": self.user.email, "password": "pass12345"},
+            format="json",
+        )
+        long_response = self.client.post(
+            self.url,
+            {
+                "email": self.user.email,
+                "password": "pass12345",
+                "remember_me": True,
+            },
+            format="json",
+        )
+
+        self.assertEqual(long_response.status_code, status.HTTP_200_OK)
+
+        short_expiry = self._refresh_expiry(short_response.data["refresh_token"])
+        long_expiry = self._refresh_expiry(long_response.data["refresh_token"])
+
+        self.assertGreater(long_expiry, short_expiry)
 
 
 @override_settings(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 import { MaintenanceProvider } from './context/MaintenanceContext';
 import { ToastProvider } from './context/ToastContext';
-import { AuthProvider, useAuth } from './context/AuthContext';
+import { AuthProvider } from './context/AuthContext';
+import { useAuth } from './context/useAuth';
 import { GameProvider } from './context/GameContext';
 import { BrowserRouter, useLocation } from 'react-router-dom';
 import { WebSocketProvider } from './context/WebSocketContext';

--- a/frontend/src/AppContent.jsx
+++ b/frontend/src/AppContent.jsx
@@ -8,13 +8,11 @@ import StaticBanner from './components/StaticBanner/StaticBanner';
 import AppRoutes from "./routes/AppRoutes";
 import Footer from './layout/Footer/Footer';
 import FeedbackWidget from './components/FeedbackWidget/FeedbackWidget';
-import { useAuth } from './context/AuthContext';
-import { useGame } from './context/GameContext';
+import { useAuth } from './context/useAuth';
 
 const announcement = `Progress RPG is in alpha status, and under active development. Bugs may appear, and data may be lost. Thank you for testing!`;
 
 export default function AppContent() {
-  const { buildNumber } = useGame();
   const { isAuthenticated } = useAuth();
   const location = useLocation();
   const [drawerOpen, setDrawerOpen] = useState(false);

--- a/frontend/src/components/PlayerSocketListener.jsx
+++ b/frontend/src/components/PlayerSocketListener.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useGame } from '../context/GameContext';
 import { API_BASE_URL } from '../config';
+import { getStoredAccessToken } from '../utils/authStorage';
 
 export default function PlayerSocketListener({ onEvent }) {
   const { player } = useGame();
@@ -12,7 +13,7 @@ export default function PlayerSocketListener({ onEvent }) {
     const connectSocket = async () => {
       try {
         // Step 1: Get JWT from storage
-        const token = localStorage.getItem('accessToken');
+        const token = getStoredAccessToken();
         if (!token) {
             console.warn('[WS] Token missing — not attempting connection');
             return;
@@ -66,7 +67,7 @@ export default function PlayerSocketListener({ onEvent }) {
 
     connectSocket();
     return () => socketRef.current?.close();
-  }, [player?.id]);
+  }, [onEvent, player?.id]);
 
   return null;
 }

--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -1,6 +1,6 @@
 //PrivateRoute.jsx
 import { Navigate } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
+import { useAuth } from '../context/useAuth';
 
 export default function PrivateRoute({ children }) {
   const { isAuthenticated, loading } = useAuth();

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,11 +1,11 @@
-import { createContext, useContext, useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { apiFetch } from "../utils/api";
-
-const AuthContext = createContext(null);
+import { AuthContext } from './authContext';
+import { clearAuthStorage, getStoredAuthTokens, storeAuthTokens } from '../utils/authStorage';
 
 export function AuthProvider({ children }) {
-  const [accessToken, setAccessToken] = useState(() => localStorage.getItem('accessToken'));
-  const [refreshToken, setRefreshToken] = useState(() => localStorage.getItem('refreshToken'));
+  const [accessToken, setAccessToken] = useState(() => getStoredAuthTokens().accessToken);
+  const [refreshToken, setRefreshToken] = useState(() => getStoredAuthTokens().refreshToken);
   const [user, setUser] = useState(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -27,7 +27,7 @@ export function AuthProvider({ children }) {
         const data = await apiFetch('/me/');
         setUser(data);
         setIsAuthenticated(true);
-      } catch (err) {
+      } catch {
         logout();
       } finally {
         setLoading(false);
@@ -37,9 +37,9 @@ export function AuthProvider({ children }) {
     verifyUser();
   }, [accessToken, refreshToken]);
 
-  const login = async (accessToken, refreshToken) => {
-    localStorage.setItem('accessToken', accessToken);
-    localStorage.setItem('refreshToken', refreshToken);
+  const login = async (accessToken, refreshToken, options = {}) => {
+    const { rememberMe = true } = options;
+    storeAuthTokens(accessToken, refreshToken, rememberMe);
     setAccessToken(accessToken);
     setRefreshToken(refreshToken);
     setLoading(true);
@@ -51,7 +51,7 @@ export function AuthProvider({ children }) {
       setUser(data.user);
       setIsAuthenticated(true);
       return data;
-    } catch (err) {
+    } catch {
       setUser(null);
       setIsAuthenticated(false);
     } finally {
@@ -60,7 +60,7 @@ export function AuthProvider({ children }) {
   };
 
   const logout = () => {
-    localStorage.clear();
+    clearAuthStorage();
     setAccessToken(null);
     setRefreshToken(null);
     setUser(null);
@@ -80,8 +80,4 @@ export function AuthProvider({ children }) {
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
-}
-
-export function useAuth() {
-  return useContext(AuthContext);
 }

--- a/frontend/src/context/GameContext.jsx
+++ b/frontend/src/context/GameContext.jsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback, use
 import { useBootstrapGameData } from '../hooks/useBootstrapGameData';
 import { apiFetch } from "../utils/api";
 import useActivityTimer from '../hooks/useActivityTimer';
-import { useAuth } from './AuthContext';
+import { useAuth } from './useAuth';
 
 
 const GameContext = createContext();

--- a/frontend/src/context/WebSocketContext.jsx
+++ b/frontend/src/context/WebSocketContext.jsx
@@ -2,7 +2,7 @@
 import React, { createContext, useContext, useRef, useCallback } from 'react';
 import { useGame } from './GameContext';
 import { useToast } from './ToastContext';
-import { useAuth } from './AuthContext';
+import { useAuth } from './useAuth';
 import { useWebSocketConnection } from '../hooks/useWebSocketConnection';
 import { handleGlobalWebSocketEvent } from '../websockets/handleGlobalWebSocketEvent';
 import { useMaintenanceStatus } from '../hooks/useMaintenanceStatus';

--- a/frontend/src/context/authContext.js
+++ b/frontend/src/context/authContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const AuthContext = createContext(null);

--- a/frontend/src/context/useAuth.js
+++ b/frontend/src/context/useAuth.js
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { AuthContext } from './authContext';
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/frontend/src/hooks/useBootstrapGameData.js
+++ b/frontend/src/hooks/useBootstrapGameData.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { apiFetch } from "../utils/api";
-import { useAuth } from '../context/AuthContext.jsx';
+import { useAuth } from '../context/useAuth';
 
 export function useBootstrapGameData() {
   const { isAuthenticated, loading: authLoading } = useAuth();

--- a/frontend/src/hooks/useLogin.js
+++ b/frontend/src/hooks/useLogin.js
@@ -5,14 +5,14 @@ import { API_BASE_URL } from '../config';
 const API_URL = `${API_BASE_URL}/api/v1`;
 
 export default function useLogin() {
-  const login = useCallback(async (email, password) => {
+  const login = useCallback(async (email, password, rememberMe = false) => {
     try {
       const response = await fetch(`${API_URL}/auth/jwt/create/`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email, password, remember_me: rememberMe }),
       });
 
       if (!response.ok) {
@@ -33,10 +33,6 @@ export default function useLogin() {
           `Login endpoint returned an invalid response payload. url=${response.url} status=${response.status} contentType=${contentType || '<none>'} body=${responsePreview}`
         );
       }
-
-      //console.log('useLogin, data:', data);
-      localStorage.setItem('accessToken', accessToken);
-      localStorage.setItem('refreshToken', refreshToken);
 
       return {
         success: true,

--- a/frontend/src/hooks/useRegister.js
+++ b/frontend/src/hooks/useRegister.js
@@ -1,6 +1,6 @@
 // hooks/useRegister.js
 import { useCallback, useState } from 'react';
-import { useAuth } from '../context/AuthContext';
+import { useAuth } from '../context/useAuth';
 import { API_BASE_URL } from '../config';
 
 const API_URL = `${API_BASE_URL}/api/v1`;
@@ -53,8 +53,6 @@ export default function useRegister() {
        // fallback: handle unexpected case (tokens returned)
       const { accessToken, refreshToken } = data;
       if (accessToken && refreshToken) {
-        localStorage.setItem('accessToken', accessToken);
-        localStorage.setItem('refreshToken', refreshToken);
         await login(accessToken, refreshToken);
         return { success: true };
       }

--- a/frontend/src/layout/Footer/Footer.jsx
+++ b/frontend/src/layout/Footer/Footer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { useAuth } from '../../context/AuthContext';
+import { useAuth } from '../../context/useAuth';
 import styles from './Footer.module.scss';
 import { API_BASE_URL } from '../../config';
 

--- a/frontend/src/layout/NavDrawer/NavDrawer.jsx
+++ b/frontend/src/layout/NavDrawer/NavDrawer.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import styles from './NavDrawer.module.scss';
 import { Link } from 'react-router-dom';
-import { useAuth } from '../../context/AuthContext';
+import { useAuth } from '../../context/useAuth';
 
 export default function NavDrawer({ drawerOpen, onClose }) {
   const drawerRef = useRef(null);

--- a/frontend/src/layout/Navbar/Navbar.jsx
+++ b/frontend/src/layout/Navbar/Navbar.jsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom';
 import styles from './Navbar.module.scss';
 import Button from '../../components/Button/Button';
 import { Link } from 'react-router-dom';
-import { useAuth } from '../../context/AuthContext';
+import { useAuth } from '../../context/useAuth';
 
 export default function Navbar({ onMenuClick }) {
   const { isAuthenticated } = useAuth();

--- a/frontend/src/pages/ConfirmationPage.jsx
+++ b/frontend/src/pages/ConfirmationPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useAuth } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 import { API_BASE_URL } from "../config";
 
 const API_URL = `${API_BASE_URL}/api/v1`;
@@ -9,22 +9,29 @@ export default function ConfirmationPage() {
   const { key } = useParams();
   const navigate = useNavigate();
   const { login } = useAuth();
+  const alreadyConfirmed = Boolean(key) && sessionStorage.getItem("confirmedKey") === key;
 
-  const [status, setStatus] = useState("loading"); // loading | success | error
-  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState(() => {
+    if (!key) {
+      return "error";
+    }
+
+    return alreadyConfirmed ? "success" : "loading";
+  }); // loading | success | error
+  const [message, setMessage] = useState(() => {
+    if (!key) {
+      return "Invalid confirmation link.";
+    }
+
+    return alreadyConfirmed ? "Email already confirmed! Redirecting..." : "";
+  });
 
   useEffect(() => {
     if (!key) {
-      setStatus("error");
-      setMessage("Invalid confirmation link.");
       return;
     }
 
-    // Prevent re-confirmation in the same session
-    const confirmedKey = sessionStorage.getItem("confirmedKey");
-    if (confirmedKey === key) {
-      setStatus("success");
-      setMessage("Email already confirmed! Redirecting...");
+    if (alreadyConfirmed) {
       setTimeout(() => navigate("/onboarding"), 2000);
       return;
     }
@@ -55,14 +62,14 @@ export default function ConfirmationPage() {
           setStatus("error");
           setMessage(data?.message || "Confirmation failed.");
         }
-      } catch (err) {
+      } catch {
         setStatus("error");
         setMessage("Something went wrong.");
       }
     }
 
     confirmEmail();
-  }, [key, navigate, login]);
+  }, [alreadyConfirmed, key, navigate, login]);
 
   return (
     <div>

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useId, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { useAuth } from '../../context/AuthContext';
+import { useAuth } from '../../context/useAuth';
 import BackToTopButton from '../../components/BackToTopButton/BackToTopButton';
 import Button from '../../components/Button/Button';
 import Seo from '../../components/Seo/Seo';

--- a/frontend/src/pages/Home/Home.test.jsx
+++ b/frontend/src/pages/Home/Home.test.jsx
@@ -11,7 +11,7 @@ const mockUseAuth = vi.fn();
 const mockTrackEvent = vi.fn();
 const mockRequestWaitlistSignup = vi.fn();
 
-vi.mock('../../context/AuthContext', () => ({
+vi.mock('../../context/useAuth', () => ({
   useAuth: () => mockUseAuth(),
 }));
 

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -1,13 +1,15 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import useLogin from '../../hooks/useLogin';
-import { useAuth } from '../../context/AuthContext';
+import { useAuth } from '../../context/useAuth';
 import Form from '../../components/Form/Form';
+import Input from '../../components/Input/Input';
 import styles from './LoginPage.module.scss';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
@@ -20,12 +22,16 @@ export default function LoginPage() {
     setSubmitting(true);
     setError('');
 
-    const result1 = await loginWithJwt(email, password);
+    const result1 = await loginWithJwt(email, password, rememberMe);
     //console.log('LoginPage login result1:', result1);
 
     if (result1.success) {
       try {
-        const result2 = await login(result1.tokens.access_token, result1.tokens.refresh_token);
+        const result2 = await login(
+          result1.tokens.access_token,
+          result1.tokens.refresh_token,
+          { rememberMe }
+        );
         //console.log('[HANDLE SUBMIT] result2:', result2);
         if (result2.onboarding_step && result2.onboarding_step < 4) {
           navigate('/onboarding');
@@ -72,6 +78,15 @@ export default function LoginPage() {
           value={password}
           onChange={e => setPassword(e.target.value)}
           required
+        />
+        <Input
+          id="remember-me"
+          type="checkbox"
+          label="Remember me"
+          checked={rememberMe}
+          onChange={setRememberMe}
+          className={styles.rememberMeField}
+          inputClassName={styles.rememberMeInput}
         />
         <p className={styles.footer}>
           New here? <Link to="/register">Create an account</Link>

--- a/frontend/src/pages/LoginPage/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage/LoginPage.module.scss
@@ -32,6 +32,17 @@
   }
 }
 
+.rememberMeField {
+  flex-direction: row;
+  align-items: center;
+  gap: v.$spacing-sm;
+}
+
+.rememberMeInput {
+  width: auto !important;
+  max-width: none !important;
+}
+
 .error {
   @include c.apply-text-tone(map.get(c.$text-tone, error));
   margin-bottom: v.$spacing-sm;

--- a/frontend/src/pages/LoginPage/LoginPage.test.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.test.jsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import LoginPage from './LoginPage';
+
+const mockNavigate = vi.fn();
+const mockLoginWithJwt = vi.fn();
+const mockAuthLogin = vi.fn();
+
+vi.mock('../../hooks/useLogin', () => ({
+  default: () => mockLoginWithJwt,
+}));
+
+vi.mock('../../context/useAuth', () => ({
+  useAuth: () => ({
+    login: mockAuthLogin,
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function renderLoginPage() {
+  return render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>
+  );
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockLoginWithJwt.mockReset();
+    mockAuthLogin.mockReset();
+    mockAuthLogin.mockResolvedValue({});
+  });
+
+  it('submits without remember me by default', async () => {
+    const user = userEvent.setup();
+    mockLoginWithJwt.mockResolvedValue({
+      success: true,
+      tokens: {
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+      },
+    });
+
+    renderLoginPage();
+
+    await user.type(screen.getByPlaceholderText('Email'), 'person@example.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'secret123');
+    await user.click(screen.getByRole('button', { name: 'Log In' }));
+
+    await waitFor(() => {
+      expect(mockLoginWithJwt).toHaveBeenCalledWith('person@example.com', 'secret123', false);
+    });
+    expect(mockAuthLogin).toHaveBeenCalledWith('access-token', 'refresh-token', { rememberMe: false });
+    expect(mockNavigate).toHaveBeenCalledWith('/timer');
+  });
+
+  it('submits remembered sessions when the checkbox is selected', async () => {
+    const user = userEvent.setup();
+    mockLoginWithJwt.mockResolvedValue({
+      success: true,
+      tokens: {
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+      },
+    });
+
+    renderLoginPage();
+
+    await user.type(screen.getByPlaceholderText('Email'), 'person@example.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'secret123');
+    await user.click(screen.getByRole('checkbox', { name: 'Remember me' }));
+    await user.click(screen.getByRole('button', { name: 'Log In' }));
+
+    await waitFor(() => {
+      expect(mockLoginWithJwt).toHaveBeenCalledWith('person@example.com', 'secret123', true);
+    });
+    expect(mockAuthLogin).toHaveBeenCalledWith('access-token', 'refresh-token', { rememberMe: true });
+  });
+});

--- a/frontend/src/pages/LogoutPage/LogoutPage.jsx
+++ b/frontend/src/pages/LogoutPage/LogoutPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useAuth } from '../../context/AuthContext';
+import { useAuth } from '../../context/useAuth';
 import { useNavigate } from 'react-router-dom';
 import { useWebSocket } from '../../context/WebSocketContext';
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,6 +1,11 @@
 // src/utils/api.js
 import { jwtDecode } from "jwt-decode";
 import { API_BASE_URL } from "../config";
+import {
+  clearAuthStorage,
+  getStoredAuthTokens,
+  updateStoredAccessToken,
+} from "./authStorage";
 
 const API_URL = `${API_BASE_URL}/api/v1`;
 
@@ -9,14 +14,13 @@ function isTokenExpiringSoon(token, bufferSeconds = 60) {
     const { exp } = jwtDecode(token);
     const now = Date.now() / 1000;
     return exp - now < bufferSeconds;
-  } catch (err) {
+  } catch {
     return true; // treat invalid token as expiring
   }
 }
 
 function clearAuthAndRedirect() {
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refreshToken");
+  clearAuthStorage();
 
   // Give user feedback before redirect
   console.warn("[Auth] Session expired, redirecting to login...");
@@ -40,7 +44,7 @@ async function refreshAccessToken(refreshToken) {
     const data = await response.json();
 
     if (data.access_token) {
-      localStorage.setItem("accessToken", data.access_token);
+      updateStoredAccessToken(data.access_token);
       return data.access_token;
     }
     throw new Error("No access token returned from refresh");
@@ -50,8 +54,7 @@ async function refreshAccessToken(refreshToken) {
 }
 
 async function getValidAccessToken() {
-  const accessToken = localStorage.getItem("accessToken");
-  const refreshToken = localStorage.getItem("refreshToken");
+  const { accessToken, refreshToken } = getStoredAuthTokens();
   if (!accessToken || !refreshToken) throw new Error("Missing tokens");
 
   if (isTokenExpiringSoon(accessToken)) {

--- a/frontend/src/utils/authStorage.js
+++ b/frontend/src/utils/authStorage.js
@@ -1,0 +1,50 @@
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+function getTokenBundle(storage) {
+  const accessToken = storage.getItem(ACCESS_TOKEN_KEY);
+  const refreshToken = storage.getItem(REFRESH_TOKEN_KEY);
+
+  if (!accessToken || !refreshToken) {
+    return null;
+  }
+
+  return { accessToken, refreshToken };
+}
+
+export function getStoredAuthTokens() {
+  return getTokenBundle(localStorage) || getTokenBundle(sessionStorage) || {
+    accessToken: null,
+    refreshToken: null,
+  };
+}
+
+export function storeAuthTokens(accessToken, refreshToken, rememberMe = true) {
+  clearAuthStorage();
+  const storage = rememberMe ? localStorage : sessionStorage;
+
+  storage.setItem(ACCESS_TOKEN_KEY, accessToken);
+  storage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+}
+
+export function updateStoredAccessToken(accessToken) {
+  if (localStorage.getItem(REFRESH_TOKEN_KEY)) {
+    localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+    return;
+  }
+
+  if (sessionStorage.getItem(REFRESH_TOKEN_KEY)) {
+    sessionStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+  }
+}
+
+export function getStoredAccessToken() {
+  return getStoredAuthTokens().accessToken;
+}
+
+export function clearAuthStorage() {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+  sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+  sessionStorage.removeItem(REFRESH_TOKEN_KEY);
+}

--- a/frontend/src/utils/authStorage.test.js
+++ b/frontend/src/utils/authStorage.test.js
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearAuthStorage,
+  getStoredAccessToken,
+  getStoredAuthTokens,
+  storeAuthTokens,
+  updateStoredAccessToken,
+} from './authStorage';
+
+describe('authStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('stores remembered tokens in localStorage', () => {
+    storeAuthTokens('access-token', 'refresh-token', true);
+
+    expect(localStorage.getItem('accessToken')).toBe('access-token');
+    expect(localStorage.getItem('refreshToken')).toBe('refresh-token');
+    expect(sessionStorage.getItem('accessToken')).toBeNull();
+    expect(sessionStorage.getItem('refreshToken')).toBeNull();
+  });
+
+  it('stores short-session tokens in sessionStorage', () => {
+    storeAuthTokens('access-token', 'refresh-token', false);
+
+    expect(sessionStorage.getItem('accessToken')).toBe('access-token');
+    expect(sessionStorage.getItem('refreshToken')).toBe('refresh-token');
+    expect(localStorage.getItem('accessToken')).toBeNull();
+    expect(localStorage.getItem('refreshToken')).toBeNull();
+  });
+
+  it('reads tokens from whichever auth storage is active', () => {
+    sessionStorage.setItem('accessToken', 'session-access');
+    sessionStorage.setItem('refreshToken', 'session-refresh');
+
+    expect(getStoredAuthTokens()).toEqual({
+      accessToken: 'session-access',
+      refreshToken: 'session-refresh',
+    });
+    expect(getStoredAccessToken()).toBe('session-access');
+  });
+
+  it('updates refreshed access tokens in the active storage', () => {
+    storeAuthTokens('old-access', 'refresh-token', false);
+
+    updateStoredAccessToken('new-access');
+
+    expect(sessionStorage.getItem('accessToken')).toBe('new-access');
+    expect(localStorage.getItem('accessToken')).toBeNull();
+  });
+
+  it('clears auth tokens from both storages', () => {
+    localStorage.setItem('accessToken', 'local-access');
+    localStorage.setItem('refreshToken', 'local-refresh');
+    sessionStorage.setItem('accessToken', 'session-access');
+    sessionStorage.setItem('refreshToken', 'session-refresh');
+
+    clearAuthStorage();
+
+    expect(getStoredAuthTokens()).toEqual({
+      accessToken: null,
+      refreshToken: null,
+    });
+  });
+});

--- a/progress_rpg/settings/base.py
+++ b/progress_rpg/settings/base.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
+from datetime import timedelta
 from pathlib import Path
 import sys
 import dj_database_url
@@ -168,8 +169,12 @@ SPECTACULAR_SETTINGS = {
     "SERVE_INCLUDE_SCHEMA": False,
 }
 
+SHORT_SESSION_REFRESH_TOKEN_LIFETIME = timedelta(days=1)
+LONG_SESSION_REFRESH_TOKEN_LIFETIME = timedelta(days=30)
+
 SIMPLE_JWT = {
     "AUTH_HEADER_TYPES": ("Bearer",),
+    "REFRESH_TOKEN_LIFETIME": SHORT_SESSION_REFRESH_TOKEN_LIFETIME,
 }
 
 REST_USE_JWT = True


### PR DESCRIPTION
## Summary
- add a remember me checkbox to login and route auth tokens through shared storage helpers
- store short sessions in sessionStorage, remembered sessions in localStorage, and keep refresh/websocket flows aligned
- extend JWT issuance to support longer remembered refresh tokens and add login/session tests

## Validation
- `cd frontend && npx eslint <changed frontend files>`
- `cd frontend && npx vitest run src/pages/Home/Home.test.jsx src/pages/LoginPage/LoginPage.test.jsx src/utils/authStorage.test.js`
- `cd frontend && npm run build:development`
- backend Docker validation: remember-me auth tests passed; broader `users api` suite still has unrelated existing failures