### PR TITLE
fix: exclude scripts/ from end-of-file-fixer hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,5 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        exclude: ^scripts/
       - id: check-yaml


### PR DESCRIPTION
## Summary
- Excludes `scripts/` from the `end-of-file-fixer` pre-commit hook

The hook was silently resetting the executable bit on `scripts/pre-deploy.sh` to `100644` on every commit, requiring a follow-up commit to restore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)