### PR TITLE
fix(analytics): unwrap Rollup CJS interop double-default for react-ga4

### DIFF
--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -1,4 +1,11 @@
-import ReactGA from 'react-ga4';
+import ReactGADefault from 'react-ga4';
+
+// Rollup's CJS interop wraps the module exports as the synthetic default
+// (forceDefault=1), so the GA4 singleton ends up at .default.default in prod
+// builds. Unwrap one layer defensively.
+const ReactGA = (
+  (ReactGADefault as unknown as { default: typeof ReactGADefault }).default ?? ReactGADefault
+);
 
 const GA_TRACKING_ID = import.meta.env.VITE_GA_TRACKING_ID as string | undefined;
 const GA_TEST_MODE = import.meta.env.VITE_GA_TEST_MODE === 'true';


### PR DESCRIPTION
## Summary
- Fixes `Uncaught TypeError: ao.default.initialize is not a function` on page load in production

## Root cause
Rollup bundles `react-ga4` with `forceDefault=1`, which creates a synthetic `.default` pointing to the entire CJS exports object rather than respecting the module's own `__esModule: true` flag. The GA4 singleton therefore lived at `.default.default` in the production bundle, so `ReactGA.initialize()` was called on the module namespace (not the instance) and threw.

## Fix
Defensive unwrap in `analytics.ts`: `ReactGADefault.default ?? ReactGADefault`. In production the double-default case resolves to the GA4 instance; in dev Vite's pre-bundler returns the instance directly so the fallback is used.

Verified by inspecting the production bundle — the call is now `oo.initialize(...)` where `oo = ao.default.default ?? ao.default`.

## Test plan
- [ ] No `initialize is not a function` error on staging page load
- [ ] GA page view tracking fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)