### PR TITLE
fix: disable auto-advance countdown on activity reward screen

### DIFF
--- a/frontend/src/components/SupportFlow/SupportFlowModal.jsx
+++ b/frontend/src/components/SupportFlow/SupportFlowModal.jsx
@@ -72,7 +72,7 @@ export default function SupportFlowModal({ state, dispatch, onConfirmActivity })
             showUpgradePrompt={ctx.rewardShowUpgradePrompt}
             activityName={ctx.completedActivityName}
             elapsedSeconds={ctx.completedActivityElapsedSeconds}
-            enableAutoSupportCountdown={ctx.supportMenuOrigin !== "reward"}
+            enableAutoSupportCountdown={false}
             onContinue={close}
             onSupport={() => dispatch({ type: "GO_SUPPORT_MENU", origin: "reward" })}
           />

--- a/frontend/src/components/SupportFlow/SupportFlowModal.test.jsx
+++ b/frontend/src/components/SupportFlow/SupportFlowModal.test.jsx
@@ -101,7 +101,7 @@ describe("SupportFlowModal", () => {
     expect(screen.getByText("Total XP gained")).toBeInTheDocument();
     expect(screen.getByText("+27 XP")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Continue with support in 3.." })
+      screen.getByRole("button", { name: "Continue with support" })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Back to timer" })
@@ -140,7 +140,7 @@ describe("SupportFlowModal", () => {
     const user = userEvent.setup();
     render(<Fixture initialEvent="OPEN_ACTIVITY_REWARD" />);
     await user.click(screen.getByRole("button", { name: "Open" }));
-    await user.click(screen.getByRole("button", { name: "Continue with support in 3.." }));
+    await user.click(screen.getByRole("button", { name: "Continue with support" }));
     await user.click(screen.getByRole("button", { name: "Back" }));
     expect(screen.getByText("Activity complete!")).toBeInTheDocument();
     expect(
@@ -239,7 +239,7 @@ describe("SupportFlowModal", () => {
     const user = userEvent.setup();
     render(<Fixture initialEvent="OPEN_ACTIVITY_REWARD" />);
     await user.click(screen.getByRole("button", { name: "Open" }));
-    await user.click(screen.getByRole("button", { name: "Continue with support in 3.." }));
+    await user.click(screen.getByRole("button", { name: "Continue with support" }));
     await user.click(
       screen.getByRole("button", { name: "I'm not ready yet" })
     );
@@ -258,7 +258,7 @@ describe("SupportFlowModal", () => {
     const user = userEvent.setup();
     render(<Fixture initialEvent="OPEN_ACTIVITY_REWARD" />);
     await user.click(screen.getByRole("button", { name: "Open" }));
-    await user.click(screen.getByRole("button", { name: "Continue with support in 3.." }));
+    await user.click(screen.getByRole("button", { name: "Continue with support" }));
     await user.click(screen.getByRole("button", { name: "I'm not ready yet" }));
     await user.click(
       screen.getByRole("button", { name: "Breathing exercise" })


### PR DESCRIPTION
## Summary

- Sets `enableAutoSupportCountdown={false}` in `SupportFlowModal` so the "Continue with support" button is static — no animated fill, no auto-advance, no hover-to-pause
- Updates 4 test assertions that expected the countdown label ("Continue with support in 3..") to match the new static label

Closes #419.

---

*Suggested by Noodles.*