### PR TITLE
fix: a11y heading consistency and Playwright test user infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ user_data.json
 *.dump
 *.sql
 playwright-report/
+/playwright/.auth/
 media/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,6 +27,25 @@ npm run test:ui
 npm run test:coverage
 ```
 
+### Running Playwright tests
+
+Playwright uses a dedicated backend user instead of a personal account. From the `frontend/` directory:
+
+```bash
+# Create or reset the dedicated E2E account
+npm run test:e2e:setup-user
+
+# Run the browser tests
+npm run test:e2e
+```
+
+The default test credentials are:
+
+- Email: `playwright@example.com`
+- Password: `correcthorsebatterystaple`
+
+The setup script runs through `docker compose` so it matches the backend test environment. You can override the defaults with `PLAYWRIGHT_TEST_EMAIL`, `PLAYWRIGHT_TEST_PASSWORD`, `PLAYWRIGHT_TEST_PLAYER_NAME`, `PLAYWRIGHT_TEST_CHARACTER_FIRST_NAME`, and `PLAYWRIGHT_TEST_CHARACTER_LAST_NAME` before running the setup command and Playwright.
+
 ### Writing Tests
 
 Tests are located alongside their component files with the `.test.jsx` extension. For example:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
+    "test:e2e:setup-user": "docker compose -f ../compose.yaml run -e PLAYWRIGHT_TEST_EMAIL -e PLAYWRIGHT_TEST_PASSWORD -e PLAYWRIGHT_TEST_PLAYER_NAME --rm web python manage.py seed_playwright_user",
+    "test:e2e": "playwright test",
     "test:a11y": "playwright test --project=a11y",
     "test:a11y:ui": "playwright test --project=a11y --ui",
     "test:a11y:report": "playwright show-report"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+import { BASE_URL } from './playwright/testUser';
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -20,7 +22,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:5173',
+    baseURL: BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -58,7 +60,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:5173',
+    url: BASE_URL,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/frontend/playwright/global-setup.ts
+++ b/frontend/playwright/global-setup.ts
@@ -1,11 +1,18 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { chromium } from '@playwright/test';
 
-const BASE_URL = 'http://localhost:5173';
-const API_URL = 'http://localhost:8000/api/v1';
-const TEST_EMAIL = 'gaidheal01+test1@gmail.com';
-const TEST_PASSWORD = 'correcthorsebatterystaple';
+import {
+  API_URL,
+  BASE_URL,
+  TEST_EMAIL,
+  TEST_PASSWORD,
+  TEST_USER_STORAGE_STATE_PATH,
+} from './testUser';
 
 export default async function globalSetup() {
+  await mkdir(dirname(TEST_USER_STORAGE_STATE_PATH), { recursive: true });
+
   const response = await fetch(`${API_URL}/auth/jwt/create/`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -13,7 +20,13 @@ export default async function globalSetup() {
   });
 
   if (!response.ok) {
-    throw new Error(`Login failed: ${response.status} ${await response.text()}`);
+    throw new Error(
+      [
+        `Login failed for Playwright test user ${TEST_EMAIL}.`,
+        `Run "npm run test:e2e:setup-user" from the frontend directory first.`,
+        `Response: ${response.status} ${await response.text()}`,
+      ].join(' '),
+    );
   }
 
   const data = await response.json();
@@ -34,6 +47,6 @@ export default async function globalSetup() {
     localStorage.setItem('refreshToken', refresh);
   }, { access: accessToken, refresh: refreshToken });
 
-  await context.storageState({ path: 'playwright/.auth/user.json' });
+  await context.storageState({ path: TEST_USER_STORAGE_STATE_PATH });
   await browser.close();
 }

--- a/frontend/playwright/testUser.ts
+++ b/frontend/playwright/testUser.ts
@@ -1,0 +1,5 @@
+export const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+export const API_URL = process.env.PLAYWRIGHT_API_URL ?? 'http://localhost:8000/api/v1';
+export const TEST_EMAIL = process.env.PLAYWRIGHT_TEST_EMAIL ?? 'playwright@example.com';
+export const TEST_PASSWORD = process.env.PLAYWRIGHT_TEST_PASSWORD ?? 'correcthorsebatterystaple';
+export const TEST_USER_STORAGE_STATE_PATH = 'playwright/.auth/user.json';

--- a/frontend/src/components/CurrentActivity/CurrentActivity.jsx
+++ b/frontend/src/components/CurrentActivity/CurrentActivity.jsx
@@ -9,7 +9,7 @@ export default function CurrentActivity() {
 
   return (
     <section className={classNames(styles.wrapper, { [styles.isActive]: isActive })}>
-      <h3 className={styles.heading}>Activity timer</h3>
+      <h2 className={styles.heading}>Activity timer</h2>
       <div className={styles.playerCard}>
         <ActivityInput />
       </div>

--- a/frontend/src/pages/Account/Account.module.scss
+++ b/frontend/src/pages/Account/Account.module.scss
@@ -73,7 +73,7 @@
 .premiumBadge {
   display: inline-block;
   background: c.$color-character;
-  color: c.$color-text-invert;
+  color: c.$color-text-heading;
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.05em;

--- a/frontend/src/pages/Game2/ActivityTimelinePage.jsx
+++ b/frontend/src/pages/Game2/ActivityTimelinePage.jsx
@@ -8,6 +8,7 @@ export default function ActivityTimelinePage() {
   return (
     <div className={styles.page}>
       <div className={styles.content}>
+        <h1 className="sr-only">Timer</h1>
         <Infobar />
         <CurrentActivity />
         <ActivityTimeline />

--- a/frontend/src/pages/SuccessPage.module.scss
+++ b/frontend/src/pages/SuccessPage.module.scss
@@ -26,7 +26,7 @@
 .heroBadge {
   display: inline-block;
   background: tc.$color-accent;
-  color: tc.$color-light;
+  color: map.get(tc.$dark-scale, 300);
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.06em;

--- a/frontend/tests/a11y/pages.spec.ts
+++ b/frontend/tests/a11y/pages.spec.ts
@@ -1,5 +1,10 @@
 import { test } from '@playwright/test';
 import { checkA11y, expectNoA11yViolations } from '../utils/a11y';
+import {
+  mockSuccessfulSubscriptionSync,
+  stabilizeTimerPage,
+  visitAuthenticatedPage,
+} from '../utils/authenticatedPage';
 
 test.describe('Page Accessibility', () => {
   test('Home page is accessible', async ({ page }) => {
@@ -62,73 +67,92 @@ test.describe('Page Accessibility', () => {
 test.describe('Authenticated Page Accessibility', () => {
   test.use({ storageState: 'playwright/.auth/user.json' });
 
-
   test('Timer page is accessible', async ({ page }) => {
-    await page.goto('/timer');
-    await page.getByRole('heading', { name: /timer/i }).waitFor();
-    const results = await checkA11y(page);
-    expectNoA11yViolations(results);
+    await stabilizeTimerPage(page);
+
+    try {
+      await page.goto('/timer');
+      await page.getByRole('heading', { name: 'Timer', exact: true }).waitFor();
+      const results = await checkA11y(page);
+      expectNoA11yViolations(results);
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 
 
   test('Account page is accessible', async ({ page }) => {
-    await page.goto('/account');
+    await visitAuthenticatedPage(page, '/account');
     await page.getByRole('heading', { name: 'Account', exact: true }).waitFor();
     const results = await checkA11y(page);
     expectNoA11yViolations(results);
   });
 
-  test('Onboarding page is accessible', async ({ page }) => {
-    await page.goto('/onboarding');
-    await page.getByRole('dialog').waitFor();
-    const results = await checkA11y(page);
-    expectNoA11yViolations(results);
+  test('Tutorial modal is accessible when opened from the navbar', async ({ page }) => {
+    await stabilizeTimerPage(page);
+
+    try {
+      await page.goto('/timer');
+      await page.getByRole('heading', { name: 'Timer', exact: true }).waitFor();
+      await page.getByRole('button', { name: 'Open tutorial' }).click();
+      await page.getByRole('dialog').waitFor();
+      const results = await checkA11y(page);
+      expectNoA11yViolations(results);
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 
   test('Upgrade page is accessible', async ({ page }) => {
-    await page.goto('/upgrade');
+    await visitAuthenticatedPage(page, '/upgrade');
     await page.getByRole('heading', { name: /upgrade to premium/i }).waitFor();
     const results = await checkA11y(page);
     expectNoA11yViolations(results);
   });
 
   test('Payment success page is accessible', async ({ page }) => {
-    await page.goto('/payment-success');
-    await page.getByRole('heading', { name: /payment successful/i }).waitFor();
-    const results = await checkA11y(page);
-    expectNoA11yViolations(results);
+    await mockSuccessfulSubscriptionSync(page);
+
+    try {
+      await visitAuthenticatedPage(page, '/payment-success');
+      await page.getByRole('heading', { name: /you're premium/i }).waitFor();
+      const results = await checkA11y(page);
+      expectNoA11yViolations(results);
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 
   test('Payment cancelled page is accessible', async ({ page }) => {
-    await page.goto('/payment-cancelled');
+    await visitAuthenticatedPage(page, '/payment-cancelled');
     await page.getByRole('heading', { name: /payment cancelled/i }).waitFor();
     const results = await checkA11y(page);
     expectNoA11yViolations(results);
   });
 
   test('Edit account page is accessible', async ({ page }) => {
-    await page.goto('/edit-account');
+    await visitAuthenticatedPage(page, '/edit-account');
     await page.getByRole('heading', { name: /edit account/i }).waitFor();
     const results = await checkA11y(page);
     expectNoA11yViolations(results);
   });
 
   test('Tasks page is accessible', async ({ page }) => {
-    await page.goto('/tasks');
+    await visitAuthenticatedPage(page, '/tasks');
     await page.getByRole('heading', { name: 'Tasks', exact: true }).waitFor();
     const results = await checkA11y(page);
     expectNoA11yViolations(results);
   });
 
   test('Projects page is accessible', async ({ page }) => {
-    await page.goto('/projects');
+    await visitAuthenticatedPage(page, '/projects');
     await page.getByRole('heading', { name: 'Projects', exact: true }).waitFor();
     const results = await checkA11y(page);
     expectNoA11yViolations(results);
   });
 
   test('Activities page is accessible', async ({ page }) => {
-    await page.goto('/activities');
+    await visitAuthenticatedPage(page, '/activities');
     await page.getByRole('heading', { name: 'Activities', exact: true }).waitFor();
     const results = await checkA11y(page);
     expectNoA11yViolations(results);

--- a/frontend/tests/flows/auth.spec.ts
+++ b/frontend/tests/flows/auth.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-const TEST_EMAIL = 'gaidheal01+test1@gmail.com';
-const TEST_PASSWORD = 'correcthorsebatterystaple';
+import { TEST_EMAIL, TEST_PASSWORD } from '../../playwright/testUser';
 
 test.describe('Login flow', () => {
   test('valid credentials redirect to timer or onboarding', async ({ page }) => {

--- a/frontend/tests/flows/tasks-projects.spec.ts
+++ b/frontend/tests/flows/tasks-projects.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { stabilizeAuthenticatedPlayer } from '../utils/authenticatedPage';
 
 test.describe('Task flow', () => {
   test.use({ storageState: 'playwright/.auth/user.json' });
@@ -6,25 +7,31 @@ test.describe('Task flow', () => {
   test('can create and delete a task', async ({ page }) => {
     const taskName = `Flow test task ${Date.now()}`;
 
-    await page.goto('/tasks');
-    await expect(page.getByRole('heading', { name: 'Tasks', exact: true })).toBeVisible();
+    await stabilizeAuthenticatedPlayer(page);
 
-    await page.getByPlaceholder('New task name').fill(taskName);
-    const [taskPostResponse] = await Promise.all([
-      page.waitForResponse(r => r.url().includes('/tasks/') && r.request().method() === 'POST'),
-      page.getByRole('button', { name: /add task/i }).click(),
-    ]);
-    expect(taskPostResponse.status()).toBeLessThan(300);
-    await page.waitForResponse(r => r.url().includes('/tasks/') && r.request().method() === 'GET');
+    try {
+      await page.goto('/tasks');
+      await expect(page.getByRole('heading', { name: 'Tasks', exact: true })).toBeVisible();
 
-    const taskItem = page.locator('button', { hasText: taskName });
-    await expect(taskItem).toBeVisible({ timeout: 10000 });
+      await page.getByPlaceholder('New task name').fill(taskName);
+      const [taskPostResponse] = await Promise.all([
+        page.waitForResponse(r => r.url().includes('/tasks/') && r.request().method() === 'POST'),
+        page.getByRole('button', { name: /add task/i }).click(),
+      ]);
+      expect(taskPostResponse.status()).toBeLessThan(300);
+      await page.waitForResponse(r => r.url().includes('/tasks/') && r.request().method() === 'GET');
 
-    // Open modal and delete
-    await taskItem.click();
-    await page.getByRole('button', { name: 'Delete' }).click();
-    await page.getByRole('button', { name: 'Delete' }).last().click(); // confirm
-    await expect(taskItem).not.toBeVisible();
+      const taskItem = page.locator('button', { hasText: taskName });
+      await expect(taskItem).toBeVisible({ timeout: 10000 });
+
+      // Open modal and delete
+      await taskItem.click();
+      await page.getByRole('button', { name: 'Delete' }).click();
+      await page.getByRole('button', { name: 'Delete' }).last().click(); // confirm
+      await expect(taskItem).not.toBeVisible();
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 });
 
@@ -34,23 +41,29 @@ test.describe('Project flow', () => {
   test('can create and delete a project', async ({ page }) => {
     const projectName = `Flow test project ${Date.now()}`;
 
-    await page.goto('/projects');
-    await expect(page.getByRole('heading', { name: 'Projects', exact: true })).toBeVisible();
+    await stabilizeAuthenticatedPlayer(page);
 
-    await page.getByPlaceholder('New project name').fill(projectName);
-    const [projectPostResponse] = await Promise.all([
-      page.waitForResponse(r => r.url().includes('/projects/') && r.request().method() === 'POST'),
-      page.getByRole('button', { name: /add project/i }).click(),
-    ]);
-    expect(projectPostResponse.status()).toBeLessThan(300);
-    await page.waitForResponse(r => r.url().includes('/projects/') && r.request().method() === 'GET');
+    try {
+      await page.goto('/projects');
+      await expect(page.getByRole('heading', { name: 'Projects', exact: true })).toBeVisible();
 
-    const projectItem = page.locator('button', { hasText: projectName });
-    await expect(projectItem).toBeVisible({ timeout: 10000 });
+      await page.getByPlaceholder('New project name').fill(projectName);
+      const [projectPostResponse] = await Promise.all([
+        page.waitForResponse(r => r.url().includes('/projects/') && r.request().method() === 'POST'),
+        page.getByRole('button', { name: /add project/i }).click(),
+      ]);
+      expect(projectPostResponse.status()).toBeLessThan(300);
+      await page.waitForResponse(r => r.url().includes('/projects/') && r.request().method() === 'GET');
 
-    await projectItem.click();
-    await page.getByRole('button', { name: 'Delete' }).click();
-    await page.getByRole('button', { name: 'Delete' }).last().click();
-    await expect(projectItem).not.toBeVisible();
+      const projectItem = page.locator('button', { hasText: projectName });
+      await expect(projectItem).toBeVisible({ timeout: 10000 });
+
+      await projectItem.click();
+      await page.getByRole('button', { name: 'Delete' }).click();
+      await page.getByRole('button', { name: 'Delete' }).last().click();
+      await expect(projectItem).not.toBeVisible();
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 });

--- a/frontend/tests/flows/timer.spec.ts
+++ b/frontend/tests/flows/timer.spec.ts
@@ -1,30 +1,31 @@
 import { expect, test } from '@playwright/test';
+import {
+  stabilizeTimerPage,
+} from '../utils/authenticatedPage';
 
 test.describe('Timer flow', () => {
   test.use({ storageState: 'playwright/.auth/user.json' });
 
   test('can start and stop an activity', async ({ page }) => {
-    await page.goto('/timer');
-    await expect(page.getByRole('heading', { name: 'Activity timer' })).toBeVisible();
+    await stabilizeTimerPage(page);
 
-    // Dismiss welcome-back modal if it appears
-    const dialog = page.getByRole('dialog');
     try {
-      await dialog.waitFor({ state: 'visible', timeout: 3000 });
-      await page.keyboard.press('Escape');
-      await dialog.waitFor({ state: 'hidden' });
-    } catch { /* no modal */ }
+      await page.goto('/timer');
+      await expect(page.getByRole('heading', { name: 'Activity timer' })).toBeVisible();
 
-    const timerSection = page.locator('section').filter({
-      has: page.getByRole('heading', { name: 'Activity timer' }),
-    });
-    const activityInput = timerSection.getByPlaceholder(/what are you working on/i);
-    await activityInput.fill('Flow test activity');
+      const timerSection = page.locator('section').filter({
+        has: page.getByRole('heading', { name: 'Activity timer' }),
+      });
+      const activityInput = timerSection.getByPlaceholder(/what are you working on/i);
+      await activityInput.fill('Flow test activity');
 
-    await timerSection.getByRole('button', { name: 'Start' }).click();
-    await expect(timerSection.getByRole('button', { name: 'Stop' })).toBeVisible();
+      await timerSection.getByRole('button', { name: 'Start' }).click();
+      await expect(timerSection.getByRole('button', { name: 'Stop' })).toBeVisible();
 
-    await timerSection.getByRole('button', { name: 'Stop' }).click();
-    await expect(timerSection.getByRole('button', { name: 'Start' })).toBeVisible();
+      await timerSection.getByRole('button', { name: 'Stop' }).click();
+      await expect(timerSection.getByRole('button', { name: 'Start' })).toBeVisible();
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 });

--- a/frontend/tests/smoke/pages.spec.ts
+++ b/frontend/tests/smoke/pages.spec.ts
@@ -1,4 +1,9 @@
 import { expect, test } from '@playwright/test';
+import {
+  mockSuccessfulSubscriptionSync,
+  stabilizeTimerPage,
+  visitAuthenticatedPage,
+} from '../utils/authenticatedPage';
 
 test.describe('Public page smoke tests', () => {
   test('Home page loads', async ({ page }) => {
@@ -51,57 +56,79 @@ test.describe('Authenticated page smoke tests', () => {
   test.use({ storageState: 'playwright/.auth/user.json' });
 
   test('Timer page loads', async ({ page }) => {
-    await page.goto('/timer');
-    await expect(page.getByRole('heading', { name: /timer/i })).toBeVisible();
+    await stabilizeTimerPage(page);
+
+    try {
+      await page.goto('/timer');
+      await expect(page.getByRole('heading', { name: 'Timer', exact: true })).toBeVisible();
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 
   test('Account page loads', async ({ page }) => {
-    await page.goto('/account');
+    await visitAuthenticatedPage(page, '/account');
     await expect(page.getByRole('heading', { name: 'Account', exact: true })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Player' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Billing' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Player', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Billing', exact: true })).toBeVisible();
   });
 
   test('Edit account page loads', async ({ page }) => {
-    await page.goto('/edit-account');
+    await visitAuthenticatedPage(page, '/edit-account');
     await expect(page.getByRole('heading', { name: /edit account/i })).toBeVisible();
   });
 
   test('Upgrade page loads', async ({ page }) => {
-    await page.goto('/upgrade');
+    await visitAuthenticatedPage(page, '/upgrade');
     await expect(page.getByRole('heading', { name: /upgrade to premium/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /premium membership/i })).toBeVisible();
+    await expect(
+      page.getByText(/you are already subscribed!|premium membership for focused progress\./i)
+    ).toBeVisible();
   });
 
   test('Payment success page loads', async ({ page }) => {
-    await page.goto('/payment-success');
-    await expect(page.getByRole('heading', { name: /payment successful/i })).toBeVisible();
+    await mockSuccessfulSubscriptionSync(page);
+
+    try {
+      await visitAuthenticatedPage(page, '/payment-success');
+      await expect(page.getByRole('heading', { name: /you're premium/i })).toBeVisible();
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 
   test('Payment cancelled page loads', async ({ page }) => {
-    await page.goto('/payment-cancelled');
+    await visitAuthenticatedPage(page, '/payment-cancelled');
     await expect(page.getByRole('heading', { name: /payment cancelled/i })).toBeVisible();
   });
 
   test('Tasks page loads', async ({ page }) => {
-    await page.goto('/tasks');
+    await visitAuthenticatedPage(page, '/tasks');
     await expect(page.getByRole('heading', { name: 'Tasks', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: /add task/i })).toBeVisible();
   });
 
   test('Projects page loads', async ({ page }) => {
-    await page.goto('/projects');
+    await visitAuthenticatedPage(page, '/projects');
     await expect(page.getByRole('heading', { name: 'Projects', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: /add project/i })).toBeVisible();
   });
 
   test('Activities page loads', async ({ page }) => {
-    await page.goto('/activities');
+    await visitAuthenticatedPage(page, '/activities');
     await expect(page.getByRole('heading', { name: 'Activities', exact: true })).toBeVisible();
   });
 
-  test('Onboarding page loads', async ({ page }) => {
-    await page.goto('/onboarding');
-    await expect(page.getByRole('dialog')).toBeVisible();
+  test('Tutorial modal opens from the navbar', async ({ page }) => {
+    await stabilizeTimerPage(page);
+
+    try {
+      await page.goto('/timer');
+      await expect(page.getByRole('heading', { name: 'Timer', exact: true })).toBeVisible();
+      await page.getByRole('button', { name: 'Open tutorial' }).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 });

--- a/frontend/tests/utils/authenticatedPage.ts
+++ b/frontend/tests/utils/authenticatedPage.ts
@@ -1,0 +1,122 @@
+import { expect, Page, Route } from '@playwright/test';
+
+type JsonRecord = Record<string, unknown>;
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export async function dismissBlockingModalIfPresent(page: Page, timeout = 3000) {
+  const dialogs = page.getByRole('dialog');
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    const dialogCount = await dialogs.count();
+
+    if (dialogCount === 0) {
+      return;
+    }
+
+    await page.keyboard.press('Escape');
+
+    const closeButton = page.getByRole('button', { name: 'Close modal' }).first();
+    if (await closeButton.isVisible().catch(() => false)) {
+      await closeButton.evaluate((button: HTMLElement) => {
+        button.click();
+      });
+    }
+
+    await page.waitForTimeout(100);
+  }
+
+  await expect.poll(async () => dialogs.count()).toBe(0);
+}
+
+export async function visitAuthenticatedPage(page: Page, path: string, modalTimeout = 3000) {
+  await page.goto(path);
+  await dismissBlockingModalIfPresent(page, modalTimeout);
+}
+
+function withSettledPlayerState(payload: unknown): unknown {
+  if (!isJsonRecord(payload)) {
+    return payload;
+  }
+
+  return {
+    ...payload,
+    onboarding_completed: true,
+    unseen_tutorial_step_ids: [],
+  };
+}
+
+function withSettledTimerBootstrap(payload: unknown): unknown {
+  if (!isJsonRecord(payload)) {
+    return payload;
+  }
+
+  return {
+    ...payload,
+    player: isJsonRecord(payload.player)
+      ? withSettledPlayerState(payload.player)
+      : payload.player,
+    login_state: 'none',
+    loginState: 'none',
+    login_event_at: null,
+    loginEventAt: null,
+    login_reward_xp: 0,
+    loginRewardXp: 0,
+    login_streak: 0,
+    loginStreak: 0,
+  };
+}
+
+async function fulfillPatchedRoute(route: Route, patch: (payload: unknown) => unknown) {
+  const response = await route.fetch();
+  const payload = patch(await response.json());
+
+  await route.fulfill({
+    response,
+    json: payload,
+  });
+}
+
+export async function stabilizeAuthenticatedPlayer(page: Page) {
+  await page.route('**/fetch_info/', async (route) => {
+    await fulfillPatchedRoute(route, (payload) => {
+      if (!isJsonRecord(payload)) {
+        return payload;
+      }
+
+      return {
+        ...payload,
+        player: isJsonRecord(payload.player)
+          ? withSettledPlayerState(payload.player)
+          : payload.player,
+      };
+    });
+  });
+
+  await page.route('**/me/player/', async (route) => {
+    await fulfillPatchedRoute(route, withSettledPlayerState);
+  });
+}
+
+export async function stabilizeTimerPage(page: Page) {
+  await page.route('**/fetch_info/', async (route) => {
+    await fulfillPatchedRoute(route, withSettledTimerBootstrap);
+  });
+
+  await page.route('**/me/player/', async (route) => {
+    await fulfillPatchedRoute(route, withSettledPlayerState);
+  });
+}
+
+export async function mockSuccessfulSubscriptionSync(page: Page) {
+  await page.route('**/payments/sync-subscription/', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'active' }),
+    });
+  });
+}

--- a/users/management/commands/seed_playwright_user.py
+++ b/users/management/commands/seed_playwright_user.py
@@ -1,0 +1,133 @@
+import os
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from users.models import TutorialStep
+
+
+DEFAULT_PLAYWRIGHT_EMAIL = "playwright@example.com"
+DEFAULT_PLAYWRIGHT_PASSWORD = "correcthorsebatterystaple"
+DEFAULT_PLAYWRIGHT_PLAYER_NAME = "Playwright Hero"
+
+
+class Command(BaseCommand):
+    help = "Create or reset the dedicated Playwright E2E user."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--email",
+            default=os.getenv("PLAYWRIGHT_TEST_EMAIL", DEFAULT_PLAYWRIGHT_EMAIL),
+            help="Email for the Playwright test user.",
+        )
+        parser.add_argument(
+            "--password",
+            default=os.getenv("PLAYWRIGHT_TEST_PASSWORD", DEFAULT_PLAYWRIGHT_PASSWORD),
+            help="Password for the Playwright test user.",
+        )
+        parser.add_argument(
+            "--player-name",
+            default=os.getenv(
+                "PLAYWRIGHT_TEST_PLAYER_NAME", DEFAULT_PLAYWRIGHT_PLAYER_NAME
+            ),
+            help="Display name for the Playwright player profile.",
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        email = options["email"]
+        password = options["password"]
+        player_name = options["player_name"]
+
+        if not password:
+            raise CommandError("A Playwright test password is required.")
+
+        User = get_user_model()
+        user, created = User.objects.get_or_create(
+            email=email,
+            defaults={
+                "is_active": True,
+                "is_confirmed": True,
+                "timezone": "UTC",
+            },
+        )
+
+        user_updates = []
+        if created or not user.check_password(password):
+            user.set_password(password)
+            user_updates.append("password")
+        if not user.is_active:
+            user.is_active = True
+            user_updates.append("is_active")
+        if not user.is_confirmed:
+            user.is_confirmed = True
+            user_updates.append("is_confirmed")
+        if str(user.timezone) != "UTC":
+            user.timezone = "UTC"
+            user_updates.append("timezone")
+
+        if user_updates:
+            user.save(update_fields=user_updates)
+
+        player = user.player
+        player_updates = []
+        if player.name != player_name:
+            player.name = player_name
+            player_updates.append("name")
+        if player.onboarding_step != 2:
+            player.onboarding_step = 2
+            player_updates.append("onboarding_step")
+        if not player.onboarding_completed:
+            player.onboarding_completed = True
+            player_updates.append("onboarding_completed")
+        if player.is_deleted:
+            player.is_deleted = False
+            player_updates.append("is_deleted")
+        if player.deleted_at is not None:
+            player.deleted_at = None
+            player_updates.append("deleted_at")
+        if player.bio:
+            player.bio = ""
+            player_updates.append("bio")
+        if player.is_online:
+            player.is_online = False
+            player_updates.append("is_online")
+        if player.active_connections != 0:
+            player.active_connections = 0
+            player_updates.append("active_connections")
+        if player.last_seen is not None:
+            player.last_seen = None
+            player_updates.append("last_seen")
+        if player.xp != 0:
+            player.xp = 0
+            player_updates.append("xp")
+        if player.level != 0:
+            player.level = 0
+            player_updates.append("level")
+        if player.xp_next_level != 100:
+            player.xp_next_level = 100
+            player_updates.append("xp_next_level")
+        if player.xp_modifier != 1:
+            player.xp_modifier = 1
+            player_updates.append("xp_modifier")
+
+        if player_updates:
+            player.save(update_fields=player_updates)
+
+        player.activities.all().delete()
+        player.tasks.all().delete()
+        player.projects.all().delete()
+
+        activity_timer = player.activity_timer
+        activity_timer.reset()
+
+        tutorial_step_ids = list(TutorialStep.objects.values_list("id", flat=True))
+        if tutorial_step_ids:
+            player.tutorial_steps_seen.set(tutorial_step_ids)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Playwright user ready: {user.email} (player={player.name})"
+            )
+        )

--- a/users/tests/test_management_commands.py
+++ b/users/tests/test_management_commands.py
@@ -1,0 +1,120 @@
+from io import StringIO
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import TestCase
+
+from progression.models import PlayerActivity, Project, Task
+from users.models import TutorialStep
+
+
+class SeedPlaywrightUserCommandTests(TestCase):
+    def setUp(self):
+        self.user_model = get_user_model()
+
+    def test_command_creates_a_ready_to_use_playwright_user(self):
+        TutorialStep.objects.create(title="Welcome", body="Body", order=1)
+
+        stdout = StringIO()
+        call_command(
+            "seed_playwright_user",
+            email="playwright-command@example.com",
+            password="correcthorsebatterystaple",
+            stdout=stdout,
+        )
+
+        user = self.user_model.objects.get(email="playwright-command@example.com")
+
+        self.assertTrue(user.check_password("correcthorsebatterystaple"))
+        self.assertTrue(user.is_confirmed)
+        self.assertEqual(str(user.timezone), "UTC")
+
+        player = user.player
+        self.assertEqual(player.name, "Playwright Hero")
+        self.assertEqual(player.onboarding_step, 2)
+        self.assertTrue(player.onboarding_completed)
+        self.assertFalse(player.is_deleted)
+        self.assertEqual(player.tutorial_steps_seen.count(), 1)
+        self.assertEqual(player.activity_timer.status, "empty")
+        self.assertIsNone(player.activity_timer.activity)
+
+        self.assertIn("Playwright user ready", stdout.getvalue())
+
+    def test_command_resets_existing_playwright_user_state(self):
+        TutorialStep.objects.create(title="Welcome", body="Body", order=1)
+
+        user = self.user_model.objects.create_user(
+            email="playwright-existing@example.com",
+            password="old-password",
+        )
+        user.is_confirmed = False
+        user.timezone = "Europe/Paris"
+        user.save(update_fields=["is_confirmed", "timezone"])
+
+        player = user.player
+        player.name = "Needs Reset"
+        player.onboarding_step = 0
+        player.onboarding_completed = False
+        player.is_deleted = True
+        player.bio = "stale bio"
+        player.xp = 99
+        player.level = 3
+        player.xp_next_level = 250
+        player.xp_modifier = 2
+        player.save(
+            update_fields=[
+                "name",
+                "onboarding_step",
+                "onboarding_completed",
+                "is_deleted",
+                "bio",
+                "xp",
+                "level",
+                "xp_next_level",
+                "xp_modifier",
+            ]
+        )
+
+        project = Project.objects.create(player=player, name="Stale project")
+        task = Task.objects.create(player=player, name="Stale task", project=project)
+        PlayerActivity.objects.create(
+            player=player,
+            name="Stale activity",
+            task=task,
+        )
+        PlayerActivity.objects.create(
+            player=player,
+            name="Second stale activity",
+            project=project,
+        )
+        player.activity_timer.new_activity("Timer activity")
+
+        call_command(
+            "seed_playwright_user",
+            email=user.email,
+            password="new-password",
+            player_name="Stable Hero",
+        )
+
+        user.refresh_from_db()
+        player.refresh_from_db()
+        player.activity_timer.refresh_from_db()
+
+        self.assertTrue(user.check_password("new-password"))
+        self.assertTrue(user.is_confirmed)
+        self.assertEqual(str(user.timezone), "UTC")
+
+        self.assertEqual(player.name, "Stable Hero")
+        self.assertEqual(player.onboarding_step, 2)
+        self.assertTrue(player.onboarding_completed)
+        self.assertFalse(player.is_deleted)
+        self.assertEqual(player.bio, "")
+        self.assertEqual(player.xp, 0)
+        self.assertEqual(player.level, 0)
+        self.assertEqual(player.xp_next_level, 100)
+        self.assertEqual(player.xp_modifier, 1)
+        self.assertEqual(player.projects.count(), 0)
+        self.assertEqual(player.tasks.count(), 0)
+        self.assertEqual(player.activities.count(), 0)
+        self.assertEqual(player.activity_timer.status, "empty")
+        self.assertIsNone(player.activity_timer.activity)


### PR DESCRIPTION
## Summary

- **A11y**: update heading levels and colour properties for consistency across pages
- **Playwright infrastructure**: `seed_playwright_user` management command creates/resets a deterministic E2E test user; new `authenticatedPage` test utilities patch API responses to avoid modal/login-state races; all e2e specs refactored to use them

## Test plan

- [ ] Django tests pass: `docker compose run --rm web python manage.py test`
- [ ] Playwright suite passes: `cd frontend && npm run test:e2e`
- [ ] Seed user command works: `cd frontend && npm run test:e2e:setup-user`

🤖 Generated with [Claude Code](https://claude.com/claude-code)