### PR TITLE
fix(email): configure SendGrid SMTP relay to fix broken transactional email

### DIFF
--- a/progress_rpg/settings/prod.py
+++ b/progress_rpg/settings/prod.py
@@ -85,7 +85,15 @@ DB_PORT = os.environ.get("DB_PORT")
 
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-DEFAULT_FROM_EMAIL = "Progress RPG <admin@progressrpg.com>"
+DEFAULT_FROM_EMAIL = "Progress RPG <noreply@progressrpg.com>"
+SERVER_EMAIL = "Progress RPG <noreply@progressrpg.com>"
+
+EMAIL_HOST = "smtp.sendgrid.net"
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_USE_SSL = False
+EMAIL_HOST_USER = "apikey"  # SendGrid SMTP requires this literal string as the username
+EMAIL_HOST_PASSWORD = os.environ.get("SENDGRID_API_KEY", "")
 
 print("DEBUG:", DEBUG, file=sys.stderr)
 

--- a/users/management/commands/send_test_email.py
+++ b/users/management/commands/send_test_email.py
@@ -3,16 +3,22 @@ from django.core.mail import send_mail
 
 
 class Command(BaseCommand):
-    help = "Send a test email"
+    help = "Send a test email to verify the email backend is working"
 
-    def handle(self, *args, **options):
-
-        send_mail(
-            "Test",
-            "Hello",
-            "noreply@progressrpg.com",
-            ["gaidheal01@gmail.com"],
-            fail_silently=False,
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--to",
+            default="gaidheal01@gmail.com",
+            help="Recipient email address (default: gaidheal01@gmail.com)",
         )
 
+    def handle(self, *args, **options):
+        recipient = options["to"]
+        send_mail(
+            subject="Progress RPG — test email",
+            message="If you're reading this, transactional email is working.",
+            from_email=None,  # uses DEFAULT_FROM_EMAIL
+            recipient_list=[recipient],
+            fail_silently=False,
+        )
         self.stdout.write(self.style.SUCCESS(f"Test email sent to '{recipient}'."))


### PR DESCRIPTION
## Summary

- Wires Django's SMTP backend to SendGrid's relay (`smtp.sendgrid.net`), using the existing `SENDGRID_API_KEY` env var as the password
- Fixes a `NameError` in the `send_test_email` management command (referenced undefined `recipient` variable) and adds a `--to` argument for flexibility

## What was broken

Production used `smtp.EmailBackend` but the Render environment only provided `SENDGRID_API_KEY` — not the SMTP credentials (`EMAIL_HOST`, `EMAIL_HOST_USER`, `EMAIL_HOST_PASSWORD`) the backend actually needs. Since email verification is mandatory for signup, this completely blocked new user registration.

## Changes

### `progress_rpg/settings/prod.py`
- Sets `EMAIL_HOST = "smtp.sendgrid.net"`, `EMAIL_PORT = 587`, `EMAIL_USE_TLS = True`
- Sets `EMAIL_HOST_USER = "apikey"` (required literal string for SendGrid SMTP auth)
- Sets `EMAIL_HOST_PASSWORD` from `SENDGRID_API_KEY` (already present in Render env groups)
- Corrects `DEFAULT_FROM_EMAIL` to use `noreply@` (the verified sender address)

### `users/management/commands/send_test_email.py`
- Fixes `NameError` (undefined `recipient` variable in success message)
- Adds `--to` argument (defaults to `gaidheal01@gmail.com`)

## No new dependencies

This uses SendGrid's SMTP relay — Django's built-in `smtp.EmailBackend` handles it. The `sendgrid` pip package (already installed) is not involved.

## Reviewer notes

- No new env vars required — `SENDGRID_API_KEY` is already set in Render's Prod and Staging env groups
- Both web and worker services use `prod.py`, so Celery email tasks will pick up the config automatically
- To verify after deploying to staging: `python manage.py send_test_email` then attempt a fresh signup

Fixes #272
Related: #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)