### PR TITLE
fix(timer): show popup and play sound even when stop API call fails

### DIFF
--- a/frontend/src/components/ActivityInput/ActivityInput.tsx
+++ b/frontend/src/components/ActivityInput/ActivityInput.tsx
@@ -175,7 +175,16 @@ export default function ActivityInput() {
     primeAudio(); // unlock AudioContext while still in user-gesture context
     if (isActive) {
       const completedActivityName = (name || currentActivity?.name || "").trim();
-      const completion = await stop({ activityName: completedActivityName });
+      const localElapsed = elapsed; // capture before async operations clear it
+
+      let completion: Awaited<ReturnType<typeof stop>> = null;
+      try {
+        completion = await stop({ activityName: completedActivityName });
+      } catch (err) {
+        console.error("[ActivityInput] Failed to stop timer:", err);
+        // Continue — play sound and show popup with local data so the user isn't left hanging
+      }
+
       // completion comes back as ActivityCompleteResponse or null — fields use snake_case from API
       const completionRaw = completion as Record<string, unknown> | null;
       const xpGained = completionRaw?.xp_gained != null ? Number(completionRaw.xp_gained) : null;
@@ -184,13 +193,19 @@ export default function ActivityInput() {
       const levelUps = Array.isArray(completionRaw?.level_ups) ? completionRaw.level_ups as number[] : [];
       const elapsedSeconds = completionRaw?.duration_seconds != null
         ? Number(completionRaw.duration_seconds)
-        : elapsed;
+        : localElapsed;
       setName("");
-      await Promise.all([
-        fetchPlayerAndCharacter(),
-        fetchCharacterCurrent(),
-        fetchActivities(),
-      ]);
+
+      try {
+        await Promise.all([
+          fetchPlayerAndCharacter(),
+          fetchCharacterCurrent(),
+          fetchActivities(),
+        ]);
+      } catch (err) {
+        console.error("[ActivityInput] Failed to refresh after stop:", err);
+      }
+
       playLimitReachedSound();
       openActivityReward({
         xpGained,

--- a/frontend/src/utils/sounds.ts
+++ b/frontend/src/utils/sounds.ts
@@ -37,37 +37,45 @@ export function primeAudio(): void {
   }
 }
 
+function scheduleNotes(ctx: AudioContext, noteSequence: Note[]): void {
+  const nodes: (OscillatorNode | GainNode)[] = []; // hold refs so Firefox doesn't GC nodes before playback ends
+  const t = ctx.currentTime;
+
+  noteSequence.forEach(({ frequency, offset, duration }) => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = "sine";
+    osc.frequency.value = frequency;
+    gain.gain.setValueAtTime(0.25, t + offset);
+    gain.gain.exponentialRampToValueAtTime(0.001, t + offset + duration);
+    osc.start(t + offset);
+    osc.stop(t + offset + duration);
+    nodes.push(osc, gain);
+  });
+
+  const finalNoteEnd =
+    noteSequence.reduce(
+      (latestEnd, note) => Math.max(latestEnd, note.offset + note.duration),
+      0,
+    ) * 1000;
+
+  setTimeout(() => { nodes.length = 0; }, finalNoteEnd + 400);
+}
+
 function playChime(noteSequence: Note[]): void {
   try {
     const ctx = getContext();
     if (!ctx) return;
 
-    if (ctx.state === "suspended") ctx.resume();
-
-    const nodes: (OscillatorNode | GainNode)[] = []; // hold refs so Firefox doesn't GC nodes before playback ends
-    const t = ctx.currentTime;
-
-    noteSequence.forEach(({ frequency, offset, duration }) => {
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      osc.type = "sine";
-      osc.frequency.value = frequency;
-      gain.gain.setValueAtTime(0.25, t + offset);
-      gain.gain.exponentialRampToValueAtTime(0.001, t + offset + duration);
-      osc.start(t + offset);
-      osc.stop(t + offset + duration);
-      nodes.push(osc, gain);
-    });
-
-    const finalNoteEnd =
-      noteSequence.reduce(
-        (latestEnd, note) => Math.max(latestEnd, note.offset + note.duration),
-        0,
-      ) * 1000;
-
-    setTimeout(() => { nodes.length = 0; }, finalNoteEnd + 400);
+    // If suspended, wait for resume to complete before scheduling notes so
+    // that notes aren't silently dropped while the context is still unlocking.
+    if (ctx.state === "suspended") {
+      ctx.resume().then(() => scheduleNotes(ctx, noteSequence)).catch(() => {});
+    } else {
+      scheduleNotes(ctx, noteSequence);
+    }
   } catch {
     // Silently ignore errors (e.g. browser blocks AudioContext creation).
   }


### PR DESCRIPTION
## Summary

- **ActivityInput.tsx** — wrapped `stop()` and the data-refresh `Promise.all` in separate try/catch blocks so the reward popup and completion sound always fire, even when the server call fails (e.g. expired session, network error). `elapsed` is captured locally before any async work so the displayed time is still accurate.
- **sounds.ts** — extracted `scheduleNotes` helper; `playChime` now calls it via `.then()` when the AudioContext is suspended, so notes are only scheduled once the context is actually running (fixes intermittent silent stops).

Closes #456

## Test plan

- [ ] Stop an active timer normally — popup and sound appear as before
- [ ] Block the `/api/v1/activity_timers/complete/` request in DevTools, stop the timer — popup still appears and sound still plays (with null XP)
- [ ] Let auth session expire, stop the timer — same as above
- [ ] Start and stop the timer immediately after a hard page refresh — sound plays on stop
- [ ] Auto-stop (free tier limit reached) — limit-reached sound plays and popup appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)