### PR TITLE
fix: use pre-deploy script for collectstatic and migrate

### DIFF
--- a/render-staging.yaml
+++ b/render-staging.yaml
@@ -13,7 +13,7 @@ projects:
             envVars:
               - fromGroup: Staging env
             region: frankfurt
-            preDeployCommand: sh -c "python manage.py collectstatic --noinput --clear && python manage.py migrate"
+            preDeployCommand: ./scripts/pre-deploy.sh
             dockerCommand: daphne -b 0.0.0.0 -p $PORT progress_rpg.asgi:application
             dockerContext: .
             dockerfilePath: ./Dockerfile

--- a/scripts/pre-deploy.sh
+++ b/scripts/pre-deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+python manage.py collectstatic --noinput --clear
+python manage.py migrate


### PR DESCRIPTION
## Summary
- Adds `scripts/pre-deploy.sh` to run `collectstatic` then `migrate` in sequence
- Updates `render-staging.yaml` `preDeployCommand` to call `./scripts/pre-deploy.sh`

Fixes two previous failures: `&&` being passed as a literal arg to `collectstatic` (direct exec), then double-quotes in `sh -c "..."` being treated as part of the command string by sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)