### PR TITLE
feat: add show/hide password toggle to login and reset password fields

### DIFF
--- a/frontend/src/components/Input/Input.jsx
+++ b/frontend/src/components/Input/Input.jsx
@@ -1,5 +1,24 @@
+import { useState } from 'react';
 import styles from './Input.module.scss';
 import classNames from 'classnames';
+
+function EyeIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+      <circle cx="12" cy="12" r="3"/>
+    </svg>
+  );
+}
+
+function EyeOffIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+      <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24"/>
+      <line x1="1" y1="1" x2="23" y2="23"/>
+    </svg>
+  );
+}
 
 export default function Input({
   id,
@@ -21,11 +40,46 @@ export default function Input({
   onBlur,
   onKeyDown,
 }) {
+  const [showPassword, setShowPassword] = useState(false);
   const isCheckbox = type === 'checkbox';
+  const isPassword = type === 'password';
+  const resolvedType = isPassword && showPassword ? 'text' : type;
 
   const helpTextId = helpText ? `${id}-help` : undefined;
   const errorId = error ? `${id}-error` : undefined;
   const describedBy = [helpTextId, errorId].filter(Boolean).join(' ') || undefined;
+
+  const inputEl = (
+    <input
+      id={id}
+      type={resolvedType}
+      className={classNames(styles.inputField, inputClassName, {
+        [styles.inputError]: error,
+        [styles.inputPassword]: isPassword,
+      })}
+      value={isCheckbox ? undefined : value}
+      checked={isCheckbox ? checked : undefined}
+      onChange={(e) => {
+        if (!onChange) return;
+        if (isCheckbox) {
+          onChange(e.target.checked);
+        } else {
+          onChange(e.target.value);
+        }
+      }}
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
+      placeholder={placeholder}
+      aria-invalid={!!error}
+      aria-describedby={describedBy}
+      aria-required={required}
+      autoComplete={autoComplete}
+      required={required}
+      minLength={minLength}
+      maxLength={maxLength}
+      disabled={disabled}
+    />
+  );
 
   return (
     <div className={classNames(styles.inputGroup, className)}>
@@ -35,34 +89,20 @@ export default function Input({
         </label>
       )}
 
-      <input
-        id={id}
-        type={type}
-        className={classNames(styles.inputField, inputClassName, {
-          [styles.inputError]: error,
-        })}
-        value={isCheckbox ? undefined : value}
-        checked={isCheckbox ? checked : undefined}
-        onChange={(e) => {
-          if (!onChange) return;
-          if (isCheckbox) {
-            onChange(e.target.checked);
-          } else {
-            onChange(e.target.value);
-          }
-        }}
-        onBlur={onBlur}
-        onKeyDown={onKeyDown}
-        placeholder={placeholder}
-        aria-invalid={!!error}
-        aria-describedby={describedBy}
-        aria-required={required}
-        autoComplete={autoComplete}
-        required={required}
-        minLength={minLength}
-        maxLength={maxLength}
-        disabled={disabled}
-      />
+      {isPassword ? (
+        <div className={styles.passwordWrapper}>
+          {inputEl}
+          <button
+            type="button"
+            className={styles.passwordToggle}
+            onClick={() => setShowPassword(prev => !prev)}
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+            disabled={disabled}
+          >
+            {showPassword ? <EyeOffIcon /> : <EyeIcon />}
+          </button>
+        </div>
+      ) : inputEl}
 
       {helpText && !error && (
         <p id={helpTextId} className={styles.helpText} role="note">

--- a/frontend/src/components/Input/Input.module.scss
+++ b/frontend/src/components/Input/Input.module.scss
@@ -60,6 +60,54 @@
   }
 }
 
+.passwordWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  max-width: 30rem;
+
+  @include m.respond-to(sm) {
+    max-width: 100%;
+  }
+}
+
+.inputPassword {
+  width: 100%;
+  max-width: 100%;
+  padding-right: 2.75rem;
+}
+
+.passwordToggle {
+  position: absolute;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: c.$color-border-primary;
+  border-radius: v.$border-radius;
+  transition: color 0.2s;
+
+  &:hover {
+    color: c.$color-border-accent;
+  }
+
+  @include m.focus-outline(c.$color-border-accent);
+
+  svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}
+
 .helpText {
   @include t.apply-text-style(t.$text-caption);
 

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import useLogin from '../../hooks/useLogin';
 import { useAuth } from '../../context/AuthContext';
 import Form from '../../components/Form/Form';
+import Input from '../../components/Input/Input';
 import styles from './LoginPage.module.scss';
 
 export default function LoginPage() {
@@ -50,22 +51,22 @@ export default function LoginPage() {
         className={styles.form}
       >
         {error && <p className={styles.error} role="alert">{error}</p>}
-        <input
+        <Input
+          id="email"
           type="email"
-          name="email"
           placeholder="Email"
           autoComplete='email'
           value={email}
-          onChange={e => setEmail(e.target.value)}
+          onChange={setEmail}
           required
         />
-        <input
+        <Input
+          id="password"
           type="password"
-          name="password"
           placeholder="Password"
           autoComplete='current-password'
           value={password}
-          onChange={e => setPassword(e.target.value)}
+          onChange={setPassword}
           required
         />
         <p className={styles.footer}>

--- a/frontend/src/pages/LoginPage/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage/LoginPage.module.scss
@@ -21,15 +21,6 @@
 .form {
   gap: v.$spacing-gap;
   width: 100%;
-
-  input {
-    width: 100%;
-    max-width: 28rem;
-    padding: v.$spacing-sm;
-    border-radius: v.$border-radius;
-    @include m.border(c.$color-border-default);
-    @include t.apply-text-style(t.$text-body);
-  }
 }
 
 .error {


### PR DESCRIPTION
## Summary
- Adds eye/eye-slash SVG icon toggle button inside all `type="password"` inputs via the shared `Input` component
- Toggle switches between `type="password"` and `type="text"`, with `aria-label="Show password"` / `"Hide password"` for accessibility
- Converts `LoginPage` to use the `Input` component for both fields (removing the raw `<input>` pattern)
- Automatically covers `PasswordResetConfirmPage` (already used `Input` via `Form`)

#418

Credit to Noodles

## Test plan
- [x] Login page: password field shows eye icon; clicking toggles visibility and icon
- [ ] Password reset confirm page: both new/confirm password fields have the toggle
- [ ] Eye icon changes to eye-slash when showing, reverts when hiding
- [ ] `aria-label` updates correctly on each click
- [ ] Disabled state: toggle button is disabled when form is submitting
- [ ] LoginPage unit tests pass (217/218 tests green; 1 pre-existing UpgradePage failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)