### PR TITLE
Staging → Main (password reset flow + form centering fix)

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from dj_rest_auth.registration.serializers import RegisterSerializer
+from dj_rest_auth.serializers import PasswordResetSerializer
 from rest_framework import serializers
 from rest_framework_simplejwt.serializers import (
     TokenObtainPairSerializer,
@@ -173,6 +174,19 @@ class WaitlistSignupRequestSerializer(serializers.Serializer):
 class WaitlistSignupResponseSerializer(serializers.Serializer):
     detail = serializers.CharField()
     state = serializers.ChoiceField(choices=["pending", "subscribed"])
+
+
+def _frontend_password_reset_url(request, user, temp_key):
+    from allauth.account.utils import user_pk_to_url_str
+
+    uid = user_pk_to_url_str(user)
+    frontend_url = getattr(settings, "FRONTEND_URL", "http://localhost:5173")
+    return f"{frontend_url}/reset-password/{uid}-{temp_key}"
+
+
+class CustomPasswordResetSerializer(PasswordResetSerializer):
+    def get_email_options(self):
+        return {"url_generator": _frontend_password_reset_url}
 
 
 def _verify_turnstile(token: str) -> bool:

--- a/frontend/src/pages/PasswordResetPage.module.scss
+++ b/frontend/src/pages/PasswordResetPage.module.scss
@@ -10,7 +10,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  min-height: 100vh;
+  flex: 1;
 }
 
 .form {

--- a/frontend/src/routes/routesConfig.jsx
+++ b/frontend/src/routes/routesConfig.jsx
@@ -10,7 +10,7 @@ const RegisterPage = lazy(() => import("../pages/RegisterPage/RegisterPage"));
 const PasswordResetConfirmPage = lazy(() =>
   import("../pages/PasswordResetConfirmPage/PasswordResetConfirmPage")
 );
-const ForgotPasswordPage = lazy(() => import("../pages/ForgotPasswordPage/ForgotPasswordPage"));
+const PasswordResetRequestPage = lazy(() => import("../pages/PasswordResetRequestPage/PasswordResetRequestPage"));
 const PrivacyPolicyPage = lazy(() => import("../pages/PrivacyPolicyPage/PrivacyPolicyPage"));
 const TermsOfServicePage = lazy(() => import("../pages/TermsOfServicePage/TermsOfServicePage"));
 const SupportPage = lazy(() => import("../pages/SupportPage/SupportPage"));
@@ -56,7 +56,7 @@ export const routes = [
   },
   {
     path: "/forgot-password",
-    element: <ForgotPasswordPage />,
+    element: <PasswordResetRequestPage />,
   },
   {
     path: "/privacy-policy",

--- a/gameplay/consumers.py
+++ b/gameplay/consumers.py
@@ -141,36 +141,38 @@ class TimerConsumer(AsyncJsonWebsocketConsumer):
             logger.info(f"[DISCONNECT] Removed from group: {self.player_group}")
             await self.channel_layer.group_discard(self.player_group, self.channel_name)
 
-        if hasattr(self, "player") and hasattr(self, "character"):
-            if self.activity_timer and self.activity_timer.status == "active":
-                # Give the player DISCONNECT_GRACE_SECONDS to reconnect before
-                # the activity is auto-completed and XP is awarded.
-                from .tasks import auto_complete_timer_on_disconnect
+        # Re-fetch the timer from DB so we don't act on stale in-memory state
+        # (process_initiation/process_completion fetch their own copies and mutate
+        # those, not self.activity_timer).
+        activity_timer = await self.get_activity_timer()
 
-                result = await sync_to_async(
-                    auto_complete_timer_on_disconnect.apply_async
-                )(
-                    kwargs={"player_id": self.player.id},
-                    countdown=DISCONNECT_GRACE_SECONDS,
-                )
-                await cache.aset(
-                    DISCONNECT_TASK_CACHE_KEY.format(player_id=self.player.id),
-                    result.id,
-                    timeout=DISCONNECT_GRACE_SECONDS + 60,
-                )
-                logger.info(
-                    f"[DISCONNECT] Scheduled auto-complete task {result.id} for player {self.player.id} in {DISCONNECT_GRACE_SECONDS}s"
-                )
-            elif self.activity_timer and self.activity_timer.status not in [
-                "completed",
-                "empty",
-                "paused",
-            ]:
-                # Timer was waiting/other non-active state — pause it immediately.
-                await control_timers(self.player, self.activity_timer, "pause")
+        if activity_timer and activity_timer.status == "active":
+            # Give the player DISCONNECT_GRACE_SECONDS to reconnect before
+            # the activity is auto-completed and XP is awarded.
+            from .tasks import auto_complete_timer_on_disconnect
 
-            if self.link is not None:
-                await sync_to_async(schedule_online_end)(self.link)
+            result = await sync_to_async(auto_complete_timer_on_disconnect.apply_async)(
+                kwargs={"player_id": self.player.id},
+                countdown=DISCONNECT_GRACE_SECONDS,
+            )
+            await cache.aset(
+                DISCONNECT_TASK_CACHE_KEY.format(player_id=self.player.id),
+                result.id,
+                timeout=DISCONNECT_GRACE_SECONDS + 60,
+            )
+            logger.info(
+                f"[DISCONNECT] Scheduled auto-complete task {result.id} for player {self.player.id} in {DISCONNECT_GRACE_SECONDS}s"
+            )
+        elif activity_timer and activity_timer.status not in [
+            "completed",
+            "empty",
+            "paused",
+        ]:
+            # Timer was waiting/other non-active state — pause it immediately.
+            await control_timers(self.player, activity_timer, "pause")
+
+        if hasattr(self, "link") and self.link is not None:
+            await sync_to_async(schedule_online_end)(self.link)
 
     async def test_message(self, event):
         logger.info(f"[TEST MESSAGE] Received test message: {event}")

--- a/progress_rpg/settings/base.py
+++ b/progress_rpg/settings/base.py
@@ -162,6 +162,10 @@ REST_AUTH_REGISTER_SERIALIZERS = {
     "REGISTER_SERIALIZER": "api.serializers.CustomRegisterSerializer",
 }
 
+REST_AUTH = {
+    "PASSWORD_RESET_SERIALIZER": "api.serializers.CustomPasswordResetSerializer",
+}
+
 SPECTACULAR_SETTINGS = {
     "TITLE": "Progress RPG API",
     "DESCRIPTION": "API documentation for Progress RPG, an ADHD-focused productivity game.",

--- a/templates/account/email/password_reset_key_message.txt
+++ b/templates/account/email/password_reset_key_message.txt
@@ -1,0 +1,10 @@
+Hi {{ user.email }},
+
+You're receiving this email because a password reset was requested for your Progress RPG account.
+
+Click the link below to choose a new password:
+{{ password_reset_url }}
+
+This link will expire after 3 days. If you didn't request a reset, you can safely ignore this email.
+
+— The Progress RPG team

--- a/templates/account/email/password_reset_key_subject.txt
+++ b/templates/account/email/password_reset_key_subject.txt
@@ -1,0 +1,1 @@
+Reset your Progress RPG password

--- a/users/adapters.py
+++ b/users/adapters.py
@@ -56,6 +56,3 @@ class CustomAccountAdapter(DefaultAccountAdapter):
             email_template = "account/email/email_confirmation"
 
         self.send_mail(email_template, emailconfirmation.email_address.email, ctx)
-
-    def get_reset_password_from_key_url(self, key):
-        return f"{settings.FRONTEND_URL.rstrip('/')}/reset-password/{key}"


### PR DESCRIPTION
## Changes

- **feat(auth):** Self-serve password reset flow end-to-end (#475)
- **refactor(auth):** Remove dead `get_reset_password_from_key_url` from adapter
- **fix(gameplay):** Re-fetch timer from DB on disconnect to avoid stale state
- **fix(ui):** Center password reset forms correctly in viewport (#483)