### PR TITLE
Online players display

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -122,6 +122,7 @@ class FetchInfoResponseSerializer(serializers.Serializer):
     login_reward_xp = serializers.IntegerField()
     free_timer_limit_seconds = serializers.IntegerField()
     game_settings = serializers.JSONField()
+    online_count = serializers.IntegerField()
 
 
 class GameSettingsSerializer(serializers.Serializer):

--- a/api/views.py
+++ b/api/views.py
@@ -75,7 +75,7 @@ from locations.serializers import PopulationCentreSerializer
 
 from progression.serializers import PlayerActivitySerializer
 
-from users.models import TutorialStep
+from users.models import Player, TutorialStep
 from users.serializers import PlayerSerializer, TutorialStepSerializer
 from users.utils import send_email_to_users
 
@@ -570,6 +570,7 @@ class FetchInfoAPIView(APIView):
                 "login_reward_xp": login_state_data["login_reward_xp"],
                 "free_timer_limit_seconds": game_settings.free_timer_limit_seconds,
                 "game_settings": GameSettingsSerializer(game_settings).data,
+                "online_count": Player.online_count(),
             }
             return Response(data)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { MaintenanceProvider } from './context/MaintenanceContext';
 import { ToastProvider } from './context/ToastContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { GameProvider } from './context/GameContext';
+import { OnlineCountProvider } from './context/OnlineCountContext';
 import { BrowserRouter, useLocation } from 'react-router-dom';
 import { WebSocketProvider } from './context/WebSocketContext';
 
@@ -48,15 +49,17 @@ function AppWithAuth(): React.ReactElement {
 
   return (
     <GameProvider>
-      <ToastProvider>
-        <WebSocketProvider>
-          <BrowserRouter>
-            <RouteChangeTracker />
-            <MaintenanceWatcher />
-            <AppContent />
-          </BrowserRouter>
-        </WebSocketProvider>
-      </ToastProvider>
+      <OnlineCountProvider>
+        <ToastProvider>
+          <WebSocketProvider>
+            <BrowserRouter>
+              <RouteChangeTracker />
+              <MaintenanceWatcher />
+              <AppContent />
+            </BrowserRouter>
+          </WebSocketProvider>
+        </ToastProvider>
+      </OnlineCountProvider>
     </GameProvider>
   );
 }

--- a/frontend/src/AppContent.tsx
+++ b/frontend/src/AppContent.tsx
@@ -6,6 +6,7 @@ import NavDrawer from './layout/NavDrawer/NavDrawer';
 import StaticBanner from './components/StaticBanner/StaticBanner';
 import AppRoutes from "./routes/AppRoutes";
 import Footer from './layout/Footer/Footer';
+import OnlineCountBadge from './components/OnlineCountBadge/OnlineCountBadge';
 import FeedbackWidget from './components/FeedbackWidget/FeedbackWidget';
 import TutorialModal from './components/TutorialModal/TutorialModal';
 import { useAuth } from './context/AuthContext';
@@ -60,6 +61,7 @@ export default function AppContent(): React.ReactElement {
       <main style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
         <AppRoutes />
       </main>
+      <OnlineCountBadge />
       <Footer />
       {isAuthenticated && !tutorialOpen && <FeedbackWidget />}
       {tutorialOpen && (

--- a/frontend/src/AppContent.tsx
+++ b/frontend/src/AppContent.tsx
@@ -10,7 +10,7 @@ import OnlineCountBadge from './components/OnlineCountBadge/OnlineCountBadge';
 import FeedbackWidget from './components/FeedbackWidget/FeedbackWidget';
 import TutorialModal from './components/TutorialModal/TutorialModal';
 import { useAuth } from './context/AuthContext';
-import { useGame } from './context/GameContext';
+import { useGame } from './hooks/useGame';
 import { apiFetch } from './utils/api';
 
 const announcement = `Progress RPG is in alpha status, and under active development. Bugs may appear, and data may be lost. Thank you for testing!`;

--- a/frontend/src/components/ActivityInput/ActivityInput.test.tsx
+++ b/frontend/src/components/ActivityInput/ActivityInput.test.tsx
@@ -21,7 +21,7 @@ const { playLimitReachedSound, primeAudio } = vi.hoisted(() => ({
   primeAudio: vi.fn(),
 }));
 
-vi.mock('../../context/GameContext', () => ({
+vi.mock('../../hooks/useGame', () => ({
   useGame: () => mockUseGame(),
 }));
 

--- a/frontend/src/components/ActivityInput/useActivityInput.ts
+++ b/frontend/src/components/ActivityInput/useActivityInput.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { useGame } from "../../context/GameContext";
+import { useGame } from "../../hooks/useGame";
 import { useEntitySearchCache } from "../../hooks/useEntitySearchCache";
 import { useSupportFlow } from "../../hooks/useSupportFlow";
 import type { PlayerActivity } from "../../types";

--- a/frontend/src/components/ActivityTimeline/ActivityTimeline.tsx
+++ b/frontend/src/components/ActivityTimeline/ActivityTimeline.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useEffect } from "react";
-import { useGame } from "../../context/GameContext";
+import { useGame } from "../../hooks/useGame";
 import { useTasks } from "../../hooks/useTasks";
 import { useFeatureFlag } from "../../hooks/useFeatureFlag";
 import List from "../List/List";

--- a/frontend/src/components/CharacterCurrentActivity/CharacterCurrentActivity.tsx
+++ b/frontend/src/components/CharacterCurrentActivity/CharacterCurrentActivity.tsx
@@ -1,6 +1,6 @@
 // components/CharacterCurrentActivity/CharacterCurrentActivity.tsx
 import { useEffect, useMemo, useState } from "react";
-import { useGame } from "../../context/GameContext";
+import { useGame } from "../../hooks/useGame";
 import styles from "./CharacterCurrentActivity.module.scss";
 
 export default function CharacterCurrentActivity() {

--- a/frontend/src/components/CurrentActivity/CurrentActivity.tsx
+++ b/frontend/src/components/CurrentActivity/CurrentActivity.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import { useGame } from "../../context/GameContext";
+import { useGame } from "../../hooks/useGame";
 import ActivityInput from "../ActivityInput/ActivityInput";
 import styles from "./CurrentActivity.module.scss";
 

--- a/frontend/src/components/FeatureToggle.test.tsx
+++ b/frontend/src/components/FeatureToggle.test.tsx
@@ -6,7 +6,7 @@ import type { FeatureFlagKey } from '../types';
 const mockUseGame = vi.fn();
 const mockUseAppConfig = vi.fn();
 
-vi.mock('../context/GameContext', () => ({
+vi.mock('../hooks/useGame', () => ({
   useGame: () => mockUseGame(),
 }));
 

--- a/frontend/src/components/OnlineCountBadge/OnlineCountBadge.module.scss
+++ b/frontend/src/components/OnlineCountBadge/OnlineCountBadge.module.scss
@@ -1,0 +1,29 @@
+@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/colors' as c;
+@use '../../styles/semantic/typography' as t;
+@use '../../styles/semantic/spacing' as sp;
+@use 'sass:map';
+
+.badge {
+  position: fixed;
+  left: 1rem;
+  bottom: 1rem;
+  z-index: v.$z-indexdropdown;
+  background: c.$color-bg;
+  border: 1px solid c.$color-border-primary;
+  border-radius: v.$border-radius;
+  padding: map.get(sp.$gap, xs) map.get(sp.$gap, sm);
+  @include t.apply-text-style(t.$text-body);
+}
+
+@media (max-width: 768px) {
+  .badge {
+    bottom: 8rem;
+  }
+}
+
+@media (max-width: 576px) {
+  .badge {
+    bottom: 9rem;
+  }
+}

--- a/frontend/src/components/OnlineCountBadge/OnlineCountBadge.module.scss
+++ b/frontend/src/components/OnlineCountBadge/OnlineCountBadge.module.scss
@@ -2,6 +2,7 @@
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/spacing' as sp;
+@use '../../styles/utilities/mixins' as mix;
 @use 'sass:map';
 
 .badge {
@@ -14,16 +15,12 @@
   border-radius: v.$border-radius;
   padding: map.get(sp.$gap, xs) map.get(sp.$gap, sm);
   @include t.apply-text-style(t.$text-body);
-}
 
-@media (max-width: 768px) {
-  .badge {
+  @include mix.respond-to(md, down) {
     bottom: 8rem;
   }
-}
 
-@media (max-width: 576px) {
-  .badge {
+  @include mix.respond-to(sm, down) {
     bottom: 9rem;
   }
 }

--- a/frontend/src/components/OnlineCountBadge/OnlineCountBadge.test.tsx
+++ b/frontend/src/components/OnlineCountBadge/OnlineCountBadge.test.tsx
@@ -7,15 +7,15 @@ vi.mock('../../context/AuthContext', () => ({
   useAuth: () => ({ isAuthenticated: true }),
 }));
 
-const mockUseGame = vi.fn(() => ({ onlinePlayerCount: 12 }));
+const mockUseOnlineCount = vi.fn(() => ({ onlinePlayerCount: 12 }));
 
-vi.mock('../../context/GameContext', () => ({
-  useGame: () => mockUseGame(),
+vi.mock('../../context/OnlineCountContext', () => ({
+  useOnlineCount: () => mockUseOnlineCount(),
 }));
 
 describe('OnlineCountBadge', () => {
   it('shows the current online player count', () => {
-    mockUseGame.mockReturnValue({ onlinePlayerCount: 12 });
+    mockUseOnlineCount.mockReturnValue({ onlinePlayerCount: 12 });
 
     render(<OnlineCountBadge />);
 
@@ -23,7 +23,7 @@ describe('OnlineCountBadge', () => {
   });
 
   it('updates displayed count from shared state', () => {
-    mockUseGame.mockReturnValue({ onlinePlayerCount: 3 });
+    mockUseOnlineCount.mockReturnValue({ onlinePlayerCount: 3 });
 
     render(<OnlineCountBadge />);
 

--- a/frontend/src/components/OnlineCountBadge/OnlineCountBadge.test.tsx
+++ b/frontend/src/components/OnlineCountBadge/OnlineCountBadge.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import OnlineCountBadge from './OnlineCountBadge';
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true }),
+}));
+
+const mockUseGame = vi.fn(() => ({ onlinePlayerCount: 12 }));
+
+vi.mock('../../context/GameContext', () => ({
+  useGame: () => mockUseGame(),
+}));
+
+describe('OnlineCountBadge', () => {
+  it('shows the current online player count', () => {
+    mockUseGame.mockReturnValue({ onlinePlayerCount: 12 });
+
+    render(<OnlineCountBadge />);
+
+    expect(screen.getByText('12 players online')).toBeInTheDocument();
+  });
+
+  it('updates displayed count from shared state', () => {
+    mockUseGame.mockReturnValue({ onlinePlayerCount: 3 });
+
+    render(<OnlineCountBadge />);
+
+    expect(screen.getByText('3 players online')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/OnlineCountBadge/OnlineCountBadge.tsx
+++ b/frontend/src/components/OnlineCountBadge/OnlineCountBadge.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useAuth } from '../../context/AuthContext';
-import { useGame } from '../../context/GameContext';
+import { useOnlineCount } from '../../context/OnlineCountContext';
 import styles from './OnlineCountBadge.module.scss';
 
 export default function OnlineCountBadge() {
   const { isAuthenticated } = useAuth();
-  const { onlinePlayerCount } = useGame();
+  const { onlinePlayerCount } = useOnlineCount();
 
   if (!isAuthenticated) {
     return null;

--- a/frontend/src/components/OnlineCountBadge/OnlineCountBadge.tsx
+++ b/frontend/src/components/OnlineCountBadge/OnlineCountBadge.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useAuth } from '../../context/AuthContext';
+import { useGame } from '../../context/GameContext';
+import styles from './OnlineCountBadge.module.scss';
+
+export default function OnlineCountBadge() {
+  const { isAuthenticated } = useAuth();
+  const { onlinePlayerCount } = useGame();
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <div className={styles.badge} aria-live="polite" role="status">
+      <span aria-hidden="true">🟢 </span>
+      {onlinePlayerCount} players online
+    </div>
+  );
+}

--- a/frontend/src/components/PlayerSocketListener.tsx
+++ b/frontend/src/components/PlayerSocketListener.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useGame } from '../context/GameContext';
+import { useGame } from '../hooks/useGame';
 import { API_BASE_URL } from '../config';
 import type { IncomingWebSocketMessage } from '../types';
 

--- a/frontend/src/components/RequirePremium.tsx
+++ b/frontend/src/components/RequirePremium.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Navigate } from "react-router-dom";
-import { useGame } from "../context/GameContext";
+import { useGame } from "../hooks/useGame";
 
 interface RequirePremiumProps {
   children: React.ReactNode;

--- a/frontend/src/components/SupportFlow/SupportFlowModal.test.tsx
+++ b/frontend/src/components/SupportFlow/SupportFlowModal.test.tsx
@@ -19,7 +19,7 @@ vi.mock("../../hooks/useFeatureFlag", () => ({
   useFeatureFlag: () => false,
 }));
 
-vi.mock("../../context/GameContext", () => ({
+vi.mock("../../hooks/useGame", () => ({
   useGame: () => mockUseGame(),
 }));
 

--- a/frontend/src/components/SupportFlow/screens/ActivityRewardScreen.test.tsx
+++ b/frontend/src/components/SupportFlow/screens/ActivityRewardScreen.test.tsx
@@ -10,7 +10,7 @@ vi.mock('../../../hooks/useTasks', () => ({
   useUpdateTask: () => ({ mutate: vi.fn() }),
 }));
 
-vi.mock('../../../context/GameContext', () => ({
+vi.mock('../../../hooks/useGame', () => ({
   useGame: () => mockUseGame(),
 }));
 

--- a/frontend/src/components/SupportFlow/screens/ActivityRewardScreen.tsx
+++ b/frontend/src/components/SupportFlow/screens/ActivityRewardScreen.tsx
@@ -4,7 +4,7 @@ import Button from "../../Button/Button";
 import ButtonFrame from "../../Button/ButtonFrame";
 import { formatDuration, formatRewardDuration } from "../../../utils/formatUtils";
 import { useTasks, useUpdateTask } from "../../../hooks/useTasks";
-import { useGame } from "../../../context/GameContext";
+import { useGame } from "../../../hooks/useGame";
 import styles from "../SupportFlowModal.module.scss";
 
 const SUPPORT_COUNTDOWN_MS = 3000;

--- a/frontend/src/components/Timer/ActivityTimer.tsx
+++ b/frontend/src/components/Timer/ActivityTimer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useGame } from "../../context/GameContext";
+import { useGame } from "../../hooks/useGame";
 import Button from "../Button/Button";
 import ButtonFrame from "../Button/ButtonFrame";
 import Input from "../Input/Input";

--- a/frontend/src/context/GameContext.tsx
+++ b/frontend/src/context/GameContext.tsx
@@ -56,6 +56,8 @@ export interface GameContextValue {
   buildNumber: string | boolean;
   freeTimerLimitSeconds: number;
   gameSettings: GameSettings | null;
+  onlinePlayerCount: number;
+  setOnlinePlayerCount: Dispatch<SetStateAction<number>>;
 }
 
 interface ProviderProps {
@@ -123,6 +125,7 @@ export const GameProvider = ({ children }: ProviderProps): ReactElement => {
   const [characterActivities, setCharacterActivities] = useState<CharacterActivity[]>([]);
   const [characterCurrentActivity, setCharacterCurrentActivity] = useState<CharacterActivity | null>(null);
   const [populationCentre, setPopulationCentre] = useState<PopulationCentre | null>(populationCentreInfo);
+  const [onlinePlayerCount, setOnlinePlayerCount] = useState<number>(0);
 
   const activityTimer = useActivityTimer();
   const { loadFromServer } = activityTimer;
@@ -235,6 +238,8 @@ export const GameProvider = ({ children }: ProviderProps): ReactElement => {
       buildNumber,
       freeTimerLimitSeconds,
       gameSettings,
+      onlinePlayerCount,
+      setOnlinePlayerCount,
     }),
     [
       player,
@@ -251,6 +256,7 @@ export const GameProvider = ({ children }: ProviderProps): ReactElement => {
       buildNumber,
       freeTimerLimitSeconds,
       gameSettings,
+      onlinePlayerCount,
       populationCentre,
       fetchPopulationCentre,
       loginState,

--- a/frontend/src/context/GameContext.tsx
+++ b/frontend/src/context/GameContext.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react-hooks/set-state-in-effect */
 // GameContext.tsx
-import { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
-import type { Dispatch, ReactElement, ReactNode, SetStateAction } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { useBootstrapGameData } from '../hooks/useBootstrapGameData';
 import { apiFetch } from "../utils/api";
 import useActivityTimer from '../hooks/useActivityTimer';
 import { useAuth } from './AuthContext';
+import { GameContext, type GameContextValue } from './gameContext';
 import type {
   Player,
   Character,
@@ -14,9 +15,6 @@ import type {
   PlayerActivity,
   CharacterActivity,
   PopulationCentre,
-  GameSettings,
-  LoginState,
-  ActivityTimerReturn,
 } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -31,44 +29,9 @@ interface CharacterCurrentResponse {
   current: CharacterActivity | null;
 }
 
-export interface GameContextValue {
-  player: Player | null;
-  setPlayer: Dispatch<SetStateAction<Player | null>>;
-  character: Character | null;
-  setCharacter: Dispatch<SetStateAction<Character | null>>;
-  xpMods: XpModifier[];
-  setXpMods: Dispatch<SetStateAction<XpModifier[]>>;
-  fetchPlayerAndCharacter: () => Promise<void>;
-  activityTimer: ActivityTimerReturn;
-  playerActivities: PlayerActivity[];
-  characterActivities: CharacterActivity[];
-  fetchActivities: () => Promise<void>;
-  fetchCharacterCurrent: () => Promise<CharacterActivity | null>;
-  characterCurrentActivity: CharacterActivity | null;
-  setCharacterCurrentActivity: Dispatch<SetStateAction<CharacterActivity | null>>;
-  populationCentre: PopulationCentre | null;
-  fetchPopulationCentre: (pcId: number) => Promise<PopulationCentre>;
-  loginState: LoginState;
-  loginStreak: number;
-  loginEventAt: string | null;
-  loginRewardXp: number;
-  loading: boolean;
-  buildNumber: string | boolean;
-  freeTimerLimitSeconds: number;
-  gameSettings: GameSettings | null;
-  onlinePlayerCount: number;
-  setOnlinePlayerCount: Dispatch<SetStateAction<number>>;
-}
-
 interface ProviderProps {
   children: ReactNode;
 }
-
-// ---------------------------------------------------------------------------
-// Context
-// ---------------------------------------------------------------------------
-
-const GameContext = createContext<GameContextValue | null>(null);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -80,19 +43,6 @@ const getActivityWindow = (): { start: string } => {
   return {
     start: since.toISOString(),
   };
-};
-
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
-// eslint-disable-next-line react-refresh/only-export-components
-export const useGame = (): GameContextValue => {
-  const ctx = useContext(GameContext);
-  if (!ctx) {
-    throw new Error('useGame must be used within a GameProvider');
-  }
-  return ctx;
 };
 
 // ---------------------------------------------------------------------------
@@ -115,6 +65,7 @@ export const GameProvider = ({ children }: ProviderProps): ReactElement => {
     buildNumber,
     freeTimerLimitSeconds,
     gameSettings,
+    onlineCount: initialOnlineCount,
   } = useBootstrapGameData();
 
 
@@ -125,7 +76,6 @@ export const GameProvider = ({ children }: ProviderProps): ReactElement => {
   const [characterActivities, setCharacterActivities] = useState<CharacterActivity[]>([]);
   const [characterCurrentActivity, setCharacterCurrentActivity] = useState<CharacterActivity | null>(null);
   const [populationCentre, setPopulationCentre] = useState<PopulationCentre | null>(populationCentreInfo);
-  const [onlinePlayerCount, setOnlinePlayerCount] = useState<number>(0);
 
   const activityTimer = useActivityTimer();
   const { loadFromServer } = activityTimer;
@@ -238,8 +188,7 @@ export const GameProvider = ({ children }: ProviderProps): ReactElement => {
       buildNumber,
       freeTimerLimitSeconds,
       gameSettings,
-      onlinePlayerCount,
-      setOnlinePlayerCount,
+      initialOnlineCount,
     }),
     [
       player,
@@ -256,7 +205,7 @@ export const GameProvider = ({ children }: ProviderProps): ReactElement => {
       buildNumber,
       freeTimerLimitSeconds,
       gameSettings,
-      onlinePlayerCount,
+      initialOnlineCount,
       populationCentre,
       fetchPopulationCentre,
       loginState,

--- a/frontend/src/context/OnlineCountContext.tsx
+++ b/frontend/src/context/OnlineCountContext.tsx
@@ -1,0 +1,50 @@
+// context/OnlineCountContext.tsx
+import { createContext, useContext, useState } from 'react';
+import type { Dispatch, ReactElement, ReactNode, SetStateAction } from 'react';
+import { useGame } from '../hooks/useGame';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface OnlineCountContextValue {
+  onlinePlayerCount: number;
+  setOnlinePlayerCount: Dispatch<SetStateAction<number>>;
+}
+
+interface ProviderProps {
+  children: ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const OnlineCountContext = createContext<OnlineCountContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+// Kept separate from GameContext so that websocket-driven updates to this
+// count don't re-render every consumer of useGame() on every connect/
+// disconnect anywhere in the system.
+export function OnlineCountProvider({ children }: ProviderProps): ReactElement {
+  const { initialOnlineCount } = useGame();
+  const [onlinePlayerCount, setOnlinePlayerCount] = useState<number>(initialOnlineCount);
+
+  return (
+    <OnlineCountContext.Provider value={{ onlinePlayerCount, setOnlinePlayerCount }}>
+      {children}
+    </OnlineCountContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useOnlineCount(): OnlineCountContextValue {
+  const context = useContext(OnlineCountContext);
+  if (!context) {
+    throw new Error('useOnlineCount must be used within an OnlineCountProvider');
+  }
+  return context;
+}

--- a/frontend/src/context/WebSocketContext.tsx
+++ b/frontend/src/context/WebSocketContext.tsx
@@ -1,7 +1,8 @@
 // context/WebSocketContext.tsx
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 import type { ReactNode, ReactElement } from 'react';
-import { useGame } from './GameContext';
+import { useGame } from '../hooks/useGame';
+import { useOnlineCount } from './OnlineCountContext';
 import { useToast } from '../hooks/useToast';
 import { useAuth } from './AuthContext';
 import { useWebSocketConnection } from '../hooks/useWebSocketConnection';
@@ -19,12 +20,18 @@ interface ProviderProps {
   children: ReactNode;
 }
 
+// How often to ping the server while connected, so the backend's
+// `last_seen` heartbeat stays fresh and this connection isn't swept up as
+// abandoned by users.tasks.reconcile_stale_online_players.
+const HEARTBEAT_INTERVAL_MS = 60_000;
+
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
 
 export const WebSocketProvider = ({ children }: ProviderProps): ReactElement => {
-  const { player, setOnlinePlayerCount } = useGame();
+  const { player } = useGame();
+  const { setOnlinePlayerCount } = useOnlineCount();
   const { isAuthenticated, loading: authLoading } = useAuth();
   const { showToast } = useToast();
   const { refetch: maintenanceRefetch } = useMaintenanceStatus();
@@ -69,6 +76,17 @@ export const WebSocketProvider = ({ children }: ProviderProps): ReactElement => 
   }, []);
 
   const typedSend = (data: OutgoingWebSocketMessage): void => send(data);
+
+  useEffect(() => {
+    if (!isConnected) {
+      return;
+    }
+    const intervalId = setInterval(() => {
+      typedSend({ type: 'ping' });
+    }, HEARTBEAT_INTERVAL_MS);
+    return () => clearInterval(intervalId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isConnected]);
 
   return (
     <WebSocketContext.Provider value={{ send: typedSend, isConnected, addEventHandler, disconnect }}>

--- a/frontend/src/context/WebSocketContext.tsx
+++ b/frontend/src/context/WebSocketContext.tsx
@@ -24,7 +24,7 @@ interface ProviderProps {
 // ---------------------------------------------------------------------------
 
 export const WebSocketProvider = ({ children }: ProviderProps): ReactElement => {
-  const { player } = useGame();
+  const { player, setOnlinePlayerCount } = useGame();
   const { isAuthenticated, loading: authLoading } = useAuth();
   const { showToast } = useToast();
   const { refetch: maintenanceRefetch } = useMaintenanceStatus();
@@ -34,10 +34,13 @@ export const WebSocketProvider = ({ children }: ProviderProps): ReactElement => 
   const wsEnabled = Boolean(!authLoading && isAuthenticated && player?.id);
 
   const onMessage = useCallback((data: IncomingWebSocketMessage) => {
+    if (data.type === 'online_count') {
+      setOnlinePlayerCount(data.count);
+    }
     //console.log("[WS Provider] showToast:", showToast);
     handleGlobalWebSocketEvent(data, { showToast, maintenanceRefetch, setMaintenance });
     eventHandlersRef.current.forEach((handler) => handler(data));
-  }, [showToast, maintenanceRefetch, setMaintenance]);
+  }, [showToast, maintenanceRefetch, setMaintenance, setOnlinePlayerCount]);
 
   const onError = useCallback(() => {
     console.error('WebSocket connection error');

--- a/frontend/src/context/gameContext.ts
+++ b/frontend/src/context/gameContext.ts
@@ -1,0 +1,46 @@
+import { createContext } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type {
+  Player,
+  Character,
+  XpModifier,
+  PlayerActivity,
+  CharacterActivity,
+  PopulationCentre,
+  GameSettings,
+  LoginState,
+  ActivityTimerReturn,
+} from '../types';
+
+export interface GameContextValue {
+  player: Player | null;
+  setPlayer: Dispatch<SetStateAction<Player | null>>;
+  character: Character | null;
+  setCharacter: Dispatch<SetStateAction<Character | null>>;
+  xpMods: XpModifier[];
+  setXpMods: Dispatch<SetStateAction<XpModifier[]>>;
+  fetchPlayerAndCharacter: () => Promise<void>;
+  activityTimer: ActivityTimerReturn;
+  playerActivities: PlayerActivity[];
+  characterActivities: CharacterActivity[];
+  fetchActivities: () => Promise<void>;
+  fetchCharacterCurrent: () => Promise<CharacterActivity | null>;
+  characterCurrentActivity: CharacterActivity | null;
+  setCharacterCurrentActivity: Dispatch<SetStateAction<CharacterActivity | null>>;
+  populationCentre: PopulationCentre | null;
+  fetchPopulationCentre: (pcId: number) => Promise<PopulationCentre>;
+  loginState: LoginState;
+  loginStreak: number;
+  loginEventAt: string | null;
+  loginRewardXp: number;
+  loading: boolean;
+  buildNumber: string | boolean;
+  freeTimerLimitSeconds: number;
+  gameSettings: GameSettings | null;
+  /** Online player count as of the initial bootstrap fetch; frozen after load.
+   *  Live updates flow through OnlineCountContext instead, to avoid
+   *  re-rendering every useGame() consumer on each websocket broadcast. */
+  initialOnlineCount: number;
+}
+
+export const GameContext = createContext<GameContextValue | null>(null);

--- a/frontend/src/hooks/useBootstrapGameData.ts
+++ b/frontend/src/hooks/useBootstrapGameData.ts
@@ -29,6 +29,7 @@ export function useBootstrapGameData() {
   const [buildNumber, setBuildNumber] = useState<string | boolean>(true);
   const [freeTimerLimitSeconds, setFreeTimerLimitSeconds] = useState<number>(1800);
   const [gameSettings, setGameSettings] = useState<GameSettings | null>(null);
+  const [onlineCount, setOnlineCount] = useState<number>(0);
 
   useEffect(() => {
     if (authLoading) return;
@@ -59,6 +60,7 @@ export function useBootstrapGameData() {
         setLoginRewardXp(Number(info.login_reward_xp) || 0);
         setBuildNumber(info.build_number);
         setGameSettings(info.game_settings ?? null);
+        setOnlineCount(Number(info.online_count) || 0);
         setFreeTimerLimitSeconds(info.game_settings?.free_timer_limit_seconds ?? info.free_timer_limit_seconds ?? 1800);
       } catch (err) {
         console.error('[Bootstrap] Error loading game data:', err);
@@ -84,6 +86,7 @@ export function useBootstrapGameData() {
     buildNumber,
     freeTimerLimitSeconds,
     gameSettings,
+    onlineCount,
     loading,
     error
   };

--- a/frontend/src/hooks/useFeatureFlag.test.ts
+++ b/frontend/src/hooks/useFeatureFlag.test.ts
@@ -6,7 +6,7 @@ import { useFeatureFlag } from "./useFeatureFlag";
 const mockUseGame = vi.fn();
 const mockUseAppConfig = vi.fn();
 
-vi.mock("../context/GameContext", () => ({
+vi.mock("./useGame", () => ({
   useGame: () => mockUseGame(),
 }));
 

--- a/frontend/src/hooks/useFeatureFlag.ts
+++ b/frontend/src/hooks/useFeatureFlag.ts
@@ -1,5 +1,5 @@
 import featureFlags from "../featureFlags";
-import { useGame } from "../context/GameContext";
+import { useGame } from "../hooks/useGame";
 import { useAppConfig } from "./useAppConfig";
 import type { AccessGroup, FeatureFlagKey } from "../types";
 

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -1,0 +1,11 @@
+// hooks/useGame.ts
+import { useContext } from 'react';
+import { GameContext, type GameContextValue } from '../context/gameContext';
+
+export function useGame(): GameContextValue {
+  const ctx = useContext(GameContext);
+  if (!ctx) {
+    throw new Error('useGame must be used within a GameProvider');
+  }
+  return ctx;
+}

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, useCallback } from 'react';
 import { apiFetch } from "../utils/api";
-import { useGame } from '../context/GameContext';
+import { useGame } from './useGame';
 
 export default function useOnboarding() {
   const {

--- a/frontend/src/layout/GameContainer/ActivitySection/ActivityPanel.tsx
+++ b/frontend/src/layout/GameContainer/ActivitySection/ActivityPanel.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import List from "../../../components/List/List";
 import styles from "./ActivityPanel.module.scss";
-import { useGame } from "../../../context/GameContext";
+import { useGame } from "../../../hooks/useGame";
 import { formatDuration } from "../../../utils/formatUtils";
 import type { PlayerActivity } from "../../../types";
 

--- a/frontend/src/layout/GameContainer/ActivitySection/ActivitySection.tsx
+++ b/frontend/src/layout/GameContainer/ActivitySection/ActivitySection.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import GameSection from "../GameSection";
 import ActivityPanel from "./ActivityPanel";
 import { ActivityTimer } from "../../../components/Timer/ActivityTimer";
-import { useGame } from "../../../context/GameContext";
+import { useGame } from "../../../hooks/useGame";
 
 // `onboardingStage` is a legacy field not yet in the typed GameContextValue.
 // It will be added when GameContext is updated in a later migration step.

--- a/frontend/src/layout/Infobar/Infobar.tsx
+++ b/frontend/src/layout/Infobar/Infobar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useGame } from "../../context/GameContext";
+import { useGame } from "../../hooks/useGame";
 import AchievementBadges from "./AchievementBadges";
 import styles from "./Infobar.module.scss";
 

--- a/frontend/src/pages/Account/Account.test.tsx
+++ b/frontend/src/pages/Account/Account.test.tsx
@@ -14,7 +14,7 @@ const mockDeleteAccount = vi.fn();
 
 const TEST_BILLING_PORTAL_URL = "https://billing.stripe.com/p/login/test_portal";
 
-vi.mock("../../context/GameContext", () => ({
+vi.mock("../../hooks/useGame", () => ({
   useGame: () => mockUseGame(),
 }));
 

--- a/frontend/src/pages/Account/useAccountPage.ts
+++ b/frontend/src/pages/Account/useAccountPage.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 
-import { useGame } from "../../context/GameContext";
+import { useGame } from "../../hooks/useGame";
 import { useAppConfig } from "../../hooks/useAppConfig";
 import { deleteAccount, downloadUserData, updatePlayer } from "../../api/player";
 import {

--- a/frontend/src/pages/Checkout/UpgradePage.test.tsx
+++ b/frontend/src/pages/Checkout/UpgradePage.test.tsx
@@ -10,7 +10,7 @@ const mockUseGame = vi.fn();
 const mockUseAppConfig = vi.fn();
 const mockApiFetch = vi.fn();
 
-vi.mock("../../context/GameContext", () => ({
+vi.mock("../../hooks/useGame", () => ({
   useGame: () => mockUseGame(),
 }));
 

--- a/frontend/src/pages/Checkout/UpgradePage.tsx
+++ b/frontend/src/pages/Checkout/UpgradePage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 
 import Button from "../../components/Button/Button";
-import { useGame } from "../../context/GameContext";
+import { useGame } from "../../hooks/useGame";
 import { useAppConfig } from "../../hooks/useAppConfig";
 import { apiFetch } from "../../utils/api";
 import styles from "./UpgradePage.module.scss";

--- a/frontend/src/pages/SuccessPage.tsx
+++ b/frontend/src/pages/SuccessPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { apiFetch } from "../utils/api";
-import { useGame } from "../context/GameContext";
+import { useGame } from "../hooks/useGame";
 import Button from "../components/Button/Button";
 import styles from "./SuccessPage.module.scss";
 

--- a/frontend/src/pages/TasksPage/TasksPage.test.tsx
+++ b/frontend/src/pages/TasksPage/TasksPage.test.tsx
@@ -39,7 +39,7 @@ vi.mock("react-router-dom", () => ({
   useNavigate: () => navigate,
 }));
 
-vi.mock("../../context/GameContext", () => ({
+vi.mock("../../hooks/useGame", () => ({
   useGame: () => gameValue,
 }));
 

--- a/frontend/src/pages/TasksPage/useTasksPage.tsx
+++ b/frontend/src/pages/TasksPage/useTasksPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useTasks, useCreateTask, useUpdateTask, useDeleteTask } from "../../hooks/useTasks";
-import { useGame } from "../../context/GameContext";
+import { useGame } from "../../hooks/useGame";
 import type { Task } from "../../types";
 import type { SortOption } from "../../components/PlayerItemList/PlayerItemList";
 import { formatRewardDuration } from "../../utils/formatUtils";

--- a/frontend/src/pages/VillagePage/VillagePage.tsx
+++ b/frontend/src/pages/VillagePage/VillagePage.tsx
@@ -1,7 +1,7 @@
 // src/pages/VillagePage.tsx
 import React, { useEffect, useState } from "react";
 import PopulationCentreMap from "../../components/Map/Map";
-import { useGame } from "../../context/GameContext";
+import { useGame } from "../../hooks/useGame";
 import { apiFetch } from "../../utils/api";
 import ProgressBar from "../../components/ProgressBar/ProgressBar";
 import PopulationCentreResidents from "../../components/PopulationCentreResidents/PopulationCentreResidents";

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -68,6 +68,7 @@ export interface FetchInfoResponse {
   login_reward_xp: number;
   free_timer_limit_seconds: number;
   game_settings: GameSettings;
+  online_count: number;
 }
 
 // Forward references resolved in domain.ts

--- a/frontend/src/types/enums.ts
+++ b/frontend/src/types/enums.ts
@@ -52,7 +52,8 @@ export type WebSocketMessageType =
   | "action"
   | "response"
   | "error"
-  | "pong";
+  | "pong"
+  | "online_count";
 
 // WebSocket action strings sent from client (handle_client_request)
 export type ClientWebSocketAction =

--- a/frontend/src/types/timers.ts
+++ b/frontend/src/types/timers.ts
@@ -175,6 +175,11 @@ export interface WebSocketServerMessage {
   message?: string;
 }
 
+export interface WebSocketOnlineCountMessage {
+  type: "online_count";
+  count: number;
+}
+
 /** Union of all known incoming WebSocket message shapes */
 export type IncomingWebSocketMessage =
   | WebSocketConsoleMessage
@@ -182,7 +187,8 @@ export type IncomingWebSocketMessage =
   | WebSocketNotificationMessage
   | WebSocketErrorMessage
   | WebSocketActionMessage
-  | WebSocketServerMessage;
+  | WebSocketServerMessage
+  | WebSocketOnlineCountMessage;
 
 /** Client-to-server message shape */
 export interface OutgoingWebSocketMessage {

--- a/frontend/src/websockets/handleGlobalWebSocketEvent.ts
+++ b/frontend/src/websockets/handleGlobalWebSocketEvent.ts
@@ -25,6 +25,9 @@ export async function handleGlobalWebSocketEvent(
     case 'server_message':
       break;
 
+    case 'online_count':
+      break;
+
     case 'action':
       switch (data.action) {
         case 'refresh':

--- a/gameplay/consumers.py
+++ b/gameplay/consumers.py
@@ -6,7 +6,7 @@ from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from django.db import transaction
 
-# from django.utils.timezone import now
+from django.utils import timezone
 import json, logging
 from django.core.cache import cache
 
@@ -15,6 +15,8 @@ from users.models import Player
 
 DISCONNECT_GRACE_SECONDS = 30
 DISCONNECT_TASK_CACHE_KEY = "disconnect_task:{player_id}"
+ONLINE_COUNT_CACHE_KEY = "online_count"
+ONLINE_COUNT_CACHE_SECONDS = 2
 
 from .models import ServerMessage
 from .utils import process_completion, process_initiation, control_timers
@@ -26,7 +28,11 @@ logger_errors = logging.getLogger("errors")
 class TimerConsumer(AsyncJsonWebsocketConsumer):
     @database_sync_to_async
     def get_online_count(self):
-        return Player.online_count()
+        count = cache.get(ONLINE_COUNT_CACHE_KEY)
+        if count is None:
+            count = Player.online_count()
+            cache.set(ONLINE_COUNT_CACHE_KEY, count, timeout=ONLINE_COUNT_CACHE_SECONDS)
+        return count
 
     async def broadcast_online_count(self):
         online_count = await self.get_online_count()
@@ -36,6 +42,18 @@ class TimerConsumer(AsyncJsonWebsocketConsumer):
                 "type": "online_count",
                 "count": online_count,
             },
+        )
+
+    @database_sync_to_async
+    def record_heartbeat(self):
+        """
+        Refresh `last_seen` so `reconcile_stale_online_players` knows this
+        connection is still alive. Without this, a player whose worker
+        process dies without running disconnect() would stay marked
+        online forever.
+        """
+        type(self.player).objects.filter(pk=self.player.pk).update(
+            last_seen=timezone.now()
         )
 
     async def connect(self):
@@ -93,11 +111,8 @@ class TimerConsumer(AsyncJsonWebsocketConsumer):
                 )
 
             await database_sync_to_async(self.player.register_connection)()
-            is_online_now = await database_sync_to_async(
-                lambda: self.player.is_online
-            )()
             logger.debug(
-                f"[CONNECT] Player {self.player.id} is_online={is_online_now}"
+                f"[CONNECT] Player {self.player.id} is_online={self.player.is_online}"
             )  # ✅ Verify status
 
             await self.channel_layer.group_add(self.player_group, self.channel_name)
@@ -225,6 +240,7 @@ class TimerConsumer(AsyncJsonWebsocketConsumer):
                 # logger.debug(f"[RECEIVE JSON] Sending to handle_client_request")
                 await self.handle_client_request(event)
             elif message_type == "ping":
+                await self.record_heartbeat()
                 await self.send_json(
                     {"type": "pong", "action": "pong", "message": "pong"}
                 )

--- a/gameplay/consumers.py
+++ b/gameplay/consumers.py
@@ -24,6 +24,20 @@ logger_errors = logging.getLogger("errors")
 
 
 class TimerConsumer(AsyncJsonWebsocketConsumer):
+    @database_sync_to_async
+    def get_online_count(self):
+        return Player.online_count()
+
+    async def broadcast_online_count(self):
+        online_count = await self.get_online_count()
+        await self.channel_layer.group_send(
+            "online_users",
+            {
+                "type": "online_count",
+                "count": online_count,
+            },
+        )
+
     async def connect(self):
         from django.contrib.auth.models import AnonymousUser
 
@@ -78,7 +92,7 @@ class TimerConsumer(AsyncJsonWebsocketConsumer):
                     f"[CONNECT] Player {self.player.id} has no active character link; continuing with player-only websocket session."
                 )
 
-            await database_sync_to_async(self.player.set_online)()
+            await database_sync_to_async(self.player.register_connection)()
             is_online_now = await database_sync_to_async(
                 lambda: self.player.is_online
             )()
@@ -96,6 +110,8 @@ class TimerConsumer(AsyncJsonWebsocketConsumer):
             logger.info(
                 f"[CONNECT] WebSocket connection accepted for player {self.player.id}"
             )
+
+            await self.broadcast_online_count()
 
             await self._send_pending_messages()
 
@@ -134,8 +150,9 @@ class TimerConsumer(AsyncJsonWebsocketConsumer):
         if not hasattr(self, "player"):
             return
 
-        await database_sync_to_async(self.player.set_offline)()
+        await database_sync_to_async(self.player.unregister_connection)()
         await self.channel_layer.group_discard("online_users", self.channel_name)
+        await self.broadcast_online_count()
 
         if hasattr(self, "player_group"):
             logger.info(f"[DISCONNECT] Removed from group: {self.player_group}")
@@ -216,6 +233,14 @@ class TimerConsumer(AsyncJsonWebsocketConsumer):
                 logger.warning(f"[RECEIVE JSON] Unknown type received: {message_type}")
         else:
             logger.warning(f"[RECEIVE JSON] Received data without type: {event}")
+
+    async def online_count(self, event):
+        await self.send_json(
+            {
+                "type": "online_count",
+                "count": event["count"],
+            }
+        )
 
     async def action(self, event):
         logger.info(f"[HANDLE ACTION] Handling action: {event}")

--- a/gameplay/tests/test_consumers.py
+++ b/gameplay/tests/test_consumers.py
@@ -1,6 +1,7 @@
 from asgiref.sync import async_to_sync
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
 from django.test import TransactionTestCase
 
 from character.models import PlayerCharacterLink
@@ -39,6 +40,9 @@ class MockTimer:
 
 class TimerConsumerNoCharacterTests(TransactionTestCase):
     def setUp(self):
+        # The online-count cache is shared real Redis state across tests;
+        # clear it so a value cached by another test doesn't leak in here.
+        cache.clear()
         self.user = get_user_model().objects.create_user(
             email="ws-no-character@example.com",
             password="test-pass-123",
@@ -148,6 +152,7 @@ class TimerConsumerAuthTests(TransactionTestCase):
 
 class TimerConsumerDisconnectTests(TransactionTestCase):
     def setUp(self):
+        cache.clear()
         self.user = get_user_model().objects.create_user(
             email="ws-disconnect@example.com",
             password="test-pass-123",
@@ -243,3 +248,32 @@ class TimerConsumerOnlineCountEventTests(TransactionTestCase):
         self.assertEqual(len(consumer.send_json.calls), 1)
         sent_payload = consumer.send_json.calls[0][0][0]
         self.assertEqual(sent_payload, {"type": "online_count", "count": 7})
+
+
+class TimerConsumerHeartbeatTests(TransactionTestCase):
+    """A client 'ping' must refresh Player.last_seen so
+    reconcile_stale_online_players doesn't sweep up live connections."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            email="ws-heartbeat@example.com",
+            password="test-pass-123",
+        )
+        self.player = self.user.player
+
+    def test_ping_refreshes_last_seen(self):
+        consumer = TimerConsumer()
+        consumer.player = self.player
+        consumer.send_json = AsyncCallRecorder()
+
+        self.assertIsNone(self.player.last_seen)
+
+        async_to_sync(consumer.receive_json)({"type": "ping"})
+
+        self.player.refresh_from_db(fields=["last_seen"])
+        self.assertIsNotNone(self.player.last_seen)
+
+        sent_payloads = [args[0] for args, _ in consumer.send_json.calls]
+        self.assertIn(
+            {"type": "pong", "action": "pong", "message": "pong"}, sent_payloads
+        )

--- a/gameplay/tests/test_consumers.py
+++ b/gameplay/tests/test_consumers.py
@@ -10,12 +10,16 @@ from gameplay.consumers import TimerConsumer
 class DummyChannelLayer:
     def __init__(self):
         self.groups = set()
+        self.group_messages = []
 
     async def group_add(self, group, channel_name):
         self.groups.add(group)
 
     async def group_discard(self, group, channel_name):
         self.groups.discard(group)
+
+    async def group_send(self, group, message):
+        self.group_messages.append((group, message))
 
 
 class AsyncCallRecorder:
@@ -83,6 +87,10 @@ class TimerConsumerNoCharacterTests(TransactionTestCase):
         self.assertIsNone(consumer.character)
         self.assertIsNone(consumer.link)
 
+        self.player.refresh_from_db(fields=["active_connections", "is_online"])
+        self.assertEqual(self.player.active_connections, 1)
+        self.assertTrue(self.player.is_online)
+
         sent_payloads = [args[0] for args, _ in send_json_recorder.calls]
         self.assertIn(
             {
@@ -92,6 +100,12 @@ class TimerConsumerNoCharacterTests(TransactionTestCase):
             },
             sent_payloads,
         )
+
+        group_messages = consumer.channel_layer.group_messages
+        self.assertEqual(len(group_messages), 1)
+        self.assertEqual(group_messages[0][0], "online_users")
+        self.assertEqual(group_messages[0][1]["type"], "online_count")
+        self.assertEqual(group_messages[0][1]["count"], 1)
 
 
 class TimerConsumerAuthTests(TransactionTestCase):
@@ -181,6 +195,34 @@ class TimerConsumerDisconnectTests(TransactionTestCase):
         self.assertNotIn(consumer.player_group, consumer.channel_layer.groups)
         self.assertNotIn("online_users", consumer.channel_layer.groups)
 
+    def test_disconnect_broadcasts_online_count(self):
+        consumer = self._make_connected_consumer()
+
+        self.player.active_connections = 1
+        self.player.is_online = True
+        self.player.save(update_fields=["active_connections", "is_online"])
+
+        async_to_sync(consumer.disconnect)(1000)
+
+        group_messages = consumer.channel_layer.group_messages
+        self.assertEqual(len(group_messages), 1)
+        self.assertEqual(group_messages[0][0], "online_users")
+        self.assertEqual(group_messages[0][1]["type"], "online_count")
+        self.assertEqual(group_messages[0][1]["count"], 0)
+
+    def test_disconnect_keeps_player_online_with_other_connections(self):
+        consumer = self._make_connected_consumer()
+
+        self.player.active_connections = 2
+        self.player.is_online = True
+        self.player.save(update_fields=["active_connections", "is_online"])
+
+        async_to_sync(consumer.disconnect)(1000)
+
+        self.player.refresh_from_db(fields=["active_connections", "is_online"])
+        self.assertEqual(self.player.active_connections, 1)
+        self.assertTrue(self.player.is_online)
+
     def test_disconnect_does_not_pause_timers_when_already_paused(self):
         """Timer in a terminal state must not trigger control_timers."""
         consumer = self._make_connected_consumer()
@@ -189,3 +231,15 @@ class TimerConsumerDisconnectTests(TransactionTestCase):
         # If control_timers were called it would hit the DB and raise; passing
         # without error is the assertion.
         async_to_sync(consumer.disconnect)(1000)
+
+
+class TimerConsumerOnlineCountEventTests(TransactionTestCase):
+    def test_online_count_event_sends_payload(self):
+        consumer = TimerConsumer()
+        consumer.send_json = AsyncCallRecorder()
+
+        async_to_sync(consumer.online_count)({"type": "online_count", "count": 7})
+
+        self.assertEqual(len(consumer.send_json.calls), 1)
+        sent_payload = consumer.send_json.calls[0][0][0]
+        self.assertEqual(sent_payload, {"type": "online_count", "count": 7})

--- a/gameplay/tests/test_disconnect_grace.py
+++ b/gameplay/tests/test_disconnect_grace.py
@@ -41,12 +41,16 @@ def _run_task(player_id, task_id):
 class DummyChannelLayer:
     def __init__(self):
         self.groups = set()
+        self.group_messages = []
 
     async def group_add(self, group, channel_name):
         self.groups.add(group)
 
     async def group_discard(self, group, channel_name):
         self.groups.discard(group)
+
+    async def group_send(self, group, message):
+        self.group_messages.append((group, message))
 
 
 class AsyncCallRecorder:

--- a/progress_rpg/celery.py
+++ b/progress_rpg/celery.py
@@ -41,6 +41,10 @@ app.conf.beat_schedule = {
         "task": "users.tasks.perform_account_wipe",
         "schedule": crontab(minute=0, hour=0),
     },
+    "reconcile_stale_online_players": {
+        "task": "users.tasks.reconcile_stale_online_players",
+        "schedule": 300.0,  # every 5 minutes
+    },
     # "generate_character_days_1am": {
     #     "task": "character.tasks.generate_character_days",
     #     "schedule": crontab(hour=1, minute=0),

--- a/users/models.py
+++ b/users/models.py
@@ -26,6 +26,7 @@ from datetime import timedelta
 from decimal import Decimal
 from django.contrib.auth.models import AbstractUser, UserManager
 from django.db import models, transaction
+from django.db.models import Case, F, Value, When
 from django.db.models import Sum
 from django.utils import timezone
 from typing import TYPE_CHECKING, Optional
@@ -345,20 +346,49 @@ class Player(Person):
         return currency
 
     def set_online(self):
-        """Marks player as online."""
+        """Registers a new active connection and updates online status."""
         logger.debug("[SET ONLINE] Running set_online for player")
-        self.is_online = True
-        self.save(update_fields=["is_online"])
+        self.register_connection()
 
     def set_offline(self):
-        """Marks player as offline."""
-        self.is_online = False
-        self.save(update_fields=["is_online"])
+        """Registers a closed connection and updates online status."""
+        self.unregister_connection()
+
+    @transaction.atomic
+    def register_connection(self):
+        """Increment active connections and mark player online."""
+        type(self).objects.filter(pk=self.pk).update(
+            active_connections=F("active_connections") + 1,
+            is_online=True,
+        )
+        self.refresh_from_db(fields=["active_connections", "is_online"])
+
+    @transaction.atomic
+    def unregister_connection(self):
+        """Decrement active connections safely and update online status."""
+        type(self).objects.filter(pk=self.pk).update(
+            active_connections=Case(
+                When(active_connections__gt=0, then=F("active_connections") - 1),
+                default=Value(0),
+                output_field=models.PositiveIntegerField(),
+            ),
+            # Condition is evaluated on the pre-update value.
+            is_online=Case(
+                When(active_connections__gt=1, then=Value(True)),
+                default=Value(False),
+                output_field=models.BooleanField(),
+            ),
+        )
+        self.refresh_from_db(fields=["active_connections", "is_online"])
 
     @classmethod
     def get_online_players(cls):
         """Returns a QuerySet of all currently online players."""
         return cls.objects.filter(is_online=True)
+
+    @classmethod
+    def online_count(cls) -> int:
+        return cls.objects.filter(is_online=True).count()
 
     @property
     def active_link(self):

--- a/users/models.py
+++ b/users/models.py
@@ -345,15 +345,6 @@ class Player(Person):
         currency, _ = self.currencies.get_or_create(currency=currency_def)
         return currency
 
-    def set_online(self):
-        """Registers a new active connection and updates online status."""
-        logger.debug("[SET ONLINE] Running set_online for player")
-        self.register_connection()
-
-    def set_offline(self):
-        """Registers a closed connection and updates online status."""
-        self.unregister_connection()
-
     @transaction.atomic
     def register_connection(self):
         """Increment active connections and mark player online."""

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -1,11 +1,14 @@
 # users/tasks.py
 
+from asgiref.sync import async_to_sync
 from celery import shared_task
+from channels.layers import get_channel_layer
 
-# from datetime import timedelta
+from datetime import timedelta
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.mail import EmailMultiAlternatives
+from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils import timezone
 import logging
@@ -16,6 +19,10 @@ from character.models import PlayerCharacterLink
 User = get_user_model()
 
 logger = logging.getLogger("general")
+
+# A connection is considered abandoned (worker crash, OOM kill, deploy
+# restart) if we haven't seen a heartbeat ping for this long.
+STALE_CONNECTION_THRESHOLD = timedelta(minutes=10)
 
 
 def _send_email_message(
@@ -65,6 +72,7 @@ def perform_account_wipe():
         player.level = 1
         player.last_seen = None
         player.active_connections = 0
+        player.is_online = False
         user.logins.all().delete()
         player.activities.all().delete()
         player.skills.all().delete()
@@ -79,6 +87,34 @@ def perform_account_wipe():
 
         # Log the deletion
         logger.info(f"User {user.username} (ID: {user.id}) was deleted after 14 days.")
+
+
+@shared_task
+def reconcile_stale_online_players():
+    """
+    Clears `is_online`/`active_connections` for players whose websocket
+    connection was never cleanly closed (worker crash, OOM kill, deploy
+    restart bypasses TimerConsumer.disconnect()), so the online-count
+    badge can't drift upward forever. A player is considered stale once
+    their `last_seen` heartbeat (refreshed on every websocket ping) is
+    older than STALE_CONNECTION_THRESHOLD, or was never set.
+    """
+    cutoff = timezone.now() - STALE_CONNECTION_THRESHOLD
+    stale_players = Player.objects.filter(is_online=True).filter(
+        Q(last_seen__isnull=True) | Q(last_seen__lt=cutoff)
+    )
+    updated = stale_players.update(active_connections=0, is_online=False)
+
+    if updated:
+        logger.info(f"[RECONCILE ONLINE PLAYERS] Reset {updated} stale player(s).")
+        channel_layer = get_channel_layer()
+        async_to_sync(channel_layer.group_send)(
+            "online_users",
+            {
+                "type": "online_count",
+                "count": Player.online_count(),
+            },
+        )
 
 
 @shared_task(bind=True, retry_backoff=True, max_retries=3)

--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -281,6 +281,50 @@ class PlayerMethodsTest(TestCase):
 
         self.assertIsNone(player.current_character)
 
+    def test_register_connection_increments_and_sets_online(self):
+        player = self.user.player
+
+        self.assertEqual(player.active_connections, 0)
+        self.assertFalse(player.is_online)
+
+        player.register_connection()
+
+        self.assertEqual(player.active_connections, 1)
+        self.assertTrue(player.is_online)
+
+    def test_unregister_connection_stays_online_with_other_connections(self):
+        player = self.user.player
+        player.active_connections = 2
+        player.is_online = True
+        player.save(update_fields=["active_connections", "is_online"])
+
+        player.unregister_connection()
+
+        self.assertEqual(player.active_connections, 1)
+        self.assertTrue(player.is_online)
+
+    def test_unregister_connection_transitions_offline_at_zero(self):
+        player = self.user.player
+        player.active_connections = 1
+        player.is_online = True
+        player.save(update_fields=["active_connections", "is_online"])
+
+        player.unregister_connection()
+
+        self.assertEqual(player.active_connections, 0)
+        self.assertFalse(player.is_online)
+
+    def test_unregister_connection_is_idempotent_at_zero(self):
+        player = self.user.player
+        player.active_connections = 0
+        player.is_online = False
+        player.save(update_fields=["active_connections", "is_online"])
+
+        player.unregister_connection()
+
+        self.assertEqual(player.active_connections, 0)
+        self.assertFalse(player.is_online)
+
 
 class UserLoginModelTest(TestCase):
     def setUp(self):

--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -20,7 +20,12 @@ from users.achievements import achievement_goals_for_player
 from users.serializers import PlayerSerializer
 from users.models import Player, UserLogin
 from progression.models import PlayerActivity
-from users.tasks import send_email_to_users_task, send_rendered_email_task
+from users.tasks import (
+    perform_account_wipe,
+    reconcile_stale_online_players,
+    send_email_to_users_task,
+    send_rendered_email_task,
+)
 from users.validators import (
     PLAYER_NAME_MAX_LENGTH,
     PLAYER_NAME_MIN_LENGTH,
@@ -544,6 +549,105 @@ class EmailTaskTest(TestCase):
         alternative = email.alternatives[0]
         alternative_content = getattr(alternative, "content", alternative[0])
         self.assertEqual(alternative_content, "<p>html body</p>")
+
+
+class ReconcileStaleOnlinePlayersTest(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            email="stale@example.com", password="testpassword123"
+        )
+        self.player = self.user.player
+
+    @patch("users.tasks.async_to_sync")
+    @patch("users.tasks.get_channel_layer")
+    def test_resets_and_broadcasts_for_stale_connection(
+        self, mock_get_channel_layer, mock_async_to_sync
+    ):
+        sent = []
+        mock_async_to_sync.side_effect = lambda fn: (
+            lambda *args, **kwargs: sent.append((args, kwargs))
+        )
+
+        self.player.active_connections = 1
+        self.player.is_online = True
+        self.player.last_seen = timezone.now() - timedelta(minutes=20)
+        self.player.save(update_fields=["active_connections", "is_online", "last_seen"])
+
+        reconcile_stale_online_players.apply()
+
+        self.player.refresh_from_db(fields=["active_connections", "is_online"])
+        self.assertEqual(self.player.active_connections, 0)
+        self.assertFalse(self.player.is_online)
+
+        self.assertEqual(len(sent), 1)
+        (group, message), _ = sent[0]
+        self.assertEqual(group, "online_users")
+        self.assertEqual(message["type"], "online_count")
+
+    @patch("users.tasks.async_to_sync")
+    @patch("users.tasks.get_channel_layer")
+    def test_resets_online_player_with_no_heartbeat_yet(
+        self, mock_get_channel_layer, mock_async_to_sync
+    ):
+        mock_async_to_sync.side_effect = lambda fn: (lambda *a, **kw: None)
+
+        self.player.active_connections = 1
+        self.player.is_online = True
+        self.player.last_seen = None
+        self.player.save(update_fields=["active_connections", "is_online", "last_seen"])
+
+        reconcile_stale_online_players.apply()
+
+        self.player.refresh_from_db(fields=["active_connections", "is_online"])
+        self.assertEqual(self.player.active_connections, 0)
+        self.assertFalse(self.player.is_online)
+
+    @patch("users.tasks.async_to_sync")
+    @patch("users.tasks.get_channel_layer")
+    def test_does_not_touch_players_with_recent_heartbeat(
+        self, mock_get_channel_layer, mock_async_to_sync
+    ):
+        sent = []
+        mock_async_to_sync.side_effect = lambda fn: (
+            lambda *args, **kwargs: sent.append((args, kwargs))
+        )
+
+        self.player.active_connections = 1
+        self.player.is_online = True
+        self.player.last_seen = timezone.now()
+        self.player.save(update_fields=["active_connections", "is_online", "last_seen"])
+
+        reconcile_stale_online_players.apply()
+
+        self.player.refresh_from_db(fields=["active_connections", "is_online"])
+        self.assertEqual(self.player.active_connections, 1)
+        self.assertTrue(self.player.is_online)
+        self.assertEqual(len(sent), 0)
+
+
+class PerformAccountWipeTest(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            email="pending-delete@example.com", password="testpassword123"
+        )
+        self.user.pending_delete = True
+        self.user.delete_at = timezone.now() - timedelta(days=1)
+        self.user.save(update_fields=["pending_delete", "delete_at"])
+
+        self.player = self.user.player
+        self.player.active_connections = 1
+        self.player.is_online = True
+        self.player.save(update_fields=["active_connections", "is_online"])
+
+    def test_wiped_player_is_marked_offline(self):
+        perform_account_wipe.apply()
+
+        self.player.refresh_from_db(fields=["active_connections", "is_online"])
+        self.assertEqual(self.player.active_connections, 0)
+        self.assertFalse(self.player.is_online)
+        self.assertNotIn(self.player, Player.get_online_players())
 
 
 class CustomAccountAdapterTest(TestCase):


### PR DESCRIPTION
Adds a minimal online player count presence indicator driven entirely by websocket updates.

The backend tracks active connections on `Player`, broadcasts the aggregate number of online players to the existing `online_users` channel group on connect/disconnect, and exposes a websocket event handler for `online_count`. The frontend listens for that event, stores the count in its own context, and renders a lightweight badge showing how many players are online.

## Follow-up fixes (post-review)

- **Stale presence never self-healed.** A worker crash/OOM/deploy restart could leave `active_connections`/`is_online` stuck forever, since `disconnect()` never ran. Added a websocket heartbeat (`ping` refreshes `Player.last_seen`) and a periodic Celery task (`reconcile_stale_online_players`) that clears presence for connections that stop heartbeating.
- **Account wipe left wiped accounts "online" forever.** `perform_account_wipe` now also sets `is_online = False`.
- **Removed dead code.** `Player.set_online`/`set_offline` had no remaining callers after the connection-count refactor.
- **Reduced DB load.** The online-count query is now cached for a short window to absorb connect/disconnect bursts (e.g. after a deploy), and a redundant DB read on connect was removed.
- **Isolated the count from `GameContext`.** `onlinePlayerCount` now lives in its own `OnlineCountContext` instead of `GameContextValue`, so a broadcast (which can fire from any player's connect/disconnect) only re-renders the badge instead of every `useGame()` consumer app-wide.
- **Seeded from bootstrap.** The badge now shows the correct count immediately via a new `online_count` field on `/fetch_info/`, instead of reading 0 until the user's own socket connects.
- **Extracted `useGame()`** into its own `hooks/useGame.ts` module (mirroring the existing `useWebSocket`/`webSocketContext` split), since mixing a hook and a provider component export in `GameContext.tsx` was breaking Vite Fast Refresh for the whole context.
- Reused the shared `respond-to()` Sass mixin for the badge's responsive breakpoints instead of hardcoded media queries.
