### PR TITLE
fix(ui): center password reset forms in viewport

### DIFF
--- a/frontend/src/pages/PasswordResetPage.module.scss
+++ b/frontend/src/pages/PasswordResetPage.module.scss
@@ -10,7 +10,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  min-height: 100vh;
+  flex: 1;
 }
 
 .form {


### PR DESCRIPTION
Replaced `min-height: 100vh` with `flex: 1` on the password reset page container. The old value made the element demand a full viewport height *below* the navbar, so `justify-content: center` was centering within an oversized box and pushing the form too far down. `flex: 1` fills only the remaining space after the navbar, giving true vertical centering.

Affects `PasswordResetRequestPage` and `PasswordResetConfirmPage` (shared `PasswordResetPage.module.scss`).