### PR TITLE
fix: update render.yaml preDeployCommand to use pre-deploy script

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -13,7 +13,7 @@ projects:
             envVars:
               - fromGroup: Prod env
             region: frankfurt
-            preDeployCommand: python manage.py migrate
+            preDeployCommand: ./scripts/pre-deploy.sh
             dockerCommand: daphne -b 0.0.0.0 -p $PORT progress_rpg.asgi:application
             dockerContext: .
             dockerfilePath: ./Dockerfile


### PR DESCRIPTION
## Summary
- Updates `render.yaml` `preDeployCommand` from `python manage.py migrate` to `./scripts/pre-deploy.sh`

Aligns production config with staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)