### PR TITLE
fix: update button text for clarity in SupportMenuScreen

### DIFF
--- a/frontend/src/components/SupportFlow/screens/SupportMenuScreen.jsx
+++ b/frontend/src/components/SupportFlow/screens/SupportMenuScreen.jsx
@@ -6,7 +6,7 @@ export default function SupportMenuScreen({ onReady, onNotReady }) {
   return (
     <div className={styles.supportOptionList}>
       <div className={styles.supportOptionRow}>
-        <Button onClick={onReady}>I&apos;m ready to start</Button>
+        <Button onClick={onReady}>Ready for next step</Button>
         <p className={styles.supportOptionText}>
           I have enough energy to begin. Help me pick and start the next task.
         </p>


### PR DESCRIPTION
## Summary

- Update button label from "I'm ready to start" to "Ready for next step" in SupportMenuScreen

## Test plan
- [ ] Button text displays correctly in Support flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)