### PR TITLE
feat: suppress free trial for returning subscribers

### DIFF
--- a/frontend/src/pages/Checkout/UpgradePage.jsx
+++ b/frontend/src/pages/Checkout/UpgradePage.jsx
@@ -38,7 +38,8 @@ export default function UpgradePage() {
   };
 
   const trialDays = appConfig?.trial_period_days ?? 0;
-  const hasTrial = trialDays > 0;
+  const hasPreviousSubscription = Boolean(player?.has_previous_subscription);
+  const hasTrial = trialDays > 0 && !hasPreviousSubscription;
   const isAlreadyPremium = Boolean(player?.is_premium);
 
   return (

--- a/payments/tests.py
+++ b/payments/tests.py
@@ -495,6 +495,79 @@ class CreateCheckoutSessionViewTests(TestCase):
         STRIPE_CANCEL_URL="https://example.com/cancel",
     )
     @patch("payments.views.stripe.checkout.Session.create")
+    @patch("payments.views.GameSettings.current")
+    def test_includes_trial_for_new_user_with_trial_configured(
+        self, mock_game_settings, mock_create_session
+    ):
+        mock_game_settings.return_value.trial_period_days = 7
+        user = get_user_model().objects.create_user(
+            email="new-trial@example.com",
+            password="testpass123",
+        )
+
+        mock_create_session.return_value = SimpleNamespace(
+            url="https://checkout.example/session",
+            id="cs_test_trial_new",
+        )
+
+        request = APIRequestFactory().post(
+            "/payments/create-checkout-session/",
+            {"plan": "monthly"},
+            format="json",
+        )
+        force_authenticate(request, user=user)
+
+        response = CreateCheckoutSessionView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        create_kwargs = mock_create_session.call_args.kwargs
+        self.assertEqual(create_kwargs["subscription_data"]["trial_period_days"], 7)
+
+    @override_settings(
+        STRIPE_SUCCESS_URL="https://example.com/success",
+        STRIPE_CANCEL_URL="https://example.com/cancel",
+    )
+    @patch("payments.views.stripe.checkout.Session.create")
+    @patch("payments.views.GameSettings.current")
+    def test_suppresses_trial_for_returning_subscriber(
+        self, mock_game_settings, mock_create_session
+    ):
+        mock_game_settings.return_value.trial_period_days = 7
+        user = get_user_model().objects.create_user(
+            email="returning@example.com",
+            password="testpass123",
+        )
+        # Returning user: has a past (inactive) subscription
+        UserSubscription.objects.create(
+            user=user,
+            plan=self.monthly_plan,
+            active=False,
+            stripe_subscription_id="sub_old_cancelled",
+        )
+
+        mock_create_session.return_value = SimpleNamespace(
+            url="https://checkout.example/session",
+            id="cs_test_no_trial",
+        )
+
+        request = APIRequestFactory().post(
+            "/payments/create-checkout-session/",
+            {"plan": "monthly"},
+            format="json",
+        )
+        force_authenticate(request, user=user)
+
+        response = CreateCheckoutSessionView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        create_kwargs = mock_create_session.call_args.kwargs
+        self.assertNotIn("trial_period_days", create_kwargs["subscription_data"])
+
+    @override_settings(
+        STRIPE_SUCCESS_URL="https://example.com/success",
+        STRIPE_CANCEL_URL="https://example.com/cancel",
+    )
+    @patch("payments.views.stripe.checkout.Session.create")
     def test_reuses_existing_customer_for_checkout(self, mock_create_session):
         user = get_user_model().objects.create_user(
             email="existing-customer@example.com",
@@ -520,6 +593,42 @@ class CreateCheckoutSessionViewTests(TestCase):
         create_kwargs = mock_create_session.call_args.kwargs
         self.assertEqual(create_kwargs["customer"], "cus_existing_123")
         self.assertNotIn("customer_email", create_kwargs)
+
+
+class HasPreviousSubscriptionTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            email="prev-sub@example.com",
+            password="testpass123",
+        )
+        self.plan = SubscriptionPlan.objects.create(
+            name="Premium Monthly",
+            description="",
+            price="9.99",
+            interval="monthly",
+            stripe_price_id="price_monthly_prev",
+        )
+
+    def test_false_when_no_subscriptions(self):
+        self.assertFalse(self.user.has_previous_subscription)
+
+    def test_true_when_inactive_subscription_exists(self):
+        UserSubscription.objects.create(
+            user=self.user,
+            plan=self.plan,
+            active=False,
+            stripe_subscription_id="sub_cancelled",
+        )
+        self.assertTrue(self.user.has_previous_subscription)
+
+    def test_true_when_active_subscription_exists(self):
+        UserSubscription.objects.create(
+            user=self.user,
+            plan=self.plan,
+            active=True,
+            stripe_subscription_id="sub_active",
+        )
+        self.assertTrue(self.user.has_previous_subscription)
 
 
 class EndActiveSubscriptionTests(TestCase):

--- a/payments/views.py
+++ b/payments/views.py
@@ -154,6 +154,9 @@ class CreateCheckoutSessionView(APIView):
         cancel_url = getattr(settings, "STRIPE_CANCEL_URL", "")
 
         trial_period_days = GameSettings.current().trial_period_days
+        offer_trial = (
+            trial_period_days > 0 and not request.user.has_previous_subscription
+        )
 
         try:
             subscription_data = {
@@ -167,7 +170,7 @@ class CreateCheckoutSessionView(APIView):
                     },
                 },
             }
-            if trial_period_days > 0:
+            if offer_trial:
                 subscription_data["trial_period_days"] = trial_period_days
 
             session_kwargs = {

--- a/users/models.py
+++ b/users/models.py
@@ -129,6 +129,12 @@ class CustomUser(AbstractUser):
             return False
         return subscription.is_active_premium
 
+    @property
+    def has_previous_subscription(self):
+        from payments.models import UserSubscription
+
+        return UserSubscription.objects.filter(user=self).exists()
+
     def __str__(self):
         return self.email
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -37,6 +37,9 @@ class PlayerSerializer(serializers.ModelSerializer):
     total_activities = serializers.IntegerField(read_only=True)
     achievements = serializers.SerializerMethodField()
     is_premium = serializers.BooleanField(source="user.is_premium", read_only=True)
+    has_previous_subscription = serializers.BooleanField(
+        source="user.has_previous_subscription", read_only=True
+    )
     login_streak = serializers.IntegerField(
         source="user.current_login_streak", read_only=True
     )
@@ -69,6 +72,7 @@ class PlayerSerializer(serializers.ModelSerializer):
             "total_activities",
             "achievements",
             "is_premium",
+            "has_previous_subscription",
             "onboarding_step",
             "onboarding_completed",
             "login_streak",
@@ -83,6 +87,8 @@ class PlayerSerializer(serializers.ModelSerializer):
             "total_time",
             "total_activities",
             "achievements",
+            "is_premium",
+            "has_previous_subscription",
             "login_streak",
             "unseen_tutorial_step_ids",
         ]


### PR DESCRIPTION
## Summary

- Adds `has_previous_subscription` property to `CustomUser` — `True` if any `UserSubscription` record exists for the user (any status: active, trialing, cancelled)
- Exposes the flag via `PlayerSerializer` so the frontend receives it with the player payload
- `CreateCheckoutSessionView` skips `trial_period_days` in the Stripe session when this flag is set, even if `GameSettings.trial_period_days > 0`
- `UpgradePage` derives `hasTrial` as `trialDays > 0 && !hasPreviousSubscription`, suppressing all trial copy and CTA text for returning users

## Test plan

- [ ] `HasPreviousSubscriptionTests` — false with no history, true with inactive sub, true with active sub
- [ ] `CreateCheckoutSessionViewTests.test_includes_trial_for_new_user_with_trial_configured` — trial days present in session for new user
- [ ] `CreateCheckoutSessionViewTests.test_suppresses_trial_for_returning_subscriber` — trial days absent for user with cancelled sub
- [x] All 24 payments tests and 37 users tests pass

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)