### PR TITLE
fix: pass dummy DATABASE_URL to collectstatic build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,6 @@ EXPOSE 8000
 ENV PORT=8000
 ENV DJANGO_SETTINGS_MODULE=progress_rpg.settings.prod
 
-RUN SECRET_KEY=dummy python manage.py collectstatic --noinput --clear
+RUN SECRET_KEY=dummy DATABASE_URL=postgres://dummy:dummy@localhost/dummy python manage.py collectstatic --noinput --clear
 
 CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "progress_rpg.asgi:application"]


### PR DESCRIPTION
## Summary
- Adds `DATABASE_URL=postgres://dummy:dummy@localhost/dummy` to the `collectstatic` RUN step

`prod.py` calls `dj_database_url.parse(DATABASE_URL)` at module import time. `collectstatic` doesn't connect to the database but settings must load without errors, so a syntactically valid dummy URL is required at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)