### PR TITLE
staging → main

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -274,7 +274,7 @@ pycparser==3.0
     # via cffi
 pygments==2.20.0
     # via sphinx
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via
     #   -r requirements.in
     #   djangorestframework-simplejwt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -93,7 +93,7 @@ cron-descriptor==1.4.5
     # via
     #   -r requirements.in
     #   django-celery-beat
-cryptography==48.0.0
+cryptography==48.0.1
     # via
     #   -r requirements.in
     #   autobahn

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -218,7 +218,7 @@ markupsafe==3.0.3
     # via
     #   jinja2
     #   werkzeug
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -r requirements.in
     #   autobahn
@@ -383,7 +383,7 @@ tzdata==2026.2
     #   kombu
 tzlocal==5.3.1
     # via celery
-ujson==5.12.1
+ujson==5.13.0
     # via autobahn
 uritemplate==4.2.0
     # via

--- a/frontend/src/components/Input/Input.jsx
+++ b/frontend/src/components/Input/Input.jsx
@@ -1,5 +1,24 @@
+import { useState } from 'react';
 import styles from './Input.module.scss';
 import classNames from 'classnames';
+
+function EyeIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+      <circle cx="12" cy="12" r="3"/>
+    </svg>
+  );
+}
+
+function EyeOffIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+      <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24"/>
+      <line x1="1" y1="1" x2="23" y2="23"/>
+    </svg>
+  );
+}
 
 export default function Input({
   id,
@@ -21,11 +40,46 @@ export default function Input({
   onBlur,
   onKeyDown,
 }) {
+  const [showPassword, setShowPassword] = useState(false);
   const isCheckbox = type === 'checkbox';
+  const isPassword = type === 'password';
+  const resolvedType = isPassword && showPassword ? 'text' : type;
 
   const helpTextId = helpText ? `${id}-help` : undefined;
   const errorId = error ? `${id}-error` : undefined;
   const describedBy = [helpTextId, errorId].filter(Boolean).join(' ') || undefined;
+
+  const inputEl = (
+    <input
+      id={id}
+      type={resolvedType}
+      className={classNames(styles.inputField, inputClassName, {
+        [styles.inputError]: error,
+        [styles.inputPassword]: isPassword,
+      })}
+      value={isCheckbox ? undefined : value}
+      checked={isCheckbox ? checked : undefined}
+      onChange={(e) => {
+        if (!onChange) return;
+        if (isCheckbox) {
+          onChange(e.target.checked);
+        } else {
+          onChange(e.target.value);
+        }
+      }}
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
+      placeholder={placeholder}
+      aria-invalid={!!error}
+      aria-describedby={describedBy}
+      aria-required={required}
+      autoComplete={autoComplete}
+      required={required}
+      minLength={minLength}
+      maxLength={maxLength}
+      disabled={disabled}
+    />
+  );
 
   return (
     <div className={classNames(styles.inputGroup, className)}>
@@ -35,34 +89,20 @@ export default function Input({
         </label>
       )}
 
-      <input
-        id={id}
-        type={type}
-        className={classNames(styles.inputField, inputClassName, {
-          [styles.inputError]: error,
-        })}
-        value={isCheckbox ? undefined : value}
-        checked={isCheckbox ? checked : undefined}
-        onChange={(e) => {
-          if (!onChange) return;
-          if (isCheckbox) {
-            onChange(e.target.checked);
-          } else {
-            onChange(e.target.value);
-          }
-        }}
-        onBlur={onBlur}
-        onKeyDown={onKeyDown}
-        placeholder={placeholder}
-        aria-invalid={!!error}
-        aria-describedby={describedBy}
-        aria-required={required}
-        autoComplete={autoComplete}
-        required={required}
-        minLength={minLength}
-        maxLength={maxLength}
-        disabled={disabled}
-      />
+      {isPassword ? (
+        <div className={styles.passwordWrapper}>
+          {inputEl}
+          <button
+            type="button"
+            className={styles.passwordToggle}
+            onClick={() => setShowPassword(prev => !prev)}
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+            disabled={disabled}
+          >
+            {showPassword ? <EyeOffIcon /> : <EyeIcon />}
+          </button>
+        </div>
+      ) : inputEl}
 
       {helpText && !error && (
         <p id={helpTextId} className={styles.helpText} role="note">

--- a/frontend/src/components/Input/Input.module.scss
+++ b/frontend/src/components/Input/Input.module.scss
@@ -60,6 +60,54 @@
   }
 }
 
+.passwordWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  max-width: 30rem;
+
+  @include m.respond-to(sm) {
+    max-width: 100%;
+  }
+}
+
+.inputPassword {
+  width: 100%;
+  max-width: 100%;
+  padding-right: 2.75rem;
+}
+
+.passwordToggle {
+  position: absolute;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: c.$color-border-primary;
+  border-radius: v.$border-radius;
+  transition: color 0.2s;
+
+  &:hover {
+    color: c.$color-border-accent;
+  }
+
+  @include m.focus-outline(c.$color-border-accent);
+
+  svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}
+
 .helpText {
   @include t.apply-text-style(t.$text-caption);
 

--- a/frontend/src/components/SupportFlow/SupportFlowModal.jsx
+++ b/frontend/src/components/SupportFlow/SupportFlowModal.jsx
@@ -72,7 +72,7 @@ export default function SupportFlowModal({ state, dispatch, onConfirmActivity })
             showUpgradePrompt={ctx.rewardShowUpgradePrompt}
             activityName={ctx.completedActivityName}
             elapsedSeconds={ctx.completedActivityElapsedSeconds}
-            enableAutoSupportCountdown={ctx.supportMenuOrigin !== "reward"}
+            enableAutoSupportCountdown={false}
             onContinue={close}
             onSupport={() => dispatch({ type: "GO_SUPPORT_MENU", origin: "reward" })}
           />

--- a/frontend/src/components/SupportFlow/SupportFlowModal.test.jsx
+++ b/frontend/src/components/SupportFlow/SupportFlowModal.test.jsx
@@ -101,7 +101,7 @@ describe("SupportFlowModal", () => {
     expect(screen.getByText("Total XP gained")).toBeInTheDocument();
     expect(screen.getByText("+27 XP")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Continue with support in 3.." })
+      screen.getByRole("button", { name: "Continue with support" })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Back to timer" })
@@ -140,7 +140,7 @@ describe("SupportFlowModal", () => {
     const user = userEvent.setup();
     render(<Fixture initialEvent="OPEN_ACTIVITY_REWARD" />);
     await user.click(screen.getByRole("button", { name: "Open" }));
-    await user.click(screen.getByRole("button", { name: "Continue with support in 3.." }));
+    await user.click(screen.getByRole("button", { name: "Continue with support" }));
     await user.click(screen.getByRole("button", { name: "Back" }));
     expect(screen.getByText("Activity complete!")).toBeInTheDocument();
     expect(
@@ -239,7 +239,7 @@ describe("SupportFlowModal", () => {
     const user = userEvent.setup();
     render(<Fixture initialEvent="OPEN_ACTIVITY_REWARD" />);
     await user.click(screen.getByRole("button", { name: "Open" }));
-    await user.click(screen.getByRole("button", { name: "Continue with support in 3.." }));
+    await user.click(screen.getByRole("button", { name: "Continue with support" }));
     await user.click(
       screen.getByRole("button", { name: "I'm not ready yet" })
     );
@@ -258,7 +258,7 @@ describe("SupportFlowModal", () => {
     const user = userEvent.setup();
     render(<Fixture initialEvent="OPEN_ACTIVITY_REWARD" />);
     await user.click(screen.getByRole("button", { name: "Open" }));
-    await user.click(screen.getByRole("button", { name: "Continue with support in 3.." }));
+    await user.click(screen.getByRole("button", { name: "Continue with support" }));
     await user.click(screen.getByRole("button", { name: "I'm not ready yet" }));
     await user.click(
       screen.getByRole("button", { name: "Breathing exercise" })

--- a/frontend/src/components/SupportFlow/screens/SupportMenuScreen.jsx
+++ b/frontend/src/components/SupportFlow/screens/SupportMenuScreen.jsx
@@ -6,7 +6,7 @@ export default function SupportMenuScreen({ onReady, onNotReady }) {
   return (
     <div className={styles.supportOptionList}>
       <div className={styles.supportOptionRow}>
-        <Button onClick={onReady}>I&apos;m ready to start</Button>
+        <Button onClick={onReady}>Ready for next step</Button>
         <p className={styles.supportOptionText}>
           I have enough energy to begin. Help me pick and start the next task.
         </p>

--- a/frontend/src/layout/Footer/Footer.jsx
+++ b/frontend/src/layout/Footer/Footer.jsx
@@ -22,6 +22,7 @@ export default function Footer() {
         </a>
       )}
       <nav className={styles.links} aria-label="Footer links">
+        <a href="https://blog.progressrpg.com/" target="_blank" rel="noopener noreferrer">Blog</a>
         <Link to="/support" onClick={scrollToTop}>Support</Link>
         <Link to="/terms-of-service" onClick={scrollToTop}>Terms of Service</Link>
         <Link to="/privacy-policy" onClick={scrollToTop}>Privacy Policy</Link>

--- a/frontend/src/pages/Checkout/UpgradePage.jsx
+++ b/frontend/src/pages/Checkout/UpgradePage.jsx
@@ -38,7 +38,8 @@ export default function UpgradePage() {
   };
 
   const trialDays = appConfig?.trial_period_days ?? 0;
-  const hasTrial = trialDays > 0;
+  const hasPreviousSubscription = Boolean(player?.has_previous_subscription);
+  const hasTrial = trialDays > 0 && !hasPreviousSubscription;
   const isAlreadyPremium = Boolean(player?.is_premium);
 
   return (

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import useLogin from '../../hooks/useLogin';
 import { useAuth } from '../../context/AuthContext';
 import Form from '../../components/Form/Form';
+import Input from '../../components/Input/Input';
 import styles from './LoginPage.module.scss';
 
 export default function LoginPage() {
@@ -50,22 +51,22 @@ export default function LoginPage() {
         className={styles.form}
       >
         {error && <p className={styles.error} role="alert">{error}</p>}
-        <input
+        <Input
+          id="email"
           type="email"
-          name="email"
           placeholder="Email"
           autoComplete='email'
           value={email}
-          onChange={e => setEmail(e.target.value)}
+          onChange={setEmail}
           required
         />
-        <input
+        <Input
+          id="password"
           type="password"
-          name="password"
           placeholder="Password"
           autoComplete='current-password'
           value={password}
-          onChange={e => setPassword(e.target.value)}
+          onChange={setPassword}
           required
         />
         <p className={styles.footer}>

--- a/frontend/src/pages/LoginPage/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage/LoginPage.module.scss
@@ -21,15 +21,6 @@
 .form {
   gap: v.$spacing-gap;
   width: 100%;
-
-  input {
-    width: 100%;
-    max-width: 28rem;
-    padding: v.$spacing-sm;
-    border-radius: v.$border-radius;
-    @include m.border(c.$color-border-default);
-    @include t.apply-text-style(t.$text-body);
-  }
 }
 
 .error {

--- a/payments/tests.py
+++ b/payments/tests.py
@@ -495,6 +495,79 @@ class CreateCheckoutSessionViewTests(TestCase):
         STRIPE_CANCEL_URL="https://example.com/cancel",
     )
     @patch("payments.views.stripe.checkout.Session.create")
+    @patch("payments.views.GameSettings.current")
+    def test_includes_trial_for_new_user_with_trial_configured(
+        self, mock_game_settings, mock_create_session
+    ):
+        mock_game_settings.return_value.trial_period_days = 7
+        user = get_user_model().objects.create_user(
+            email="new-trial@example.com",
+            password="testpass123",
+        )
+
+        mock_create_session.return_value = SimpleNamespace(
+            url="https://checkout.example/session",
+            id="cs_test_trial_new",
+        )
+
+        request = APIRequestFactory().post(
+            "/payments/create-checkout-session/",
+            {"plan": "monthly"},
+            format="json",
+        )
+        force_authenticate(request, user=user)
+
+        response = CreateCheckoutSessionView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        create_kwargs = mock_create_session.call_args.kwargs
+        self.assertEqual(create_kwargs["subscription_data"]["trial_period_days"], 7)
+
+    @override_settings(
+        STRIPE_SUCCESS_URL="https://example.com/success",
+        STRIPE_CANCEL_URL="https://example.com/cancel",
+    )
+    @patch("payments.views.stripe.checkout.Session.create")
+    @patch("payments.views.GameSettings.current")
+    def test_suppresses_trial_for_returning_subscriber(
+        self, mock_game_settings, mock_create_session
+    ):
+        mock_game_settings.return_value.trial_period_days = 7
+        user = get_user_model().objects.create_user(
+            email="returning@example.com",
+            password="testpass123",
+        )
+        # Returning user: has a past (inactive) subscription
+        UserSubscription.objects.create(
+            user=user,
+            plan=self.monthly_plan,
+            active=False,
+            stripe_subscription_id="sub_old_cancelled",
+        )
+
+        mock_create_session.return_value = SimpleNamespace(
+            url="https://checkout.example/session",
+            id="cs_test_no_trial",
+        )
+
+        request = APIRequestFactory().post(
+            "/payments/create-checkout-session/",
+            {"plan": "monthly"},
+            format="json",
+        )
+        force_authenticate(request, user=user)
+
+        response = CreateCheckoutSessionView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        create_kwargs = mock_create_session.call_args.kwargs
+        self.assertNotIn("trial_period_days", create_kwargs["subscription_data"])
+
+    @override_settings(
+        STRIPE_SUCCESS_URL="https://example.com/success",
+        STRIPE_CANCEL_URL="https://example.com/cancel",
+    )
+    @patch("payments.views.stripe.checkout.Session.create")
     def test_reuses_existing_customer_for_checkout(self, mock_create_session):
         user = get_user_model().objects.create_user(
             email="existing-customer@example.com",
@@ -520,6 +593,42 @@ class CreateCheckoutSessionViewTests(TestCase):
         create_kwargs = mock_create_session.call_args.kwargs
         self.assertEqual(create_kwargs["customer"], "cus_existing_123")
         self.assertNotIn("customer_email", create_kwargs)
+
+
+class HasPreviousSubscriptionTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            email="prev-sub@example.com",
+            password="testpass123",
+        )
+        self.plan = SubscriptionPlan.objects.create(
+            name="Premium Monthly",
+            description="",
+            price="9.99",
+            interval="monthly",
+            stripe_price_id="price_monthly_prev",
+        )
+
+    def test_false_when_no_subscriptions(self):
+        self.assertFalse(self.user.has_previous_subscription)
+
+    def test_true_when_inactive_subscription_exists(self):
+        UserSubscription.objects.create(
+            user=self.user,
+            plan=self.plan,
+            active=False,
+            stripe_subscription_id="sub_cancelled",
+        )
+        self.assertTrue(self.user.has_previous_subscription)
+
+    def test_true_when_active_subscription_exists(self):
+        UserSubscription.objects.create(
+            user=self.user,
+            plan=self.plan,
+            active=True,
+            stripe_subscription_id="sub_active",
+        )
+        self.assertTrue(self.user.has_previous_subscription)
 
 
 class EndActiveSubscriptionTests(TestCase):

--- a/payments/tests.py
+++ b/payments/tests.py
@@ -13,6 +13,7 @@ from payments.webhooks import (
     handle_checkout_session_completed,
     handle_subscription_updated,
     handle_subscription_deleted,
+    handle_payment_failed,
     process_stripe_event,
 )
 
@@ -218,6 +219,127 @@ class HandleSubscriptionEventTests(TestCase):
         subscription.refresh_from_db()
         self.assertFalse(subscription.active)
         self.assertIsNotNone(subscription.end_date)
+
+    def test_trial_has_ended_logged_when_status_transitions_from_trialing(self):
+        UserSubscription.deactivate_all_for_user(self.user)
+        subscription = UserSubscription.objects.create(
+            user=self.user,
+            plan=self.monthly_plan,
+            active=True,
+            stripe_subscription_id="sub_trial_end",
+        )
+
+        event = make_event(
+            {
+                "id": "evt_trial_end_1",
+                "type": "customer.subscription.updated",
+                "data": {
+                    "object": {
+                        "id": "sub_trial_end",
+                        "customer": "cus_test_123",
+                        "status": "active",
+                        "items": {"data": [{"price": {"id": "price_premium_monthly"}}]},
+                    },
+                    "previous_attributes": {"status": "trialing"},
+                },
+            }
+        )
+
+        with self.assertLogs("general", level="INFO") as cm:
+            handle_subscription_updated(event)
+
+        self.assertTrue(
+            any("Trial ended" in line for line in cm.output),
+            msg=f"Expected 'Trial ended' in logs, got: {cm.output}",
+        )
+        subscription.refresh_from_db()
+        self.assertTrue(subscription.active)
+
+    def test_incomplete_status_deactivates_subscription(self):
+        UserSubscription.deactivate_all_for_user(self.user)
+        subscription = UserSubscription.objects.create(
+            user=self.user,
+            plan=self.monthly_plan,
+            active=True,
+            stripe_subscription_id="sub_incomplete",
+        )
+
+        event = make_event(
+            {
+                "id": "evt_incomplete_1",
+                "type": "customer.subscription.updated",
+                "data": {
+                    "object": {
+                        "id": "sub_incomplete",
+                        "customer": "cus_test_123",
+                        "status": "incomplete",
+                        "items": {"data": [{"price": {"id": "price_premium_monthly"}}]},
+                    },
+                    "previous_attributes": {},
+                },
+            }
+        )
+
+        handle_subscription_updated(event)
+
+        subscription.refresh_from_db()
+        self.assertFalse(subscription.active)
+
+    def test_unhandled_event_type_logs_info(self):
+        event = make_event(
+            {
+                "id": "evt_unknown_1",
+                "type": "payment_intent.created",
+            }
+        )
+
+        with self.assertLogs("general", level="INFO") as cm:
+            process_stripe_event(event)
+
+        self.assertTrue(
+            any("Unhandled event" in line for line in cm.output),
+            msg=f"Expected 'Unhandled event' in logs, got: {cm.output}",
+        )
+
+    @patch("payments.webhooks.stripe.Subscription.retrieve")
+    def test_payment_failed_retrieves_unexpanded_subscription(self, mock_retrieve):
+        mock_retrieve.return_value = make_event(
+            {
+                "id": "sub_payment_failed",
+                "items": {"data": [{"price": {"id": "price_premium_monthly"}}]},
+            }
+        )
+        UserSubscription.deactivate_all_for_user(self.user)
+        UserSubscription.objects.create(
+            user=self.user,
+            plan=self.monthly_plan,
+            active=True,
+            stripe_subscription_id="sub_payment_failed",
+        )
+
+        event = make_event(
+            {
+                "id": "evt_payment_failed_1",
+                "type": "invoice.payment_failed",
+                "data": {
+                    "object": {
+                        "id": "in_test_1",
+                        "customer": "cus_test_123",
+                        # subscription is a bare string (unexpanded)
+                        "subscription": "sub_payment_failed",
+                    }
+                },
+            }
+        )
+
+        with self.assertLogs("general", level="WARNING") as cm:
+            handle_payment_failed(event)
+
+        mock_retrieve.assert_called_once_with("sub_payment_failed")
+        self.assertTrue(
+            any("Payment failed" in line for line in cm.output),
+            msg=f"Expected 'Payment failed' in logs, got: {cm.output}",
+        )
 
 
 class UserPremiumPropertyTests(TestCase):

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -73,7 +73,7 @@ def resolve_subscription_payload_and_model(event, event_name):
         )
         return None, subscription_payload, None, None
 
-    if not subscription_payload or isinstance(subscription_payload, str):
+    if not subscription_payload:
         logger.warning(f"[PAYMENTS.WEBHOOK] {event_name} missing subscription payload")
         return None, None, None, None
 
@@ -104,29 +104,3 @@ def resolve_subscription_payload_and_model(event, event_name):
         )
 
     return user, subscription_id, subscription_payload, subscription
-
-
-def resolve_subscription_from_event(event, event_name):
-    stripe_object = event.data.object
-
-    subscription_id = stripe_object.id
-    customer_id = stripe_object.customer
-
-    user = get_user_from_customer_id(customer_id)
-
-    subscription = (
-        UserSubscription.objects.filter(
-            user=user,
-            stripe_subscription_id=subscription_id,
-        )
-        .select_related("plan")
-        .first()
-    )
-
-    if not subscription:
-        logger.warning(
-            f"[PAYMENTS.WEBHOOK] {event_name} for unknown (subscription_id={subscription_id}, customer_id={customer_id})"
-        )
-        return None, subscription_id, None
-
-    return user, subscription_id, subscription

--- a/payments/views.py
+++ b/payments/views.py
@@ -154,6 +154,9 @@ class CreateCheckoutSessionView(APIView):
         cancel_url = getattr(settings, "STRIPE_CANCEL_URL", "")
 
         trial_period_days = GameSettings.current().trial_period_days
+        offer_trial = (
+            trial_period_days > 0 and not request.user.has_previous_subscription
+        )
 
         try:
             subscription_data = {
@@ -167,7 +170,7 @@ class CreateCheckoutSessionView(APIView):
                     },
                 },
             }
-            if trial_period_days > 0:
+            if offer_trial:
                 subscription_data["trial_period_days"] = trial_period_days
 
             session_kwargs = {

--- a/payments/webhooks.py
+++ b/payments/webhooks.py
@@ -9,7 +9,6 @@ from .utils import (
     resolve_subscription_payload_and_model,
     resolve_user_from_checkout_session,
     extract_price_id,
-    get_user_from_customer_id,
 )
 
 logger = logging.getLogger("general")
@@ -23,13 +22,18 @@ def process_stripe_event(event):
         "checkout.session.completed": handle_checkout_session_completed,
         "customer.subscription.updated": handle_subscription_updated,
         "customer.subscription.deleted": handle_subscription_deleted,
-        "customer.subscription.trial_will_end": handle_trial_will_end,
         "invoice.payment_failed": handle_payment_failed,
     }
 
     handler = handlers.get(event_type)
     if handler:
         handler(event)
+    else:
+        logger.info(
+            "[PAYMENTS.WEBHOOK] Unhandled event type=%s event_id=%s — no action taken",
+            event_type,
+            getattr(event, "id", None),
+        )
 
 
 @transaction.atomic
@@ -103,9 +107,11 @@ def handle_checkout_session_completed(event):
 
 
 def handle_subscription_updated(event):
-    _, _, subscription_payload, subscription = resolve_subscription_payload_and_model(
-        event,
-        "subscription.updated",
+    user, _, subscription_payload, subscription = (
+        resolve_subscription_payload_and_model(
+            event,
+            "subscription.updated",
+        )
     )
 
     if not subscription_payload or not subscription:
@@ -129,6 +135,15 @@ def handle_subscription_updated(event):
                 plan.name,
             )
 
+    previous_attrs = getattr(event.data, "previous_attributes", None) or {}
+    prev_status = (
+        previous_attrs.get("status")
+        if isinstance(previous_attrs, dict)
+        else getattr(previous_attrs, "status", None)
+    )
+    if prev_status == "trialing" and status != "trialing":
+        _handle_trial_has_ended(user, subscription, status)
+
     if status in ["active", "trialing"]:
         subscription.activate()
         logger.info(
@@ -137,7 +152,7 @@ def handle_subscription_updated(event):
             subscription.user_id,
             status,
         )
-    elif status in ["canceled", "incomplete_expired", "unpaid"]:
+    elif status in ["canceled", "incomplete", "incomplete_expired", "unpaid"]:
         subscription.deactivate()
         logger.info(
             "[PAYMENTS.WEBHOOK] Deactivated stripe_subscription_id=%s user_id=%s status=%s",
@@ -160,8 +175,6 @@ def handle_subscription_updated(event):
             subscription.user_id,
         )
 
-    return
-
 
 def handle_subscription_deleted(event):
     _, _, _, subscription = resolve_subscription_payload_and_model(
@@ -179,37 +192,43 @@ def handle_subscription_deleted(event):
     )
 
 
-def handle_trial_will_end(event):
-    subscription_payload = event.data.object
-    subscription_id = subscription_payload.id
-    customer_id = subscription_payload.customer
-
-    user = get_user_from_customer_id(customer_id)
-    if not user:
-        logger.warning(
-            "[PAYMENTS.WEBHOOK] customer.subscription.trial_will_end for unknown "
-            "customer_id=%s subscription_id=%s",
-            customer_id,
-            subscription_id,
-        )
-        return
-
+def _handle_trial_has_ended(user, subscription, new_status):
     logger.info(
-        "[PAYMENTS.WEBHOOK] Trial ending soon for user_id=%s subscription_id=%s "
-        "trial_end=%s",
-        user.id,
-        subscription_id,
-        subscription_payload.trial_end,
+        "[PAYMENTS.WEBHOOK] Trial ended for user_id=%s stripe_subscription_id=%s "
+        "new_status=%s",
+        user.id if user else None,
+        subscription.stripe_subscription_id,
+        new_status,
     )
-    # TODO: send trial-ending reminder email
+    # TODO: send trial-ended email
 
 
 def handle_payment_failed(event):
-    _, _, _, subscription = resolve_subscription_payload_and_model(
+    _, subscription_id, _, subscription = resolve_subscription_payload_and_model(
         event, "invoice.payment_failed"
     )
 
+    # invoice.payment_failed sends subscription as a bare ID (not expanded).
+    # The resolver returns the ID as subscription_id but None for subscription.
+    if subscription is None and isinstance(subscription_id, str):
+        try:
+            stripe.Subscription.retrieve(subscription_id)
+        except stripe.error.StripeError:
+            logger.exception(
+                "[PAYMENTS.WEBHOOK] Failed to retrieve subscription for payment failure "
+                "subscription_id=%s",
+                subscription_id,
+            )
+            return
+        subscription = UserSubscription.objects.filter(
+            stripe_subscription_id=subscription_id
+        ).first()
+
     if not subscription:
+        logger.warning(
+            "[PAYMENTS.WEBHOOK] Payment failed for unknown subscription_id=%s",
+            subscription_id,
+        )
         return
 
     logger.warning(
@@ -217,3 +236,4 @@ def handle_payment_failed(event):
         subscription.stripe_subscription_id,
         subscription.user_id,
     )
+    # TODO: notify user of payment failure

--- a/requirements.txt
+++ b/requirements.txt
@@ -177,7 +177,7 @@ kombu==5.6.2
     #   celery
 markupsafe==3.0.3
     # via werkzeug
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -r requirements.in
     #   autobahn
@@ -281,7 +281,7 @@ tzdata==2026.2
     #   kombu
 tzlocal==5.3.1
     # via celery
-ujson==5.12.1
+ujson==5.13.0
     # via autobahn
 uritemplate==4.2.0
     # via

--- a/users/models.py
+++ b/users/models.py
@@ -129,6 +129,12 @@ class CustomUser(AbstractUser):
             return False
         return subscription.is_active_premium
 
+    @property
+    def has_previous_subscription(self):
+        from payments.models import UserSubscription
+
+        return UserSubscription.objects.filter(user=self).exists()
+
     def __str__(self):
         return self.email
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -37,6 +37,9 @@ class PlayerSerializer(serializers.ModelSerializer):
     total_activities = serializers.IntegerField(read_only=True)
     achievements = serializers.SerializerMethodField()
     is_premium = serializers.BooleanField(source="user.is_premium", read_only=True)
+    has_previous_subscription = serializers.BooleanField(
+        source="user.has_previous_subscription", read_only=True
+    )
     login_streak = serializers.IntegerField(
         source="user.current_login_streak", read_only=True
     )
@@ -69,6 +72,7 @@ class PlayerSerializer(serializers.ModelSerializer):
             "total_activities",
             "achievements",
             "is_premium",
+            "has_previous_subscription",
             "onboarding_step",
             "onboarding_completed",
             "login_streak",
@@ -83,6 +87,8 @@ class PlayerSerializer(serializers.ModelSerializer):
             "total_time",
             "total_activities",
             "achievements",
+            "is_premium",
+            "has_previous_subscription",
             "login_streak",
             "unseen_tutorial_step_ids",
         ]


### PR DESCRIPTION
## Summary

- feat: suppress free trial offer for returning subscribers — `has_previous_subscription` on User model, exposed via API, used to skip trial in checkout session creation
- fix: improve Stripe webhook error handling — trial_has_ended detection, incomplete subscription deactivation, payment_failed unexpanded-subscription retrieval, unhandled event logging
- feat: add show/hide password toggle to login and password reset fields (thanks to Hanna for suggesting)
- fix: disable auto-advance countdown on activity reward screen (thanks to Hanna for suggesting)
- chore: add blog link to footer
- fix: update msgpack to 1.2.1 and ujson to 5.13.0 (security)
- fix: update cryptography to 48.0.1 and pyjwt to 2.13.0 (security)

## Test plan

- [ ] Run Django tests: `docker compose run --rm web python manage.py test`
- [ ] Run frontend tests: `npm run test`
- [ ] Verify returning subscribers are not offered a free trial at checkout
- [ ] Verify password field on login and reset pages shows eye toggle
- [ ] Verify activity reward screen shows static "Continue with support" button (no countdown)
- [ ] Check production deploy on Render after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)