### PR TITLE
Send trial lifecycle emails: ending soon, ended, converted

### DIFF
--- a/payments/emails.py
+++ b/payments/emails.py
@@ -1,0 +1,56 @@
+from django.conf import settings
+from django.utils import timezone
+
+from users.utils import send_email_to_users
+
+
+def _account_url():
+    return f"{settings.FRONTEND_URL}/account"
+
+
+def _upgrade_url():
+    return f"{settings.FRONTEND_URL}/upgrade"
+
+
+def send_trial_ending_soon_email(user, trial_end):
+    context = {
+        "email": user.email,
+        "trial_end": trial_end,
+        "account_url": _account_url(),
+        "current_year": timezone.now().year,
+    }
+    send_email_to_users(
+        users=[user],
+        subject="Your Progress RPG trial is ending soon",
+        template_base="emails/trial_ending_soon",
+        context=context,
+    )
+
+
+def send_trial_ended_email(user):
+    context = {
+        "email": user.email,
+        "upgrade_url": _upgrade_url(),
+        "current_year": timezone.now().year,
+    }
+    send_email_to_users(
+        users=[user],
+        subject="Your Progress RPG trial has ended",
+        template_base="emails/trial_ended",
+        context=context,
+    )
+
+
+def send_trial_converted_email(user, subscription):
+    context = {
+        "email": user.email,
+        "plan_name": subscription.plan.name if subscription.plan else "Premium",
+        "account_url": _account_url(),
+        "current_year": timezone.now().year,
+    }
+    send_email_to_users(
+        users=[user],
+        subject="Welcome to Progress RPG Premium!",
+        template_base="emails/trial_converted",
+        context=context,
+    )

--- a/payments/tests.py
+++ b/payments/tests.py
@@ -14,6 +14,7 @@ from payments.webhooks import (
     handle_subscription_updated,
     handle_subscription_deleted,
     handle_payment_failed,
+    handle_trial_will_end,
     process_stripe_event,
 )
 
@@ -255,6 +256,131 @@ class HandleSubscriptionEventTests(TestCase):
         subscription.refresh_from_db()
         self.assertTrue(subscription.active)
 
+    @patch("payments.webhooks.send_trial_converted_email")
+    @patch("payments.webhooks.send_trial_ended_email")
+    def test_trial_ended_without_payment_sends_ended_email_only(
+        self, mock_ended_email, mock_converted_email
+    ):
+        UserSubscription.deactivate_all_for_user(self.user)
+        UserSubscription.objects.create(
+            user=self.user,
+            plan=self.monthly_plan,
+            active=True,
+            stripe_subscription_id="sub_trial_canceled",
+        )
+
+        event = make_event(
+            {
+                "id": "evt_trial_canceled_1",
+                "type": "customer.subscription.updated",
+                "data": {
+                    "object": {
+                        "id": "sub_trial_canceled",
+                        "customer": "cus_test_123",
+                        "status": "canceled",
+                        "items": {"data": [{"price": {"id": "price_premium_monthly"}}]},
+                    },
+                    "previous_attributes": {"status": "trialing"},
+                },
+            }
+        )
+
+        handle_subscription_updated(event)
+
+        mock_ended_email.assert_called_once_with(self.user)
+        mock_converted_email.assert_not_called()
+
+    @patch("payments.webhooks.send_trial_converted_email")
+    @patch("payments.webhooks.send_trial_ended_email")
+    def test_trial_converted_to_paid_sends_converted_email_only(
+        self, mock_ended_email, mock_converted_email
+    ):
+        UserSubscription.deactivate_all_for_user(self.user)
+        subscription = UserSubscription.objects.create(
+            user=self.user,
+            plan=self.monthly_plan,
+            active=True,
+            stripe_subscription_id="sub_trial_converted",
+        )
+
+        event = make_event(
+            {
+                "id": "evt_trial_converted_1",
+                "type": "customer.subscription.updated",
+                "data": {
+                    "object": {
+                        "id": "sub_trial_converted",
+                        "customer": "cus_test_123",
+                        "status": "active",
+                        "items": {"data": [{"price": {"id": "price_premium_monthly"}}]},
+                    },
+                    "previous_attributes": {"status": "trialing"},
+                },
+            }
+        )
+
+        handle_subscription_updated(event)
+
+        mock_converted_email.assert_called_once_with(self.user, subscription)
+        mock_ended_email.assert_not_called()
+
+    @patch("payments.webhooks.send_trial_ending_soon_email")
+    def test_trial_will_end_sends_ending_soon_email_with_trial_end_date(
+        self, mock_email
+    ):
+        UserSubscription.deactivate_all_for_user(self.user)
+        UserSubscription.objects.create(
+            user=self.user,
+            plan=self.monthly_plan,
+            active=True,
+            stripe_subscription_id="sub_trial_will_end",
+        )
+
+        event = make_event(
+            {
+                "id": "evt_trial_will_end_1",
+                "type": "customer.subscription.trial_will_end",
+                "data": {
+                    "object": {
+                        "id": "sub_trial_will_end",
+                        "customer": "cus_test_123",
+                        "status": "trialing",
+                        "trial_end": 1735689600,  # 2025-01-01T00:00:00Z
+                        "items": {"data": [{"price": {"id": "price_premium_monthly"}}]},
+                    },
+                },
+            }
+        )
+
+        handle_trial_will_end(event)
+
+        self.assertEqual(mock_email.call_count, 1)
+        called_user, called_trial_end = mock_email.call_args.args
+        self.assertEqual(called_user, self.user)
+        self.assertEqual(called_trial_end.isoformat(), "2025-01-01T00:00:00+00:00")
+
+    @patch("payments.webhooks.send_trial_ending_soon_email")
+    def test_trial_will_end_no_op_for_unknown_customer(self, mock_email):
+        event = make_event(
+            {
+                "id": "evt_trial_will_end_unknown_1",
+                "type": "customer.subscription.trial_will_end",
+                "data": {
+                    "object": {
+                        "id": "sub_unknown",
+                        "customer": "cus_does_not_exist",
+                        "status": "trialing",
+                        "trial_end": 1735689600,
+                        "items": {"data": []},
+                    },
+                },
+            }
+        )
+
+        handle_trial_will_end(event)
+
+        mock_email.assert_not_called()
+
     def test_incomplete_status_deactivates_subscription(self):
         UserSubscription.deactivate_all_for_user(self.user)
         subscription = UserSubscription.objects.create(
@@ -388,6 +514,14 @@ class ProcessStripeEventRoutingTests(SimpleTestCase):
         process_stripe_event(event)
 
         mock_checkout.assert_called_once_with(event)
+
+    @patch("payments.webhooks.handle_trial_will_end")
+    def test_routes_trial_will_end_events(self, mock_trial_will_end):
+        event = SimpleNamespace(type="customer.subscription.trial_will_end")
+
+        process_stripe_event(event)
+
+        mock_trial_will_end.assert_called_once_with(event)
 
 
 @override_settings(STRIPE_WEBHOOK_SECRET="whsec_test")

--- a/payments/webhooks.py
+++ b/payments/webhooks.py
@@ -1,9 +1,16 @@
 import logging
 import stripe
 
+from datetime import datetime, timezone as dt_timezone
+
 from django.conf import settings
 from django.db import transaction
 
+from .emails import (
+    send_trial_ending_soon_email,
+    send_trial_ended_email,
+    send_trial_converted_email,
+)
 from .models import SubscriptionPlan, UserSubscription
 from .utils import (
     resolve_subscription_payload_and_model,
@@ -22,6 +29,7 @@ def process_stripe_event(event):
         "checkout.session.completed": handle_checkout_session_completed,
         "customer.subscription.updated": handle_subscription_updated,
         "customer.subscription.deleted": handle_subscription_deleted,
+        "customer.subscription.trial_will_end": handle_trial_will_end,
         "invoice.payment_failed": handle_payment_failed,
     }
 
@@ -192,6 +200,30 @@ def handle_subscription_deleted(event):
     )
 
 
+def handle_trial_will_end(event):
+    user, _, subscription_payload, _ = resolve_subscription_payload_and_model(
+        event, "subscription.updated"
+    )
+
+    if not user or not subscription_payload:
+        return
+
+    trial_end_ts = getattr(subscription_payload, "trial_end", None)
+    trial_end = (
+        datetime.fromtimestamp(trial_end_ts, tz=dt_timezone.utc)
+        if trial_end_ts
+        else None
+    )
+
+    send_trial_ending_soon_email(user, trial_end)
+    logger.info(
+        "[PAYMENTS.WEBHOOK] Sent trial-ending-soon email user_id=%s "
+        "stripe_subscription_id=%s",
+        user.id,
+        subscription_payload.id,
+    )
+
+
 def _handle_trial_has_ended(user, subscription, new_status):
     logger.info(
         "[PAYMENTS.WEBHOOK] Trial ended for user_id=%s stripe_subscription_id=%s "
@@ -200,7 +232,14 @@ def _handle_trial_has_ended(user, subscription, new_status):
         subscription.stripe_subscription_id,
         new_status,
     )
-    # TODO: send trial-ended email
+
+    if not user:
+        return
+
+    if new_status == "canceled":
+        send_trial_ended_email(user)
+    elif new_status == "active":
+        send_trial_converted_email(user, subscription)
 
 
 def handle_payment_failed(event):

--- a/templates/emails/email_confirmation_message.html
+++ b/templates/emails/email_confirmation_message.html
@@ -12,8 +12,8 @@
 
 <p>We recommend you complete your profile to get started with all the features available to you!</p>
 
-<p>Best regards,</p>
-<p>The Team</p>
+<p>Best wishes,</p>
+<p>Duncan (Founder, Progress RPG)</p>
 
 <p>© 2025 Progress RPG. All rights reserved.</p>
 

--- a/templates/emails/email_confirmation_message.txt
+++ b/templates/emails/email_confirmation_message.txt
@@ -9,7 +9,7 @@ To activate your account, please click the link below:
 
 We recommend you complete your profile to get started with all the features available to you!
 
-Best regards,
-The Team
+Best wishes,
+Duncan (Founder, Progress RPG)
 
 © 2025 Progress RPG. All rights reserved.

--- a/templates/emails/trial_converted.html
+++ b/templates/emails/trial_converted.html
@@ -1,0 +1,50 @@
+<!-- templates/emails/trial_converted.html -->
+<html>
+<head>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            color: #333;
+            background-color: #f4f4f4;
+            padding: 20px;
+        }
+        .email-container {
+            background-color: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        }
+        .email-header {
+            text-align: center;
+            font-size: 24px;
+            color: #333;
+        }
+        .email-content {
+            margin-top: 20px;
+            font-size: 16px;
+        }
+        .email-footer {
+            margin-top: 40px;
+            font-size: 14px;
+            text-align: center;
+            color: #888;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="email-header">
+            Welcome to Premium!
+        </div>
+        <div class="email-content">
+            <p>Hello,</p>
+            <p>Your trial has converted to a paid {{ plan_name }} subscription — welcome to Progress RPG Premium!</p>
+            <p><a href="{{ account_url }}">Manage your subscription and billing details</a></p>
+            <p>Best regards, <br/> The Team</p>
+        </div>
+        <div class="email-footer">
+            <p>&copy; {{ current_year }} Progress RPG. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/emails/trial_converted.html
+++ b/templates/emails/trial_converted.html
@@ -40,7 +40,7 @@
             <p>Hello,</p>
             <p>Your trial has converted to a paid {{ plan_name }} subscription — welcome to Progress RPG Premium!</p>
             <p><a href="{{ account_url }}">Manage your subscription and billing details</a></p>
-            <p>Best regards, <br/> The Team</p>
+            <p>Best wishes, <br/> Duncan (Founder, Progress RPG)</p>
         </div>
         <div class="email-footer">
             <p>&copy; {{ current_year }} Progress RPG. All rights reserved.</p>

--- a/templates/emails/trial_converted.txt
+++ b/templates/emails/trial_converted.txt
@@ -6,7 +6,7 @@ Your trial has converted to a paid {{ plan_name }} subscription — welcome to P
 
 Manage your subscription and billing details: {{ account_url }}
 
-Best regards,
-The Team
+Best wishes,
+Duncan (Founder, Progress RPG)
 
 © {{ current_year }} Progress RPG. All rights reserved.

--- a/templates/emails/trial_converted.txt
+++ b/templates/emails/trial_converted.txt
@@ -1,0 +1,12 @@
+Welcome to Progress RPG Premium!
+
+Hello {{ email }},
+
+Your trial has converted to a paid {{ plan_name }} subscription — welcome to Progress RPG Premium!
+
+Manage your subscription and billing details: {{ account_url }}
+
+Best regards,
+The Team
+
+© {{ current_year }} Progress RPG. All rights reserved.

--- a/templates/emails/trial_ended.html
+++ b/templates/emails/trial_ended.html
@@ -1,0 +1,50 @@
+<!-- templates/emails/trial_ended.html -->
+<html>
+<head>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            color: #333;
+            background-color: #f4f4f4;
+            padding: 20px;
+        }
+        .email-container {
+            background-color: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        }
+        .email-header {
+            text-align: center;
+            font-size: 24px;
+            color: #333;
+        }
+        .email-content {
+            margin-top: 20px;
+            font-size: 16px;
+        }
+        .email-footer {
+            margin-top: 40px;
+            font-size: 14px;
+            text-align: center;
+            color: #888;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="email-header">
+            Your trial has ended
+        </div>
+        <div class="email-content">
+            <p>Hello,</p>
+            <p>Your Progress RPG premium trial has ended and premium features have been turned off, since no payment method was added.</p>
+            <p><a href="{{ upgrade_url }}">Resubscribe to get premium back</a></p>
+            <p>Best regards, <br/> The Team</p>
+        </div>
+        <div class="email-footer">
+            <p>&copy; {{ current_year }} Progress RPG. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/emails/trial_ended.html
+++ b/templates/emails/trial_ended.html
@@ -40,7 +40,7 @@
             <p>Hello,</p>
             <p>Your Progress RPG premium trial has ended and premium features have been turned off, since no payment method was added.</p>
             <p><a href="{{ upgrade_url }}">Resubscribe to get premium back</a></p>
-            <p>Best regards, <br/> The Team</p>
+            <p>Best wishes, <br/> Duncan (Founder, Progress RPG)</p>
         </div>
         <div class="email-footer">
             <p>&copy; {{ current_year }} Progress RPG. All rights reserved.</p>

--- a/templates/emails/trial_ended.txt
+++ b/templates/emails/trial_ended.txt
@@ -1,0 +1,12 @@
+Your Progress RPG trial has ended
+
+Hello {{ email }},
+
+Your Progress RPG premium trial has ended and premium features have been turned off, since no payment method was added.
+
+You can resubscribe at any time to get premium back: {{ upgrade_url }}
+
+Best regards,
+The Team
+
+© {{ current_year }} Progress RPG. All rights reserved.

--- a/templates/emails/trial_ended.txt
+++ b/templates/emails/trial_ended.txt
@@ -6,7 +6,7 @@ Your Progress RPG premium trial has ended and premium features have been turned 
 
 You can resubscribe at any time to get premium back: {{ upgrade_url }}
 
-Best regards,
-The Team
+Best wishes,
+Duncan (Founder, Progress RPG)
 
 © {{ current_year }} Progress RPG. All rights reserved.

--- a/templates/emails/trial_ending_soon.html
+++ b/templates/emails/trial_ending_soon.html
@@ -41,7 +41,7 @@
             <p>Your Progress RPG premium trial is ending{% if trial_end %} on {{ trial_end|date:"F j, Y" }}{% else %} soon{% endif %}. Add a payment method now to keep your premium features without interruption.</p>
             <p><a href="{{ account_url }}">Manage your subscription</a></p>
             <p>If you don't add payment details, your premium access will end automatically and you won't be charged.</p>
-            <p>Best regards, <br/> The Team</p>
+            <p>Best wishes, <br/> Duncan (Founder, Progress RPG)</p>
         </div>
         <div class="email-footer">
             <p>&copy; {{ current_year }} Progress RPG. All rights reserved.</p>

--- a/templates/emails/trial_ending_soon.html
+++ b/templates/emails/trial_ending_soon.html
@@ -1,0 +1,51 @@
+<!-- templates/emails/trial_ending_soon.html -->
+<html>
+<head>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            color: #333;
+            background-color: #f4f4f4;
+            padding: 20px;
+        }
+        .email-container {
+            background-color: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        }
+        .email-header {
+            text-align: center;
+            font-size: 24px;
+            color: #333;
+        }
+        .email-content {
+            margin-top: 20px;
+            font-size: 16px;
+        }
+        .email-footer {
+            margin-top: 40px;
+            font-size: 14px;
+            text-align: center;
+            color: #888;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="email-header">
+            Your trial is ending soon
+        </div>
+        <div class="email-content">
+            <p>Hello,</p>
+            <p>Your Progress RPG premium trial is ending{% if trial_end %} on {{ trial_end|date:"F j, Y" }}{% else %} soon{% endif %}. Add a payment method now to keep your premium features without interruption.</p>
+            <p><a href="{{ account_url }}">Manage your subscription</a></p>
+            <p>If you don't add payment details, your premium access will end automatically and you won't be charged.</p>
+            <p>Best regards, <br/> The Team</p>
+        </div>
+        <div class="email-footer">
+            <p>&copy; {{ current_year }} Progress RPG. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/emails/trial_ending_soon.txt
+++ b/templates/emails/trial_ending_soon.txt
@@ -8,7 +8,7 @@ Manage your subscription: {{ account_url }}
 
 If you don't add payment details, your premium access will end automatically and you won't be charged.
 
-Best regards,
-The Team
+Best wishes,
+Duncan (Founder, Progress RPG)
 
 © {{ current_year }} Progress RPG. All rights reserved.

--- a/templates/emails/trial_ending_soon.txt
+++ b/templates/emails/trial_ending_soon.txt
@@ -1,0 +1,14 @@
+Your Progress RPG trial is ending soon
+
+Hello {{ email }},
+
+Your Progress RPG premium trial is ending{% if trial_end %} on {{ trial_end|date:"F j, Y" }}{% else %} soon{% endif %}. Add a payment method now to keep your premium features without interruption.
+
+Manage your subscription: {{ account_url }}
+
+If you don't add payment details, your premium access will end automatically and you won't be charged.
+
+Best regards,
+The Team
+
+© {{ current_year }} Progress RPG. All rights reserved.

--- a/templates/emails/welcome_email.html
+++ b/templates/emails/welcome_email.html
@@ -40,7 +40,7 @@
             <p>Hello,</p>
             <p>Thank you for signing up to Progress RPG! We are excited to have you as part of our community.</p>
             <p>We recommend you complete your profile to get started with all the features available to you!</p>
-            <p>Best regards, <br/> The Team</p>
+            <p>Best wishes, <br/> Duncan (Founder, Progress RPG)</p>
         </div>
         <div class="email-footer">
             <p>&copy; {{ current_year }} Progress RPG. All rights reserved.</p>

--- a/templates/emails/welcome_email.txt
+++ b/templates/emails/welcome_email.txt
@@ -6,7 +6,7 @@ Thank you for signing up to Progress RPG! We are excited to have you as part of 
 
 We recommend you complete your profile to get started with all the features available to you!
 
-Best regards,
-The Team
+Best wishes,
+Duncan (Founder, Progress RPG)
 
 © {{ current_year }} Progress RPG. All rights reserved.


### PR DESCRIPTION
## Summary
- Handle `customer.subscription.trial_will_end` to email users ~3 days before a trial ends, prompting them to add payment details.
- Extend `_handle_trial_has_ended` to email on `trialing -> canceled` (trial ended without payment) and `trialing -> active` (trial converted to paid), mutually exclusive per the acceptance criteria.
- Reuse the existing async email infra (`send_email_to_users` -> Celery `send_email_to_users_task`), same path as password reset/welcome emails — no new provider or infra.
- Copy avoids hardcoding trial length; the "ending soon" email uses the actual `trial_end` timestamp from the Stripe subscription payload.
- Dedup relies on the existing `StripeEvent` webhook dedup (`processed_at` check in `StripeWebhookView`).

## Test plan
- [x] `docker compose run --rm web python manage.py test payments --noinput` — 32/32 passing, including 5 new tests covering all three transitions and unknown-customer no-op.
- [ ] Manually trigger `stripe trigger customer.subscription.trial_will_end` / equivalent against a test subscription with `make stripelistener` to confirm real email delivery end-to-end.

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)