### PR TITLE
Stop auto-provisioning free Stripe subscriptions

### DIFF
--- a/payments/admin.py
+++ b/payments/admin.py
@@ -4,7 +4,7 @@ import stripe
 from django.contrib import admin, messages
 
 from payments.models import SubscriptionPlan, UserSubscription, StripeEvent
-from payments.services import end_active_subscription_and_activate_free
+from payments.services import end_active_subscription
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +42,10 @@ class UserSubscriptionAdmin(admin.ModelAdmin):
     list_display = ["user", "plan", "active", "start_date", "end_date"]
     list_filter = ["active", "plan__name"]
     search_fields = ["user__email", "plan__name", "stripe_subscription_id"]
-    actions = ["end_subscription_and_activate_free"]
+    actions = ["end_subscription"]
 
-    @admin.action(description="End active subscription and activate free plan")
-    def end_subscription_and_activate_free(self, request, queryset):
+    @admin.action(description="End active subscription")
+    def end_subscription(self, request, queryset):
         success_count = 0
         skip_count = 0
 
@@ -55,7 +55,7 @@ class UserSubscriptionAdmin(admin.ModelAdmin):
                 continue
 
             try:
-                end_active_subscription_and_activate_free(subscription.user)
+                end_active_subscription(subscription.user)
                 success_count += 1
             except stripe.error.StripeError as exc:
                 logger.warning(
@@ -83,7 +83,7 @@ class UserSubscriptionAdmin(admin.ModelAdmin):
         if success_count:
             self.message_user(
                 request,
-                f"Successfully ended subscription and activated free plan for {success_count} user(s).",
+                f"Successfully ended active subscriptions for {success_count} user(s).",
                 level=messages.SUCCESS,
             )
         if skip_count:

--- a/payments/management/commands/end_active_subscription.py
+++ b/payments/management/commands/end_active_subscription.py
@@ -3,14 +3,14 @@ import logging
 import stripe
 from django.core.management.base import BaseCommand, CommandError
 
-from payments.services import end_active_subscription_and_activate_free
+from payments.services import end_active_subscription
 from users.models import CustomUser
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "End a user's active subscription and activate a free plan. Pass one or more user emails."
+    help = "End a user's active premium subscription. Pass one or more user emails."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -33,7 +33,7 @@ class Command(BaseCommand):
                 continue
 
             try:
-                result = end_active_subscription_and_activate_free(user)
+                result = end_active_subscription(user)
             except stripe.error.StripeError as exc:
                 self.stderr.write(self.style.ERROR(f"Stripe error for {email}: {exc}"))
                 logger.error("Stripe error when downgrading %s: %s", email, exc)
@@ -54,7 +54,7 @@ class Command(BaseCommand):
             else:
                 self.stdout.write(
                     self.style.SUCCESS(
-                        f"Downgraded {email} to free plan (subscription: {result.stripe_subscription_id})."
+                        f"Ended active subscription for {email} (subscription: {result.stripe_subscription_id})."
                     )
                 )
                 success_count += 1
@@ -65,6 +65,6 @@ class Command(BaseCommand):
             )
         self.stdout.write(
             self.style.SUCCESS(
-                f"Done. Downgraded {success_count} user(s) to free plan."
+                f"Done. Ended subscriptions for {success_count} user(s)."
             )
         )

--- a/payments/management/commands/provision_free_subscriptions.py
+++ b/payments/management/commands/provision_free_subscriptions.py
@@ -1,23 +1,11 @@
-from django.core.management.base import BaseCommand
-
-from payments.services import provision_free_subscription
-from users.models import CustomUser
+from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):
-    help = "Provision free Stripe subscriptions for users without one."
+    help = "Deprecated: free Stripe subscription provisioning has been removed."
 
     def handle(self, *args, **options):
-        count = 0
-        users = CustomUser.objects.select_related("player").all()
-
-        for user in users:
-            try:
-                provision_free_subscription(user)
-                count += 1
-            except Exception as exc:
-                self.stderr.write(f"Failed for user {user.id}: {exc}")
-
-        self.stdout.write(
-            self.style.SUCCESS(f"Provisioned free subscriptions for {count} users.")
+        raise CommandError(
+            "Free Stripe subscription provisioning has been removed. "
+            "Free users are not created in Stripe until they start a premium checkout session."
         )

--- a/payments/services.py
+++ b/payments/services.py
@@ -2,69 +2,14 @@ import stripe
 from django.conf import settings
 from django.db import transaction
 
-from payments.models import SubscriptionPlan, UserSubscription
+from payments.models import UserSubscription
 
 stripe.api_key = settings.STRIPE_SECRET_KEY
 
 
 @transaction.atomic
-def provision_free_subscription(user):
-    """Create a Stripe subscription on the configured free price and persist it locally."""
-    current_subscription = UserSubscription.current_for_user(user)
-    if current_subscription and current_subscription.active:
-        return current_subscription
-
-    free_price_id = getattr(settings, "STRIPE_PRICE_ID_FREE", "")
-    if not free_price_id:
-        raise ValueError("Missing STRIPE_PRICE_ID_FREE setting")
-
-    free_plan = SubscriptionPlan.objects.filter(stripe_price_id=free_price_id).first()
-    if not free_plan:
-        raise ValueError(
-            f"No SubscriptionPlan configured for STRIPE_PRICE_ID_FREE={free_price_id}"
-        )
-
-    customer_id = user.stripe_customer_id
-    if not customer_id:
-        customer = stripe.Customer.create(
-            email=user.email,
-            metadata={"user_id": str(user.id)},
-        )
-        customer_id = customer.id
-        user.stripe_customer_id = customer_id
-        user.save(update_fields=["stripe_customer_id"])
-
-    subscription = stripe.Subscription.create(
-        customer=customer_id,
-        items=[{"price": free_price_id}],
-        metadata={"user_id": str(user.id)},
-        idempotency_key=f"free-subscription:{user.id}:{free_price_id}",
-    )
-
-    subscription_id = subscription.id
-    user_subscription, _ = UserSubscription.objects.get_or_create(
-        stripe_subscription_id=subscription_id,
-        defaults={"user": user},
-    )
-
-    user_subscription.user = user
-    user_subscription.active = subscription.status in {"active", "trialing"}
-    user_subscription.plan = free_plan
-    user_subscription.save(update_fields=["user", "active", "plan"])
-
-    if user_subscription.active:
-        UserSubscription.deactivate_all_for_user(user)
-        user_subscription.activate()
-
-    return user_subscription
-
-
-def end_active_subscription_and_activate_free(user):
-    """Cancel a user's active subscription on Stripe (if premium) and provision a free one.
-
-    Returns the new free UserSubscription, or None if the user had no active subscription.
-    Raises stripe.error.StripeError if the Stripe cancellation fails.
-    """
+def end_active_subscription(user):
+    """Cancel a user's active premium Stripe subscription and deactivate it locally."""
     active_sub = UserSubscription.active_for_user(user)
     if active_sub is None:
         return None
@@ -77,4 +22,4 @@ def end_active_subscription_and_activate_free(user):
         stripe.Subscription.cancel(active_sub.stripe_subscription_id)
 
     active_sub.deactivate()
-    return provision_free_subscription(user)
+    return active_sub

--- a/payments/signals.py
+++ b/payments/signals.py
@@ -1,31 +1,10 @@
-import logging
-
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-
-from payments.services import provision_free_subscription
-
-logger = logging.getLogger("general")
 
 User = get_user_model()
 
 
 @receiver(post_save, sender=User)
 def provision_default_subscription(sender, instance, created, raw=False, **kwargs):
-    if raw or not created:
-        return
-
-    free_price_id = getattr(settings, "STRIPE_PRICE_ID_FREE", "")
-    stripe_secret_key = getattr(settings, "STRIPE_SECRET_KEY", "")
-    if not free_price_id or not stripe_secret_key:
-        return
-
-    try:
-        provision_free_subscription(instance)
-    except Exception:
-        logger.exception(
-            "[PAYMENTS.SIGNALS] Failed to provision free subscription for user %s",
-            instance.id,
-        )
+    return

--- a/payments/tests.py
+++ b/payments/tests.py
@@ -7,7 +7,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 
 from payments.signals import provision_default_subscription
 from payments.models import StripeEvent, SubscriptionPlan, UserSubscription
-from payments.services import provision_free_subscription
+from payments.services import end_active_subscription
 from payments.views import CreateCheckoutSessionView, StripeWebhookView
 from payments.webhooks import (
     handle_checkout_session_completed,
@@ -18,9 +18,7 @@ from payments.webhooks import (
 
 
 class ProvisionDefaultSubscriptionSignalTests(SimpleTestCase):
-    @override_settings(STRIPE_PRICE_ID_FREE="price_free", STRIPE_SECRET_KEY="sk_test")
-    @patch("payments.signals.provision_free_subscription")
-    def test_provisions_for_new_user_when_configured(self, mock_provision):
+    def test_does_not_provision_default_subscription_for_new_users(self):
         user = SimpleNamespace(id=123)
 
         provision_default_subscription(
@@ -30,41 +28,14 @@ class ProvisionDefaultSubscriptionSignalTests(SimpleTestCase):
             raw=False,
         )
 
-        mock_provision.assert_called_once_with(user)
-
-    @override_settings(STRIPE_PRICE_ID_FREE="", STRIPE_SECRET_KEY="")
-    @patch("payments.signals.provision_free_subscription")
-    def test_skips_when_stripe_not_configured(self, mock_provision):
-        user = SimpleNamespace(id=123)
-
-        provision_default_subscription(
-            sender=object,
-            instance=user,
-            created=True,
-            raw=False,
+        self.assertIsNone(
+            provision_default_subscription(
+                sender=object,
+                instance=user,
+                created=False,
+                raw=True,
+            )
         )
-
-        mock_provision.assert_not_called()
-
-    @override_settings(STRIPE_PRICE_ID_FREE="price_free", STRIPE_SECRET_KEY="sk_test")
-    @patch("payments.signals.provision_free_subscription")
-    def test_skips_for_existing_user_or_raw_save(self, mock_provision):
-        user = SimpleNamespace(id=123)
-
-        provision_default_subscription(
-            sender=object,
-            instance=user,
-            created=False,
-            raw=False,
-        )
-        provision_default_subscription(
-            sender=object,
-            instance=user,
-            created=True,
-            raw=True,
-        )
-
-        mock_provision.assert_not_called()
 
 
 @override_settings(
@@ -228,6 +199,7 @@ class HandleSubscriptionEventTests(TestCase):
         self.assertEqual(subscription.plan.stripe_price_id, "price_premium_annual")
 
     def test_subscription_deleted_deactivates_subscription(self):
+        UserSubscription.deactivate_all_for_user(self.user)
         subscription = UserSubscription.objects.create(
             user=self.user,
             plan=self.premium_monthly_plan,
@@ -252,6 +224,48 @@ class HandleSubscriptionEventTests(TestCase):
         subscription.refresh_from_db()
         self.assertFalse(subscription.active)
         self.assertIsNotNone(subscription.end_date)
+
+
+@override_settings(
+    STRIPE_PRICE_ID_PREMIUM_MONTHLY="price_premium_monthly",
+    STRIPE_PRICE_ID_PREMIUM_ANNUAL="price_premium_annual",
+)
+class UserPremiumPropertyTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            email="premium-property@example.com",
+            password="testpass123",
+        )
+        self.premium_plan = SubscriptionPlan.objects.create(
+            name="Premium Monthly",
+            description="",
+            price="9.99",
+            interval="monthly",
+            stripe_price_id="price_premium_monthly",
+        )
+
+    def test_returns_false_without_active_subscription(self):
+        self.assertFalse(self.user.is_premium)
+
+    def test_returns_false_for_inactive_premium_subscription(self):
+        UserSubscription.objects.create(
+            user=self.user,
+            plan=self.premium_plan,
+            active=False,
+            stripe_subscription_id="sub_inactive_premium",
+        )
+
+        self.assertFalse(self.user.is_premium)
+
+    def test_returns_true_for_active_premium_subscription(self):
+        UserSubscription.objects.create(
+            user=self.user,
+            plan=self.premium_plan,
+            active=True,
+            stripe_subscription_id="sub_active_premium",
+        )
+
+        self.assertTrue(self.user.is_premium)
 
 
 class ProcessStripeEventRoutingTests(SimpleTestCase):
@@ -473,13 +487,64 @@ class CreateCheckoutSessionViewTests(TestCase):
             create_kwargs["subscription_data"]["metadata"]["billing_plan"],
             "annual",
         )
+        self.assertEqual(create_kwargs["customer_email"], "annual@example.com")
+        self.assertNotIn("customer", create_kwargs)
 
-
-@override_settings(STRIPE_PRICE_ID_FREE="price_free", STRIPE_SECRET_KEY="sk_test")
-class ProvisionFreeSubscriptionTests(TestCase):
-    def test_returns_existing_active_premium_without_calling_stripe(self):
+    @override_settings(
+        STRIPE_SUCCESS_URL="https://example.com/success",
+        STRIPE_CANCEL_URL="https://example.com/cancel",
+    )
+    @patch("payments.views.stripe.checkout.Session.create")
+    def test_reuses_existing_customer_for_checkout(self, mock_create_session):
         user = get_user_model().objects.create_user(
-            email="guarded@example.com",
+            email="existing-customer@example.com",
+            password="testpass123",
+            stripe_customer_id="cus_existing_123",
+        )
+
+        session = SimpleNamespace(url="https://checkout.example/session")
+        session.get = lambda key, default=None: (
+            "cs_test_existing_customer" if key == "id" else default
+        )
+        mock_create_session.return_value = session
+
+        request = APIRequestFactory().post(
+            "/payments/create-checkout-session/",
+            {"plan": "monthly"},
+            format="json",
+        )
+        force_authenticate(request, user=user)
+
+        response = CreateCheckoutSessionView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        create_kwargs = mock_create_session.call_args.kwargs
+        self.assertEqual(create_kwargs["customer"], "cus_existing_123")
+        self.assertNotIn("customer_email", create_kwargs)
+
+
+class EndActiveSubscriptionTests(TestCase):
+    @override_settings(STRIPE_PRICE_ID_PREMIUM_MONTHLY="price_premium_monthly")
+    def test_returns_none_without_active_subscription(self):
+        user = get_user_model().objects.create_user(
+            email="no-active-subscription@example.com",
+            password="testpass123",
+        )
+
+        with patch("payments.services.stripe.Subscription.cancel") as mock_cancel:
+            result = end_active_subscription(user)
+
+        self.assertIsNone(result)
+        mock_cancel.assert_not_called()
+
+    @override_settings(STRIPE_PRICE_ID_PREMIUM_MONTHLY="price_premium_monthly")
+    @patch("payments.services.stripe.Subscription.cancel")
+    def test_cancels_active_premium_subscription_and_deactivates_it(
+        self,
+        mock_cancel,
+    ):
+        user = get_user_model().objects.create_user(
+            email="premium-downgrade@example.com",
             password="testpass123",
         )
         premium_plan = SubscriptionPlan.objects.create(
@@ -496,97 +561,22 @@ class ProvisionFreeSubscriptionTests(TestCase):
             stripe_subscription_id="sub_existing_premium",
         )
 
-        with patch("payments.services.stripe.Customer.create") as mock_customer_create:
-            result = provision_free_subscription(user)
+        result = end_active_subscription(user)
 
         self.assertEqual(result, existing_subscription)
-        mock_customer_create.assert_not_called()
+        existing_subscription.refresh_from_db()
+        self.assertFalse(existing_subscription.active)
+        self.assertIsNotNone(existing_subscription.end_date)
+        mock_cancel.assert_called_once_with("sub_existing_premium")
 
-    @patch("payments.services.stripe.Subscription.create")
-    @patch("payments.services.stripe.Customer.create")
-    def test_persists_new_customer_id_and_reuses_it_for_subscription(
+    @patch("payments.services.stripe.Subscription.cancel")
+    def test_deactivates_legacy_non_premium_subscription_without_stripe_cancel(
         self,
-        mock_customer_create,
-        mock_subscription_create,
+        mock_cancel,
     ):
         user = get_user_model().objects.create_user(
-            email="new-free@example.com",
+            email="legacy-free@example.com",
             password="testpass123",
-            stripe_customer_id="",
-        )
-        SubscriptionPlan.objects.create(
-            name="Free",
-            description="",
-            price="0.00",
-            interval="monthly",
-            stripe_price_id="price_free",
-        )
-
-        mock_customer_create.return_value = SimpleNamespace(id="cus_new_123")
-        mock_subscription_create.return_value = SimpleNamespace(
-            id="sub_free_123",
-            status="active",
-        )
-
-        result = provision_free_subscription(user)
-
-        user.refresh_from_db()
-        self.assertEqual(user.stripe_customer_id, "cus_new_123")
-        self.assertTrue(result.active)
-        self.assertEqual(result.plan.stripe_price_id, "price_free")
-
-        mock_customer_create.assert_called_once()
-        mock_subscription_create.assert_called_once()
-        self.assertEqual(
-            mock_subscription_create.call_args.kwargs["customer"],
-            "cus_new_123",
-        )
-
-    @patch("payments.services.stripe.Subscription.create")
-    @patch("payments.services.stripe.Customer.create")
-    def test_reuses_existing_customer_id_without_creating_customer(
-        self,
-        mock_customer_create,
-        mock_subscription_create,
-    ):
-        user = get_user_model().objects.create_user(
-            email="existing-customer@example.com",
-            password="testpass123",
-            stripe_customer_id="cus_existing_123",
-        )
-        SubscriptionPlan.objects.create(
-            name="Free",
-            description="",
-            price="0.00",
-            interval="monthly",
-            stripe_price_id="price_free",
-        )
-
-        mock_subscription_create.return_value = SimpleNamespace(
-            id="sub_free_existing_customer",
-            status="active",
-        )
-
-        provision_free_subscription(user)
-
-        mock_customer_create.assert_not_called()
-        mock_subscription_create.assert_called_once()
-        self.assertEqual(
-            mock_subscription_create.call_args.kwargs["customer"],
-            "cus_existing_123",
-        )
-
-    @patch("payments.services.stripe.Subscription.create")
-    @patch("payments.services.stripe.Customer.create")
-    def test_deactivates_previous_active_subscription_with_end_date(
-        self,
-        mock_customer_create,
-        mock_subscription_create,
-    ):
-        user = get_user_model().objects.create_user(
-            email="rollover@example.com",
-            password="testpass123",
-            stripe_customer_id="",
         )
         free_plan = SubscriptionPlan.objects.create(
             name="Free",
@@ -595,37 +585,17 @@ class ProvisionFreeSubscriptionTests(TestCase):
             interval="monthly",
             stripe_price_id="price_free",
         )
-        old_subscription = UserSubscription.objects.create(
+        legacy_subscription = UserSubscription.objects.create(
             user=user,
             plan=free_plan,
             active=True,
-            stripe_subscription_id="sub_old",
+            stripe_subscription_id="sub_legacy_free",
         )
 
-        mock_customer_create.return_value = SimpleNamespace(id="cus_rollover")
-        mock_subscription_create.return_value = SimpleNamespace(
-            id="sub_new_rollover",
-            status="active",
-        )
+        result = end_active_subscription(user)
 
-        with patch(
-            "payments.services.UserSubscription.current_for_user", return_value=None
-        ):
-            new_subscription = provision_free_subscription(user)
-
-        old_subscription.refresh_from_db()
-        new_subscription.refresh_from_db()
-        self.assertFalse(old_subscription.active)
-        self.assertIsNotNone(old_subscription.end_date)
-        self.assertTrue(new_subscription.active)
-        self.assertIsNone(new_subscription.end_date)
-
-    def test_raises_when_free_plan_is_missing(self):
-        user = get_user_model().objects.create_user(
-            email="missing-plan@example.com",
-            password="testpass123",
-            stripe_customer_id="",
-        )
-
-        with self.assertRaisesMessage(ValueError, "No SubscriptionPlan configured"):
-            provision_free_subscription(user)
+        self.assertEqual(result, legacy_subscription)
+        legacy_subscription.refresh_from_db()
+        self.assertFalse(legacy_subscription.active)
+        self.assertIsNotNone(legacy_subscription.end_date)
+        mock_cancel.assert_not_called()

--- a/payments/views.py
+++ b/payments/views.py
@@ -146,13 +146,12 @@ class CreateCheckoutSessionView(APIView):
         cancel_url = getattr(settings, "STRIPE_CANCEL_URL", "")
 
         try:
-            session = stripe.checkout.Session.create(
-                mode="subscription",
-                payment_method_types=["card"],
-                customer_email=request.user.email,
-                client_reference_id=str(request.user.id),
-                line_items=[{"price": premium_price_id, "quantity": 1}],
-                subscription_data={
+            session_kwargs = {
+                "mode": "subscription",
+                "payment_method_types": ["card"],
+                "client_reference_id": str(request.user.id),
+                "line_items": [{"price": premium_price_id, "quantity": 1}],
+                "subscription_data": {
                     "metadata": {
                         "user_id": str(request.user.id),
                         "billing_plan": "annual" if plan == "annual" else "monthly",
@@ -164,9 +163,15 @@ class CreateCheckoutSessionView(APIView):
                         },
                     },
                 },
-                success_url=success_url,
-                cancel_url=cancel_url,
-            )
+                "success_url": success_url,
+                "cancel_url": cancel_url,
+            }
+            if request.user.stripe_customer_id:
+                session_kwargs["customer"] = request.user.stripe_customer_id
+            else:
+                session_kwargs["customer_email"] = request.user.email
+
+            session = stripe.checkout.Session.create(**session_kwargs)
             logger.info(
                 "[PAYMENTS.CHECKOUT] Created "
                 f"session_id={session.get('id')} for user_id={request.user.id} "

--- a/users/models.py
+++ b/users/models.py
@@ -124,7 +124,7 @@ class CustomUser(AbstractUser):
     def is_premium(self):
         from payments.models import UserSubscription
 
-        subscription = UserSubscription.current_for_user(self)
+        subscription = UserSubscription.active_for_user(self)
         if not subscription:
             return False
         return subscription.is_active_premium


### PR DESCRIPTION
## Summary
- stop creating Stripe customers and free Stripe subscriptions automatically for new free users
- only attach Stripe customer state when a user starts premium checkout, while reusing existing Stripe customers on re-upgrade
- end premium subscriptions without recreating a free Stripe subscription, and compute premium status from active premium subscriptions only

## Validation
- docker compose up -d db redis
- docker compose run --rm migrate
- docker compose run --rm web python manage.py test payments.tests progression.tests.test_premium_activity_rewards gameplay.tests.test_activity_timer_premium
- docker compose down