### PR TITLE
Replace django-channels-jwt websocket auth

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -3,7 +3,6 @@ from rest_framework_simplejwt.views import TokenVerifyView
 
 from django.urls import path, include, register_converter
 from rest_framework.routers import DefaultRouter
-from django_channels_jwt.views import AsgiValidateTokenView
 
 from .views import (
     CustomRegisterView,
@@ -77,7 +76,6 @@ urlpatterns = [
     path("fetch_info/", FetchInfoAPIView.as_view(), name="fetch_info"),
     path("waitlist_signup/", WaitlistSignupAPIView.as_view(), name="waitlist_signup"),
     # Auth urls
-    path("ws_auth/", AsgiValidateTokenView.as_view(), name="ws_auth"),
     path("auth/", include(auth_urls)),
     path("auth/jwt/create/", CustomTokenObtainPairView.as_view(), name="jwt_create"),
     path("auth/jwt/refresh/", CustomTokenRefreshView.as_view(), name="jwt_refresh"),

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -342,8 +342,6 @@ pycparser==2.23
     # via
     #   -c requirements.txt
     #   cffi
-pygments==2.19.2
-    # via sphinx
 pyjwt==2.10.1
     # via
     #   -c requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -72,7 +72,6 @@ channels==4.1.0
     #   -c requirements.txt
     #   -r requirements.in
     #   channels-redis
-    #   django-channels-jwt
 channels-redis==4.1.0
     # via
     #   -c requirements.txt
@@ -151,7 +150,6 @@ django==5.2.13
     #   django-allauth
     #   django-celery-beat
     #   django-cf-turnstile
-    #   django-channels-jwt
     #   django-cors-headers
     #   django-extensions
     #   django-filter
@@ -172,10 +170,6 @@ django-celery-beat==2.8.1
     #   -c requirements.txt
     #   -r requirements.in
 django-cf-turnstile==0.1.0
-    # via
-    #   -c requirements.txt
-    #   -r requirements.in
-django-channels-jwt==0.0.3
     # via
     #   -c requirements.txt
     #   -r requirements.in

--- a/frontend/src/hooks/useWebSocketConnection.js
+++ b/frontend/src/hooks/useWebSocketConnection.js
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/set-state-in-effect */
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { API_BASE_URL } from '../config';
-import { apiFetch } from "../utils/api";
+import { getValidAccessToken } from "../utils/api";
 
 // WebSocket connection constants
 const RECONNECT_DELAY_MS = 3000;
@@ -27,13 +27,13 @@ export function useWebSocketConnection(playerId, onMessage, onError, onClose, on
     }
 
     try {
-      // Get UUID for connection using shared auth/refresh logic.
-      const { uuid } = await apiFetch('/ws_auth/', { method: 'GET' });
+      const accessToken = await getValidAccessToken();
 
       // Build WebSocket URL
       const url = new URL(API_BASE_URL);
       const protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-      const wsUrl = `${protocol}//${url.host}/ws/profile_${playerId}/?uuid=${uuid}`;
+      const wsUrl = new URL(`${protocol}//${url.host}/ws/profile_${playerId}/`);
+      wsUrl.searchParams.set('token', accessToken);
 
       // Close existing socket if any
       if (socketRef.current?.readyState === WebSocket.OPEN) {
@@ -41,7 +41,7 @@ export function useWebSocketConnection(playerId, onMessage, onError, onClose, on
         socketRef.current.close();
       }
 
-      const socket = new WebSocket(wsUrl);
+      const socket = new WebSocket(wsUrl.toString());
       socketRef.current = socket;
 
       socket.onopen = () => {

--- a/frontend/src/hooks/useWebSocketConnection.test.jsx
+++ b/frontend/src/hooks/useWebSocketConnection.test.jsx
@@ -1,0 +1,67 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useWebSocketConnection } from './useWebSocketConnection';
+
+const mockGetValidAccessToken = vi.fn();
+const sockets = [];
+
+vi.mock('../utils/api', () => ({
+  getValidAccessToken: (...args) => mockGetValidAccessToken(...args),
+}));
+
+class MockWebSocket {
+  static OPEN = 1;
+
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0;
+    this.close = vi.fn(() => {
+      this.readyState = 3;
+    });
+    this.send = vi.fn();
+    sockets.push(this);
+  }
+}
+
+describe('useWebSocketConnection', () => {
+  beforeEach(() => {
+    sockets.length = 0;
+    mockGetValidAccessToken.mockReset();
+    vi.stubGlobal('WebSocket', MockWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('connects with a JWT query parameter instead of calling ws_auth', async () => {
+    mockGetValidAccessToken.mockResolvedValue('test-access-token');
+
+    const onMessage = vi.fn();
+    const onError = vi.fn();
+    const onClose = vi.fn();
+    const onOpen = vi.fn();
+
+    const { result } = renderHook(() =>
+      useWebSocketConnection(42, onMessage, onError, onClose, onOpen)
+    );
+
+    await waitFor(() => {
+      expect(mockGetValidAccessToken).toHaveBeenCalledTimes(1);
+      expect(sockets).toHaveLength(1);
+    });
+
+    expect(sockets[0].url).toBe(
+      'ws://localhost:8000/ws/profile_42/?token=test-access-token'
+    );
+
+    act(() => {
+      sockets[0].readyState = MockWebSocket.OPEN;
+      sockets[0].onopen();
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -49,7 +49,7 @@ async function refreshAccessToken(refreshToken) {
   }
 }
 
-async function getValidAccessToken() {
+export async function getValidAccessToken() {
   const accessToken = localStorage.getItem("accessToken");
   const refreshToken = localStorage.getItem("refreshToken");
   if (!accessToken || !refreshToken) throw new Error("Missing tokens");

--- a/progress_rpg/asgi.py
+++ b/progress_rpg/asgi.py
@@ -8,16 +8,11 @@ https://docs.djangoproject.com/en/5.1/howto/deployment/asgi/
 """
 
 import os
+
 import django
 
 from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
-from django.conf import settings
-from django.urls import re_path
-from django.views.static import serve
-
-# from channels.auth import AuthMiddlewareStack
-# from gameplay.mymiddleware import MyAuthMiddleware
 
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE",
@@ -26,15 +21,15 @@ os.environ.setdefault(
 
 django.setup()
 
-from django_channels_jwt.middleware import JwtAuthMiddlewareStack
 from gameplay.routing import load_websocket_urlpatterns
+from progress_rpg.middleware.channels_jwt import JWTQueryStringAuthMiddlewareStack
 
 django_asgi_app = get_asgi_application()
 
 application = ProtocolTypeRouter(
     {
         "http": django_asgi_app,
-        "websocket": JwtAuthMiddlewareStack(
+        "websocket": JWTQueryStringAuthMiddlewareStack(
             URLRouter(load_websocket_urlpatterns()),
         ),
     }

--- a/progress_rpg/middleware/channels_jwt.py
+++ b/progress_rpg/middleware/channels_jwt.py
@@ -1,0 +1,63 @@
+import logging
+from urllib.parse import parse_qs
+
+from channels.auth import AuthMiddlewareStack
+from channels.db import database_sync_to_async
+from channels.middleware import BaseMiddleware
+from django.contrib.auth.models import AnonymousUser
+from django.db import close_old_connections
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+
+logger = logging.getLogger("general")
+
+SUPPORTED_TOKEN_QUERY_PARAMS = ("token", "access_token")
+
+
+@database_sync_to_async
+def get_user_from_token(raw_token):
+    authenticator = JWTAuthentication()
+    validated_token = authenticator.get_validated_token(raw_token)
+    return authenticator.get_user(validated_token)
+
+
+class QueryStringJWTAuthMiddleware(BaseMiddleware):
+    async def __call__(self, scope, receive, send):
+        close_old_connections()
+
+        scope = dict(scope)
+        current_user = scope.get("user")
+
+        if current_user is None:
+            scope["user"] = AnonymousUser()
+
+        raw_token = self._extract_token(scope)
+        if raw_token:
+            try:
+                scope["user"] = await get_user_from_token(raw_token)
+            except (AuthenticationFailed, InvalidToken, TokenError) as exc:
+                logger.warning(
+                    "WebSocket JWT authentication failed.",
+                    exc_info=exc,
+                )
+                if scope.get("user") is None:
+                    scope["user"] = AnonymousUser()
+
+        return await super().__call__(scope, receive, send)
+
+    @staticmethod
+    def _extract_token(scope):
+        query_string = scope.get("query_string", b"")
+        params = parse_qs(query_string.decode("utf-8"))
+
+        for key in SUPPORTED_TOKEN_QUERY_PARAMS:
+            values = params.get(key)
+            if values:
+                return values[0]
+
+        return None
+
+
+def JWTQueryStringAuthMiddlewareStack(inner):
+    return AuthMiddlewareStack(QueryStringJWTAuthMiddleware(inner))

--- a/progress_rpg/tests/test_channels_jwt_middleware.py
+++ b/progress_rpg/tests/test_channels_jwt_middleware.py
@@ -1,0 +1,57 @@
+from asgiref.sync import async_to_sync
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import TransactionTestCase
+from rest_framework_simplejwt.tokens import AccessToken
+
+from progress_rpg.middleware.channels_jwt import QueryStringJWTAuthMiddleware
+
+
+class QueryStringJWTAuthMiddlewareTests(TransactionTestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            email="websocket-auth@example.com",
+            password="test-pass-123",
+        )
+
+    def _run_middleware(self, query_string):
+        captured = {}
+
+        async def inner(scope, receive, send):
+            captured["user"] = scope["user"]
+
+        middleware = QueryStringJWTAuthMiddleware(inner)
+        scope = {
+            "type": "websocket",
+            "headers": [],
+            "query_string": query_string,
+        }
+
+        async def receive():
+            return {"type": "websocket.disconnect"}
+
+        async def send(message):
+            return message
+
+        async_to_sync(middleware)(scope, receive, send)
+        return captured["user"]
+
+    def test_sets_authenticated_user_from_valid_token_query_param(self):
+        token = str(AccessToken.for_user(self.user))
+
+        user = self._run_middleware(f"token={token}".encode("utf-8"))
+
+        self.assertEqual(user.pk, self.user.pk)
+        self.assertTrue(user.is_authenticated)
+
+    def test_leaves_anonymous_user_when_token_is_missing(self):
+        user = self._run_middleware(b"")
+
+        self.assertIsInstance(user, AnonymousUser)
+        self.assertFalse(user.is_authenticated)
+
+    def test_leaves_anonymous_user_when_token_is_invalid(self):
+        user = self._run_middleware(b"token=not-a-real-token")
+
+        self.assertIsInstance(user, AnonymousUser)
+        self.assertFalse(user.is_authenticated)

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,6 @@ Django<6
 django-allauth
 django-celery-beat
 django-cf-turnstile
-django-channels-jwt
 django-cors-headers
 django-environ
 django-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,6 @@ channels==4.1.0
     # via
     #   -r requirements.in
     #   channels-redis
-    #   django-channels-jwt
 channels-redis==4.1.0
     # via -r requirements.in
 charset-normalizer==3.4.4
@@ -103,7 +102,6 @@ django==5.2.13
     #   django-allauth
     #   django-celery-beat
     #   django-cf-turnstile
-    #   django-channels-jwt
     #   django-cors-headers
     #   django-extensions
     #   django-filter
@@ -118,8 +116,6 @@ django-allauth==65.14.1
 django-celery-beat==2.8.1
     # via -r requirements.in
 django-cf-turnstile==0.1.0
-    # via -r requirements.in
-django-channels-jwt==0.0.3
     # via -r requirements.in
 django-cors-headers==4.9.0
     # via -r requirements.in


### PR DESCRIPTION
## Summary
- replace django-channels-jwt with a custom Channels middleware backed by SimpleJWT
- connect the frontend websocket directly with a refreshed access token instead of the legacy /api/ws_auth/ handshake
- remove the old dependency and add focused websocket auth coverage

## Validation
- cd frontend && npm run lint -- --quiet
- cd frontend && npx vitest run src/hooks/useWebSocketConnection.test.jsx
- docker compose up -d db redis
- docker compose run --rm migrate
- docker compose run --rm web python manage.py test progress_rpg.tests.test_channels_jwt_middleware gameplay.tests.test_consumers
- docker compose down