### PR TITLE
Timer stop & auth session hotfix

### DIFF
--- a/frontend/src/components/ActivityInput/ActivityInput.tsx
+++ b/frontend/src/components/ActivityInput/ActivityInput.tsx
@@ -175,7 +175,16 @@ export default function ActivityInput() {
     primeAudio(); // unlock AudioContext while still in user-gesture context
     if (isActive) {
       const completedActivityName = (name || currentActivity?.name || "").trim();
-      const completion = await stop({ activityName: completedActivityName });
+      const localElapsed = elapsed; // capture before async operations clear it
+
+      let completion: Awaited<ReturnType<typeof stop>> = null;
+      try {
+        completion = await stop({ activityName: completedActivityName });
+      } catch (err) {
+        console.error("[ActivityInput] Failed to stop timer:", err);
+        // Continue — play sound and show popup with local data so the user isn't left hanging
+      }
+
       // completion comes back as ActivityCompleteResponse or null — fields use snake_case from API
       const completionRaw = completion as Record<string, unknown> | null;
       const xpGained = completionRaw?.xp_gained != null ? Number(completionRaw.xp_gained) : null;
@@ -184,13 +193,19 @@ export default function ActivityInput() {
       const levelUps = Array.isArray(completionRaw?.level_ups) ? completionRaw.level_ups as number[] : [];
       const elapsedSeconds = completionRaw?.duration_seconds != null
         ? Number(completionRaw.duration_seconds)
-        : elapsed;
+        : localElapsed;
       setName("");
-      await Promise.all([
-        fetchPlayerAndCharacter(),
-        fetchCharacterCurrent(),
-        fetchActivities(),
-      ]);
+
+      try {
+        await Promise.all([
+          fetchPlayerAndCharacter(),
+          fetchCharacterCurrent(),
+          fetchActivities(),
+        ]);
+      } catch (err) {
+        console.error("[ActivityInput] Failed to refresh after stop:", err);
+      }
+
       playLimitReachedSound();
       openActivityReward({
         xpGained,

--- a/frontend/src/hooks/useActivityTimer.ts
+++ b/frontend/src/hooks/useActivityTimer.ts
@@ -268,8 +268,18 @@ export default function useActivityTimer(): ActivityTimerReturn {
       return result;
     } catch (err) {
       console.error("Failed to stop timer:", err);
-      // You might want to restore interval here if status was active,
-      // but for MVP it's okay to leave it stopped and let user retry.
+      // Reset local state so the user isn't left stuck in "active" with a
+      // dead interval — they can retry or start a new activity.
+      setStatus("empty");
+      setElapsed(0);
+      setDuration(0);
+      setCurrentActivity(null);
+      setLimitSeconds(null);
+      limitRef.current = null;
+      autoStopReasonRef.current = null;
+      didAutoStopRef.current = false;
+      setLimitReached(false);
+      pausedTimeRef.current = 0;
       throw err;
     }
     },

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -59,11 +59,17 @@ async function refreshAccessToken(refreshToken: string): Promise<string | false>
 export async function getValidAccessToken(): Promise<string> {
   const accessToken = localStorage.getItem("accessToken");
   const refreshToken = localStorage.getItem("refreshToken");
-  if (!accessToken || !refreshToken) throw new Error("Missing tokens");
+  if (!accessToken || !refreshToken) {
+    clearAuthAndRedirect();
+    throw new Error("Missing tokens");
+  }
 
   if (isTokenExpiringSoon(accessToken)) {
     const newAccess = await refreshAccessToken(refreshToken);
-    if (!newAccess) throw new Error("Token refresh failed");
+    if (!newAccess) {
+      clearAuthAndRedirect();
+      throw new Error("Token refresh failed");
+    }
     return newAccess;
   }
 

--- a/frontend/src/utils/sounds.ts
+++ b/frontend/src/utils/sounds.ts
@@ -37,37 +37,45 @@ export function primeAudio(): void {
   }
 }
 
+function scheduleNotes(ctx: AudioContext, noteSequence: Note[]): void {
+  const nodes: (OscillatorNode | GainNode)[] = []; // hold refs so Firefox doesn't GC nodes before playback ends
+  const t = ctx.currentTime;
+
+  noteSequence.forEach(({ frequency, offset, duration }) => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = "sine";
+    osc.frequency.value = frequency;
+    gain.gain.setValueAtTime(0.25, t + offset);
+    gain.gain.exponentialRampToValueAtTime(0.001, t + offset + duration);
+    osc.start(t + offset);
+    osc.stop(t + offset + duration);
+    nodes.push(osc, gain);
+  });
+
+  const finalNoteEnd =
+    noteSequence.reduce(
+      (latestEnd, note) => Math.max(latestEnd, note.offset + note.duration),
+      0,
+    ) * 1000;
+
+  setTimeout(() => { nodes.length = 0; }, finalNoteEnd + 400);
+}
+
 function playChime(noteSequence: Note[]): void {
   try {
     const ctx = getContext();
     if (!ctx) return;
 
-    if (ctx.state === "suspended") ctx.resume();
-
-    const nodes: (OscillatorNode | GainNode)[] = []; // hold refs so Firefox doesn't GC nodes before playback ends
-    const t = ctx.currentTime;
-
-    noteSequence.forEach(({ frequency, offset, duration }) => {
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      osc.type = "sine";
-      osc.frequency.value = frequency;
-      gain.gain.setValueAtTime(0.25, t + offset);
-      gain.gain.exponentialRampToValueAtTime(0.001, t + offset + duration);
-      osc.start(t + offset);
-      osc.stop(t + offset + duration);
-      nodes.push(osc, gain);
-    });
-
-    const finalNoteEnd =
-      noteSequence.reduce(
-        (latestEnd, note) => Math.max(latestEnd, note.offset + note.duration),
-        0,
-      ) * 1000;
-
-    setTimeout(() => { nodes.length = 0; }, finalNoteEnd + 400);
+    // If suspended, wait for resume to complete before scheduling notes so
+    // that notes aren't silently dropped while the context is still unlocking.
+    if (ctx.state === "suspended") {
+      ctx.resume().then(() => scheduleNotes(ctx, noteSequence)).catch(() => {});
+    } else {
+      scheduleNotes(ctx, noteSequence);
+    }
   } catch {
     // Silently ignore errors (e.g. browser blocks AudioContext creation).
   }

--- a/progress_rpg/settings/prod.py
+++ b/progress_rpg/settings/prod.py
@@ -88,12 +88,12 @@ EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 DEFAULT_FROM_EMAIL = "Progress RPG <noreply@progressrpg.com>"
 SERVER_EMAIL = "Progress RPG <noreply@progressrpg.com>"
 
-EMAIL_HOST = "smtp.sendgrid.net"
+EMAIL_HOST = "smtp.resend.com"
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False
-EMAIL_HOST_USER = "apikey"  # SendGrid SMTP requires this literal string as the username
-EMAIL_HOST_PASSWORD = os.environ.get("SENDGRID_API_KEY", "")
+EMAIL_HOST_USER = "resend"  # Resend SMTP requires this literal string as the username
+EMAIL_HOST_PASSWORD = os.environ.get("RESEND_API_KEY", "")
 
 print("DEBUG:", DEBUG, file=sys.stderr)
 

--- a/progress_rpg/settings/prod.py
+++ b/progress_rpg/settings/prod.py
@@ -86,7 +86,7 @@ DB_PORT = os.environ.get("DB_PORT")
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 DEFAULT_FROM_EMAIL = "Progress RPG <noreply@mail.progressrpg.com>"
-SERVER_EMAIL = "Progress RPG <noreply@progressrpg.com>"
+SERVER_EMAIL = "Progress RPG <noreply@mail.progressrpg.com>"
 
 EMAIL_HOST = "smtp.resend.com"
 EMAIL_PORT = 587

--- a/progress_rpg/settings/prod.py
+++ b/progress_rpg/settings/prod.py
@@ -85,7 +85,15 @@ DB_PORT = os.environ.get("DB_PORT")
 
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-DEFAULT_FROM_EMAIL = "Progress RPG <admin@progressrpg.com>"
+DEFAULT_FROM_EMAIL = "Progress RPG <noreply@progressrpg.com>"
+SERVER_EMAIL = "Progress RPG <noreply@progressrpg.com>"
+
+EMAIL_HOST = "smtp.sendgrid.net"
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_USE_SSL = False
+EMAIL_HOST_USER = "apikey"  # SendGrid SMTP requires this literal string as the username
+EMAIL_HOST_PASSWORD = os.environ.get("SENDGRID_API_KEY", "")
 
 print("DEBUG:", DEBUG, file=sys.stderr)
 

--- a/progress_rpg/settings/prod.py
+++ b/progress_rpg/settings/prod.py
@@ -85,7 +85,7 @@ DB_PORT = os.environ.get("DB_PORT")
 
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-DEFAULT_FROM_EMAIL = "Progress RPG <noreply@progressrpg.com>"
+DEFAULT_FROM_EMAIL = "Progress RPG <noreply@mail.progressrpg.com>"
 SERVER_EMAIL = "Progress RPG <noreply@progressrpg.com>"
 
 EMAIL_HOST = "smtp.resend.com"

--- a/users/management/commands/send_test_email.py
+++ b/users/management/commands/send_test_email.py
@@ -3,16 +3,22 @@ from django.core.mail import send_mail
 
 
 class Command(BaseCommand):
-    help = "Send a test email"
+    help = "Send a test email to verify the email backend is working"
 
-    def handle(self, *args, **options):
-
-        send_mail(
-            "Test",
-            "Hello",
-            "noreply@progressrpg.com",
-            ["gaidheal01@gmail.com"],
-            fail_silently=False,
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--to",
+            default="gaidheal01@gmail.com",
+            help="Recipient email address (default: gaidheal01@gmail.com)",
         )
 
+    def handle(self, *args, **options):
+        recipient = options["to"]
+        send_mail(
+            subject="Progress RPG — test email",
+            message="If you're reading this, transactional email is working.",
+            from_email=None,  # uses DEFAULT_FROM_EMAIL
+            recipient_list=[recipient],
+            fail_silently=False,
+        )
         self.stdout.write(self.style.SUCCESS(f"Test email sent to '{recipient}'."))


### PR DESCRIPTION
## Summary

Promotes the **v0.26.1** hotfix from staging to production, addressing a timer-stop failure reported by a tester plus the underlying auth-session issues that triggered it. Also includes the pending transactional-email relay migration (SendGrid → Resend).

## Timer & auth fixes

- **Timer stop: no popup or sound on API failure** — the reward popup and completion chime now always fire even if `/activity_timers/complete/` throws; the error is logged but does not block the UI.
- **Stuck timer after a failed stop** — local timer state is now reset on failure so the user can retry or start a new activity instead of being locked until a hard refresh.
- **Intermittent silent completion sound** — audio nodes are now scheduled only after `AudioContext.resume()` resolves.
- **No redirect to login when the session fully expired** — both the missing-token and failed-refresh paths now call `clearAuthAndRedirect()`.

## Also included

- Transactional email relay switched from SendGrid to Resend (`mail.progressrpg.com`).

Closes #456

## Test plan

- [ ] Stop an active timer normally — popup and sound appear
- [ ] Block `/api/v1/activity_timers/complete/` in DevTools, stop the timer — popup + sound still fire, timer resets
- [ ] Expire the session, stop the timer — redirected to /login
- [ ] Verify transactional email sends via Resend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
