### PR TITLE
fix(auth): prevent repeated login-page reloads on session expiry

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -48,6 +48,14 @@ export function AuthProvider({ children }: ProviderProps): ReactElement {
   };
 
   useEffect(() => {
+    const handleAuthExpired = () => logout();
+    window.addEventListener("auth:expired", handleAuthExpired);
+    return () => window.removeEventListener("auth:expired", handleAuthExpired);
+  // logout is defined in the same render scope and only uses stable state setters
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
     async function verifyUser(): Promise<void> {
       if (!accessToken || !refreshToken) {
         setLoading(false);

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -24,14 +24,7 @@ function isTokenExpiringSoon(token: string, bufferSeconds = 60): boolean {
 function clearAuthAndRedirect(): void {
   localStorage.removeItem("accessToken");
   localStorage.removeItem("refreshToken");
-
-  // Give user feedback before redirect
-  console.warn("[Auth] Session expired, redirecting to login...");
-
-  // Small delay to allow any error messages to display
-  setTimeout(() => {
-    window.location.href = "/login";
-  }, 500);
+  window.dispatchEvent(new CustomEvent("auth:expired"));
 }
 
 async function refreshAccessToken(refreshToken: string): Promise<string | false> {


### PR DESCRIPTION
## Summary

- Replaces `window.location.href` hard-redirect in `clearAuthAndRedirect()` with a `CustomEvent('auth:expired')` dispatch
- `AuthContext` listens for the event and calls `logout()`, setting `isAuthenticated=false`
- `PrivateRoute` then does a single React Router navigate to `/login` — no hard reload, no loop

**Root cause:** When the tab regained focus with expired tokens, TanStack Query refetched all stale queries simultaneously. Each 401 response called `clearAuthAndRedirect()` independently, queuing multiple `setTimeout` redirects that fired in sequence and repeatedly reloaded `/login`.

## Test plan

- [ ] Let your session expire (or clear tokens from localStorage manually)
- [ ] Switch back to the tab — should navigate to `/login` once, cleanly
- [ ] Refresh on `/login` — should stay on login, no loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)