### PR TITLE
Restructure Docker files and add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,73 @@
+# Python cache and compiled files
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.sqlite3
+.pytype
+.pytest_cache
+*.egg-info/
+.eggs/
+
+# Virtual environments
+.venv
+venv/
+venv-windows/
+venv-linux/
+env/
+
+# Version control and CI/CD
+.git
+.gitignore
+.github
+.worktrees
+.git-rebase-merge
+.git-rebase-apply
+
+# Development tools
+.vscode
+.idea
+.editorconfig
+.pre-commit-config.yaml
+.remember
+.claude
+
+# Node/Frontend (aggressive matching)
+node_modules/
+frontend/node_modules/
+frontend/.node_modules/
+**node_modules**
+.npm/
+dist/
+frontend/dist/
+.sass-cache/
+
+# Build artifacts
+build
+*.dump
+*.sql
+*.log
+logs/
+
+# Test and coverage artifacts
+playwright-report/
+coverage/
+test-results/
+.coverage
+celerybeat-schedule
+
+# Media and static (use volumes)
+media/
+staticfiles/
+
+# Documentation builds
+docs/_build/
+*.md
+!README.md
+
+# OS files
+.DS_Store
+*.swp
+*.swo
+*~
+Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ env
 node_modules/
 /frontend/dist/
 test-results/
-.dockerignore
 gunicorn_config.py
 backup_file.sql
 backup_file.dump

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,52 @@
 ARG PYTHON_VERSION=3.12
 
 # --------------------------
-# Python runtime stage
+# Builder stage: compile dependencies
 # --------------------------
-FROM python:${PYTHON_VERSION}-slim AS runtime
+FROM python:${PYTHON_VERSION}-slim AS builder
+
+# Install build dependencies first (cached separately from app code)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpq-dev \
+        gdal-bin \
+        libgdal-dev \
+        build-essential \
+        gcc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV GDAL_LIBRARY_PATH=/usr/lib/libgdal.so
+
+# Copy ONLY requirements.txt (not app code) so pip install layer caches independently
+COPY requirements.txt /tmp/requirements.txt
+
+# Use BuildKit cache mount for pip (persistent across builds)
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m pip install --user --no-warn-script-location --no-compile \
+    -r /tmp/requirements.txt
+
+
+# --------------------------
+# Runtime base stage: minimal production runtime
+# --------------------------
+FROM python:${PYTHON_VERSION}-slim AS runtime-base
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
-ENV PORT=8000
+ENV GDAL_LIBRARY_PATH=/usr/lib/libgdal.so
+ENV PATH="/usr/local/bin:$PATH"
+
+# Install runtime-only system dependencies BEFORE app code (better cache)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpq5 \
+        gdal-bin \
+        libgdal-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-ENTRYPOINT ["/app/entrypoint.sh"]
 
+# Create app user BEFORE copying code (avoid invalidating on code changes)
 ARG UID=1000
 RUN adduser \
     --disabled-password \
@@ -21,47 +56,57 @@ RUN adduser \
     --home "/home/appuser" \
     --shell "/bin/bash" \
     --uid "${UID}" \
-    appuser
-RUN mkdir -p /home/appuser && chown -R appuser:appuser /home/appuser
+    appuser \
+    && mkdir -p /home/appuser \
+    && chown -R appuser:appuser /home/appuser
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libpq-dev \
-        gdal-bin \
-        libgdal-dev \
-        build-essential \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# Copy pre-built Python packages from builder stage
+COPY --from=builder --chown=appuser:appuser /root/.local /home/appuser/.local
+ENV PATH="/home/appuser/.local/bin:$PATH"
 
-ENV GDAL_LIBRARY_PATH=/usr/lib/libgdal.so
-
-COPY requirements.txt ./
-RUN --mount=type=cache,target=/root/.cache/pip \
-    python -m pip install -r requirements.txt
-
-COPY . .
-COPY --chmod=755 entrypoint.sh /app/entrypoint.sh
-
-
-RUN mkdir -p /app/staticfiles \
-    && chown -R appuser:appuser /app/staticfiles
+# Copy application files (changes frequently, so last in layer chain)
+COPY --chown=appuser:appuser . .
+COPY --chown=appuser:appuser --chmod=755 entrypoint.sh /app/entrypoint.sh
 
 USER appuser
 
-ENV SECRET_KEY=dummy-build-secret-key
-RUN python manage.py collectstatic --noinput
+ENTRYPOINT ["/app/entrypoint.sh"]
+
+
+# --------------------------
+# Web service: Django ASGI server
+# --------------------------
+FROM runtime-base AS web
 
 EXPOSE 8000
-ENV PATH="/usr/local/bin:$PATH"
+
+ENV PORT=8000
+ENV SECRET_KEY=dummy-build-secret-key
+ENV DJANGO_SETTINGS_MODULE=progress_rpg.settings.production
+
+# Note: collectstatic runs at deployment time (via preDeployCommand in Render)
+# Skipping during build avoids database/settings dependency issues
+
 CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "progress_rpg.asgi:application"]
 
-# --------------------------
-# Service-specific targets
-# --------------------------
-FROM runtime AS web
-CMD ["sh", "-c", "daphne -b 0.0.0.0 -p 8000 progress_rpg.asgi:application"]
 
-FROM runtime AS celery
+# --------------------------
+# Celery worker service
+# --------------------------
+FROM runtime-base AS celery
+
+# Strip web-only artifacts (runs as root before USER, so permissions OK)
+RUN rm -rf /app/staticfiles /app/static 2>/dev/null || true
+
 CMD ["celery", "-A", "progress_rpg", "worker", "--loglevel=info"]
 
-FROM runtime AS celery-beat
+
+# --------------------------
+# Celery Beat scheduler service
+# --------------------------
+FROM runtime-base AS celery-beat
+
+# Strip web-only artifacts (runs as root before USER, so permissions OK)
+RUN rm -rf /app/staticfiles /app/static 2>/dev/null || true
+
 CMD ["celery", "-A", "progress_rpg", "beat", "--loglevel=info", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,9 @@ services:
         condition: service_healthy
 
   web:
-    build: .
+    build:
+      context: .
+      target: web
     command: ["daphne", "-b", "0.0.0.0", "-p", "${PORT:-8000}", "progress_rpg.asgi:application"]
     ports:
       - "8000:8000"
@@ -30,9 +32,9 @@ services:
       - .:/app
     environment:
       - PORT=8000
-      - DOCKER="true"
+      - DOCKER=true
     env_file:
-     - .env
+      - .env
     depends_on:
       redis:
         condition: service_healthy
@@ -53,7 +55,7 @@ services:
       - POSTGRES_DB=progress
       - DB_PORT=5432
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "progress"]
+      test: ["CMD", "pg_isready", "-U", "progress"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/render-staging.yaml
+++ b/render-staging.yaml
@@ -13,10 +13,11 @@ projects:
             envVars:
               - fromGroup: Staging env
             region: frankfurt
-            preDeployCommand: python manage.py migrate
+            preDeployCommand: python manage.py collectstatic --noinput && python manage.py migrate
             dockerCommand: daphne -b 0.0.0.0 -p $PORT progress_rpg.asgi:application
             dockerContext: .
             dockerfilePath: ./Dockerfile
+            dockerTarget: web
             autoDeployTrigger: commit
             buildFilter:
               ignoredPaths:
@@ -34,6 +35,7 @@ projects:
             dockerCommand: celery -A progress_rpg worker --loglevel=info --concurrency=1 --prefetch-multiplier=1 --max-tasks-per-child=1000
             dockerContext: .
             dockerfilePath: ./Dockerfile
+            dockerTarget: celery
             autoDeployTrigger: checksPass
             buildFilter:
               ignoredPaths:
@@ -51,6 +53,7 @@ projects:
             dockerCommand: celery -A progress_rpg beat --loglevel=info --scheduler django_celery_beat.schedulers:DatabaseScheduler --max-interval=30
             dockerContext: .
             dockerfilePath: ./Dockerfile
+            dockerTarget: celery-beat
             autoDeployTrigger: checksPass
             buildFilter:
               ignoredPaths:


### PR DESCRIPTION
This pull request refactors the Docker build process to use a multi-stage approach, improving build efficiency, security, and production readiness. It also updates the Docker ignore rules, and aligns the Docker Compose and Render deployment configuration to use the new Docker targets for each service. The most important changes are summarized below.

**Docker build and runtime improvements:**

* Refactored the `Dockerfile` to use multi-stage builds with separate `builder`, `runtime-base`, `web`, `celery`, and `celery-beat` targets. This separates build dependencies from runtime images, reduces image size, and improves security by running as a non-root user.
* Added a comprehensive `.dockerignore` file to exclude Python caches, virtual environments, version control, development tools, frontend/node artifacts, build/test artifacts, media/static files, and OS-specific files from Docker build context, speeding up builds and reducing image size.

**Deployment configuration updates:**

* Updated `compose.yaml` to specify the correct Docker build target (`web`) for the web service, ensuring the correct image variant is used.
* Updated `render-staging.yaml` to use the new multi-stage Docker targets (`web`, `celery`, `celery-beat`) for each service, and added a `collectstatic` step to the pre-deploy command for the web service to ensure static files are collected before migration. [[1]](diffhunk://#diff-706af0a41547275e82672e157c52ef01294c35aa0dd47768cf7dcf9d1e97d0f8L16-R20) [[2]](diffhunk://#diff-706af0a41547275e82672e157c52ef01294c35aa0dd47768cf7dcf9d1e97d0f8R38) [[3]](diffhunk://#diff-706af0a41547275e82672e157c52ef01294c35aa0dd47768cf7dcf9d1e97d0f8R56)