### PR TITLE
Unified timer homepage (feature-flagged)

### DIFF
--- a/.claude/plans/unified-timer-homepage-plan.md
+++ b/.claude/plans/unified-timer-homepage-plan.md
@@ -1,0 +1,385 @@
+# Unified Timer + List Homepage Component — Implementation Plan
+
+Base branch: new branch off `development` (this plan was drafted on
+`feat/unified-timer-homepage-plan`, cut from `development` at `b4f0f6c`).
+Reference-only: `claude/unified-activity-list-522` (not a base — see notes below
+on which pieces are ported vs. rebuilt).
+
+Feature flag: `unified_homepage` (new `FeatureFlagKey`, default `[]` = off for
+everyone until explicitly enabled).
+
+---
+
+## Assumptions
+
+These are read as given from the task brief; flagging them up front since the
+plan depends on them:
+
+1. "Homepage" = `frontend/src/pages/Game2/ActivityTimelinePage.tsx` (route
+   `/timer`), not `frontend/src/pages/Home/Home.tsx` (logged-out marketing
+   page). The latter has no timer/list and is out of scope.
+2. Blank Start is expected to work with **no backend schema change** — the
+   `ActivityTimer`/`PlayerActivity` models already allow a blank activity name
+   (see Design decision 2). Only a new DRF action is needed.
+3. "Attaches the selected label to the running timer" applies whenever a
+   timer is active, regardless of whether it already has a label — i.e.
+   picking a different list item while a *labelled* timer is running
+   relabels it in place, not just the unlabelled→labelled case. (Flagged
+   again under Open Questions in case that's not the intent.)
+4. Mode suggestion buttons ("Task planning", "Free text") are presentational
+   triggers only for this plan — their exact behaviour needs product input
+   (see Open Questions) and is scoped to a late, isolated phase so the rest
+   of the work isn't blocked on it.
+5. No existing animation library is present in `frontend/package.json`, so
+   "a single animation system" requires adding one (Design decision 5).
+
+---
+
+## 1. High-level strategy
+
+Keep all business logic exactly where it already lives — `useActivityTimer`,
+`useActivityInput`, `useEntitySearchInput`/`useEntitySearchCache` — and extend
+it additively (new optional params/handlers, nothing existing changes
+behaviour). Build a new presentational component tree,
+`UnifiedTimerHome`, that consumes this shared logic and renders the three UI
+states. Gate the whole new tree behind `useFeatureFlag("unified_homepage")`
+in `ActivityTimelinePage.tsx`, exactly like the existing hook-level flag
+branches elsewhere in the app (e.g. `ActivityTimeline.tsx:49`). The legacy
+`CurrentActivity` / `ActivityInput` / `ActivityTimeline` components are not
+touched, so flag-off is a strict no-op.
+
+Two small, self-contained backend/shared-logic gaps need filling before the
+UI work can start:
+
+- **Blank timer start**: mechanically already supported server-side
+  (`set_activity` tolerates an empty name); the frontend hook just needs its
+  early-return guard relaxed for an explicit "start blank" call.
+- **Relabel a running timer without losing progress**: the model already has
+  `ActivityTimer.rename_activity()` and `ActivityTimer.change_task()`, but
+  neither is exposed over the API — today the only way to change a timer's
+  activity is `set_activity`, which discards elapsed time and resets status
+  to `"waiting"` (`gameplay/models.py:432-458`). This plan adds one new DRF
+  action that calls the existing model methods in place.
+
+The reference branch (`claude/unified-activity-list-522`) contributes one
+genuinely reusable, self-contained piece: `useDefaultActivityEntries.ts`
+(task/activity grouping for the default list). Everything else on that
+branch is treated as design reference only, per the task brief, because it
+deletes `ActivityTimeline` outright and tangles the grouping logic with UI
+changes that predate this flag/phase structure.
+
+---
+
+## 2. Files likely to change
+
+**Backend**
+| File | Change | Exists? |
+|---|---|---|
+| `gameplay/views.py` | New `label_activity` action on `ActivityTimerViewSet` | Yes, extend |
+| `gameplay/tests/` (wherever `ActivityTimerViewSet` is tested) | New tests for the action | Yes, extend |
+
+No model or migration changes — `rename_activity`/`change_task` already exist
+(`gameplay/models.py:496-500`).
+
+**Frontend — shared logic (additive only)**
+| File | Change | Exists? |
+|---|---|---|
+| `frontend/src/featureFlags.ts` | Add `unified_homepage: []` | Yes, extend |
+| `frontend/src/types/enums.ts` | Add `"unified_homepage"` to `FeatureFlagKey` | Yes, extend |
+| `frontend/src/types/timers.ts` | Add `labelActivity` to `ActivityTimerReturn`; extend `StartActivityInput`/`startActivity` signature for blank-start | Yes, extend |
+| `frontend/src/hooks/useActivityTimer.ts` | Relax blank-text guard for explicit blank start; add `labelActivity(name, taskId)` | Yes, extend |
+| `frontend/src/hooks/useDefaultActivityEntries.ts` | New hook, ported from reference branch | New (ported) |
+| `frontend/src/hooks/useDefaultActivityEntries.test.ts` | Ported test | New (ported) |
+| `frontend/src/components/ActivityInput/useActivityInput.ts` | Add `handleBlankStart`, `handleUnifiedSelect`/`handleUnifiedSubmit` handlers | Yes, extend |
+| `frontend/src/components/EntitySearchInput/useEntitySearchInput.ts` | Add optional `defaultResults`/`alwaysOpen` support (falls back to current behaviour when unused) | Yes, extend |
+| `frontend/src/components/EntitySearchInput/EntitySearchInput.tsx` | Render default/persistent list when `alwaysOpen` | Yes, extend |
+
+**Frontend — new presentational tree**
+| File | Change | Exists? |
+|---|---|---|
+| `frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx` | New: three-state layout, uses shared hooks | New |
+| `frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss` | New | New |
+| `frontend/src/components/UnifiedTimerHome/ModeSuggestions.tsx` | New, isolated (Phase 5) | New |
+| `frontend/src/pages/Game2/ActivityTimelinePage.tsx` | Branch on `useFeatureFlag("unified_homepage")` | Yes, extend |
+| `frontend/package.json` | Add animation dependency (Design decision 5) | Yes, extend |
+
+**Tests**
+- New Vitest unit tests for the extended hooks/handlers.
+- New/extended Playwright spec covering flag-on and flag-off paths.
+
+---
+
+## 3. Implementation plan (phased, each phase leaves the app working with the flag ON and OFF)
+
+**Phase 0 — flag scaffold**
+Add `unified_homepage` to `featureFlags.ts` and `FeatureFlagKey`. No
+consumers yet. Zero behaviour change.
+
+**Phase 1 — backend: expose relabel-in-place**
+Add `label_activity` action to `ActivityTimerViewSet`:
+- Accepts `activityName` (string) and optional `task_id`.
+- Requires timer status in `{"active", "waiting"}`; no-op/400 otherwise
+  (mirrors the "attach label to running timer" scope — nothing to attach to
+  if nothing is running).
+- Calls `timer.rename_activity(name)`, and `timer.change_task(task)` if
+  `task_id` provided (reusing `get_object_or_404(Task, pk=task_id,
+  player=request.user.player)` exactly as `set_activity` does today, line
+  ~157).
+- Returns the same shape as `set_activity` (`{"success": True,
+  "activity_timer": ...}`) for frontend consistency.
+- Unused by any frontend code yet — safe to ship standalone. Add tests.
+
+**Phase 2 — frontend: extend the timer hook**
+- `useActivityTimer.startActivity`: change the guard from
+  `if (!text?.trim()) return null;` to also allow an explicit
+  `allowBlank: true` flag on the input object, defaulting to `false` so
+  every existing caller is unaffected.
+- Add `labelActivity(name, taskId)`: posts to the new endpoint, then updates
+  local `currentActivity` optimistically (`{ text: name.trim(), taskId }`)
+  without touching `elapsed`/`status`/`startTimeRef` — this is the key
+  difference from `startActivity`, which resets all of those.
+- Extend `ActivityTimerReturn`/`StartActivityInput` types accordingly.
+- Unit tests: blank start leaves `status: "active"`, `currentActivity.text:
+  ""`; `labelActivity` updates the name without resetting `elapsed`.
+
+**Phase 3 — port the grouping hook**
+- Add `useDefaultActivityEntries.ts` + its test, adapted from the reference
+  branch to current `development` types (`PlayerActivity`, `CharacterActivity`,
+  `Task`, `SearchEntity`) — the research pass confirmed the dependencies
+  (`useGame`, `useTasks`, `useFeatureFlag`) already match current
+  `development`, so this should be a near-verbatim port.
+- Not wired into any UI yet — pure addition, covered by its own unit tests.
+
+**Phase 4 — extend `useActivityInput` with unified handlers**
+- `handleBlankStart()`: calls `startActivity({ text: "", allowBlank: true,
+  limitSeconds: ... })` (same limit logic already in `handleToggle`/
+  `handleCreateActivity`).
+- `handleUnifiedSelect(entity)` / `handleUnifiedSubmit(text)`: if
+  `!isActive`, delegate to existing `handleSelectActivity`/
+  `handleCreateActivity`; if `isActive`, call `labelActivity(name, taskId)`
+  instead (covers both unlabelled→labelled and relabel-while-labelled per
+  Assumption 3).
+- Derive `isUnlabelled = isActive && !(currentActivity?.name ??
+  currentActivity?.text ?? "").trim()` for the new components to consume.
+- These are net-new exports from the hook; `ActivityInput.tsx` (legacy)
+  doesn't call them, so its behaviour is unchanged. Unit tests for the new
+  branch logic.
+
+**Phase 5 — extend `EntitySearchInput` for a persistent/default list**
+- Add optional props: `alwaysOpen?: boolean`, `defaultResults?:
+  SearchEntity[]`, `emptyMessage?: string`.
+- When `alwaysOpen` is true and the query is blank, render `defaultResults`
+  (fed by `useDefaultActivityEntries` from the call site) instead of hiding
+  the dropdown; when there's a query, existing Fuse-based `results` take
+  over unchanged.
+- Existing callers (`ActivityInput.tsx`) don't pass these props, so nothing
+  changes for them. Unit/RTL tests for the new prop combination.
+
+**Phase 6 — `UnifiedTimerHome` component + wiring**
+- Build the three-state layout (Input / Running-unlabelled /
+  Running-labelled) using: `useActivityInput()` (extended),
+  `useDefaultActivityEntries()`, extended `EntitySearchInput`, and the
+  existing `Button` component for Start/Stop.
+- Add the animation dependency (Design decision 5) and use it only inside
+  this new tree.
+- Branch `ActivityTimelinePage.tsx` on `useFeatureFlag("unified_homepage")`:
+  render `UnifiedTimerHome` instead of `CurrentActivity` + `ActivityTimeline`
+  when on. This is the only edit to a shared file in the whole plan, and
+  it's a pure conditional — flag off renders byte-identical output to today.
+- Component/RTL tests for state transitions; manual QA against real backend.
+
+**Phase 7 — mode suggestion buttons (isolated, needs Open Questions resolved)**
+- Add `ModeSuggestions.tsx`: dismissible buttons shown only in
+  Running-unlabelled state, per Assumption 4. Kept as its own commit since
+  its actual behaviour is unresolved (see Open Questions) and everything
+  else in the plan works without it.
+
+**Phase 8 — polish**
+- Accessibility pass (`aria-live` on the timer, focus management across
+  state transitions, list `role`/labelling consistency with existing
+  `EntitySearchInput`/`List` patterns).
+- Playwright coverage for flag-on happy path and flag-off regression guard.
+
+---
+
+## 4. Design decisions
+
+**1. Flag branch point: hook-level in `ActivityTimelinePage.tsx`, not
+`<FeatureToggle>`.**
+`FeatureToggle` (`components/FeatureToggle.tsx`) renders a fallback
+"coming soon" card when off — appropriate for gating an entire route, not
+for swapping between two equally-real implementations. Precedent for
+hook-level branching already exists (`ActivityTimeline.tsx:49`,
+`NavDrawer.tsx:15`). Chosen because it matches the existing convention for
+this exact kind of "same route, different UI" flag.
+
+**2. Blank start: extend `startActivity` with an explicit `allowBlank` flag,
+not a separate function.**
+Alternative considered: a standalone `startBlankActivity()`. Rejected
+because it would duplicate the optimistic-state-set / API-call / rollback
+logic already in `startActivity` (`useActivityTimer.ts:100-183`) for no
+benefit — the backend already accepts a blank name via the same
+`set_activity` → `start` call sequence (`gameplay/views.py:150-152` coerces
+missing/falsy names to `""`; `PlayerActivity.name` is `blank=True`). A single
+function with an opt-in flag keeps one source of truth.
+
+**3. Relabel-in-place: new `label_activity` DRF action calling existing
+model methods.**
+Alternatives considered:
+- Reuse `set_activity` — rejected: `new_activity()` always creates a *new*
+  `PlayerActivity` and resets `start_time`/`elapsed_time`/`status` to
+  `"waiting"` (`gameplay/models.py:449-451`), which would wipe the running
+  timer's progress every time a label is attached.
+- Do it client-side only, sync the name to the server on stop (via the
+  existing `complete(newName=...)` override) — rejected: the server-side
+  `PlayerActivity` would carry a blank name for the full duration of the
+  timer, and other surfaces (task views, admin, any mid-flight polling)
+  would see a nameless activity until stop. The model already has exactly
+  the right primitive (`rename_activity`) sitting unused; exposing it is a
+  ~15-line view change vs. carrying a client/server divergence.
+
+**4. List unification: extend `EntitySearchInput` with default-results
+support, don't restyle `ActivityTimeline` in place.**
+Directly required by the task brief ("Reuse the existing fuzzy entity search
+as the single source for both default and filtered list results"). Restyling
+`ActivityTimeline` would leave two independent list implementations
+(recent-activities list + search dropdown) that need to be kept visually and
+behaviourally consistent by hand.
+
+**5. Animation: add a library (Framer Motion) scoped to the new component
+tree, not hand-rolled CSS.**
+The codebase currently has zero collapse/expand or list enter/exit animation
+patterns — every existing transition is a simple property tween or infinite
+pulse loop (`CurrentActivity.module.scss:47`, `ActivityInput.module.scss:88`).
+The brief explicitly asks for "a single animation system capable of handling
+both layout resizing and enter/exit animations consistently" across three
+states — that's exactly `AnimatePresence` + the `layout` prop. Hand-rolling
+an equivalent (e.g. `grid-template-rows` tricks for resize + manual
+mount/unmount timers for enter/exit) would end up building a bespoke, harder
+to maintain version of the same thing. Framer Motion is a natural fit for
+React 19 and has no dependency conflicts with the existing stack. Scoping it
+to `UnifiedTimerHome` only avoids any risk to the legacy tree.
+
+---
+
+## 5. Edge cases
+
+- **Blank Start double-click**: existing `isActive`/button-disabled guards
+  in `useActivityInput`/`ActivityInput` already prevent double-start; the
+  same pattern (disable Start while `status !== "empty"`/`!== "waiting"`)
+  applies to the new blank-start button.
+- **Select/submit while a *labelled* timer is running**: per Assumption 3,
+  relabels in place rather than being a no-op — confirm this is the
+  intended reading before implementing Phase 4.
+- **`label_activity` called after the timer already completed** (e.g. a
+  queued UI event fires after Stop): the new action should check
+  `timer.status in {"active", "waiting"}` server-side and return a 409/no-op
+  otherwise, mirroring the guard already needed for "attach to nothing
+  running."
+- **Selecting a task-grouped row while unlabelled-running**: needs to both
+  rename the activity *and* link it to the task (`change_task`), so
+  `label_activity` must accept `task_id` the same way `set_activity` does
+  today — not just a name.
+- **Data downstream of blank-named `PlayerActivity` rows**: these are
+  already possible in the DB today (`name` is `blank=True`) but previously
+  unreachable through the UI. Before Phase 6 ships, verify
+  `get_xp_reward_summary()`/serializers/admin list views don't assume a
+  non-empty name (quick grep + a manual check, not a redesign).
+- **Auto-stop (time-limit) firing while unlabelled**: `tickMain`'s auto-stop
+  path (`useActivityTimer.ts:76-84`) submits
+  `currentActivityRef.current?.name || currentActivityRef.current?.text` as
+  the completion name — if that's still blank, `complete()` already handles
+  a blank/no `newName` gracefully (keeps existing activity name, i.e. `""`).
+  No special-casing needed, but worth a test.
+- **Concurrent renames**: two rapid `label_activity` calls (e.g. fast
+  double-select) — no explicit locking needed; each call is a simple
+  in-place field update (`self.activity.rename(name)`), last-write-wins is
+  acceptable for a single-user timer resource (same reasoning as existing
+  `set_activity`/`complete` which have no locking either).
+
+---
+
+## 6. Tests
+
+**Backend**
+- `label_activity`: renames in place without resetting `elapsed_time`/
+  `start_time`/`status`; optionally attaches `task_id`; 404/400 for a
+  non-owned task; no-op/409 when timer isn't active/waiting; requires auth.
+
+**Frontend unit (Vitest)**
+- `useActivityTimer`: blank start (`allowBlank: true`) leaves timer active
+  with empty name; rejects blank start without the flag (regression guard
+  for existing callers); `labelActivity` updates name/taskId without
+  touching `elapsed`.
+- `useActivityInput`: `handleBlankStart`, `handleUnifiedSelect`/
+  `handleUnifiedSubmit` branch correctly on `isActive`/`isUnlabelled`.
+- `useDefaultActivityEntries`: port existing reference-branch test as-is,
+  adjust only for any type drift found during Phase 3.
+- `EntitySearchInput`/`useEntitySearchInput`: `alwaysOpen` + `defaultResults`
+  renders the default list on blank query, existing Fuse behaviour still
+  used once query is non-empty, and legacy callers (no new props) are
+  pixel/behaviour-identical to today.
+
+**Frontend component (RTL)**
+- `UnifiedTimerHome`: renders Input state by default; Blank Start →
+  Running-unlabelled (timer visible, list still visible, mode suggestions
+  shown); submit/select → Running-labelled (list/input shrink or hide).
+
+**E2E (Playwright)**
+- Flag ON: full happy path — blank start, type or select a label, stop,
+  activity appears correctly grouped in the list afterward.
+- Flag OFF: existing `/timer` page renders unchanged (regression guard —
+  extend whatever spec currently covers `ActivityTimelinePage`/
+  `ActivityTimeline`, noted as a known flaky area in project memory:
+  "Projects page heading not found" / WebKit nav a11y issues, so isolate
+  this new spec rather than bolting onto the flaky one).
+
+---
+
+## 7. Risks
+
+- **State bleed between the two presentational trees**: since
+  `useActivityInput`/`useActivityTimer` are shared, a bug introduced while
+  extending them (e.g. changing the meaning of an existing field) would
+  silently break the legacy flag-off UI too. Mitigation: every extension in
+  Phases 2–5 must be additive (new optional params/exports only); this
+  should be explicitly checked in review, not just tested.
+- **Reusing `new_activity()`/`set_activity` by mistake instead of the new
+  `label_activity` action**: easy mistake for whoever implements Phase 6,
+  since `set_activity` is the "obvious" existing endpoint — but it silently
+  destroys running progress. Flag explicitly in the Phase 4/6 PR
+  description.
+- **New animation dependency**: first use of Framer Motion in this repo —
+  bundle size and unfamiliarity risk. Mitigated by scoping usage to one
+  component tree and by the flag itself (fully reversible by toggling off).
+- **Default-list cap and dataset mismatch**: `useDefaultActivityEntries`
+  (ported, cap of 4, sourced from `useGame().playerActivities/
+  characterActivities`) and the Fuse-based filtered results (cap of 8,
+  sourced from `useEntitySearchCache`'s full-history query) are different
+  datasets with different caps. This is fine per the task brief's "single
+  source for both default and filtered list results" (they share the same
+  *component* and *search mechanism*, not literally the same array), but an
+  implementer should not assume they can be trivially merged into one
+  `useMemo`.
+
+---
+
+## 8. Open questions
+
+1. Does relabelling apply to an already-labelled running timer (spec says
+   "otherwise attaches the selected label to the running timer" with no
+   unlabelled/labelled distinction), or should selecting a new item while a
+   labelled timer is running be a no-op? (Assumption 3 currently reads it as
+   "always relabels.")
+2. What do the mode suggestion buttons ("Task planning", "Free text")
+   actually do when clicked — prefill the input, open the existing
+   `SupportFlowModal`, or something else? Phase 7 is isolated specifically
+   so this can be resolved without blocking the rest of the plan.
+3. Is there a target row count for the default/persistent list, or is the
+   reference branch's `MAX_DEFAULT_ENTRIES = 4` acceptable to carry over
+   as-is?
+4. Any specific requirement for what happens to `handleUnifiedSelect` when
+   the running timer is a *support-flow* activity (`useSupportFlow`
+   integration in `useActivityInput.ts:185-215` has its own start path) —
+   out of scope for this plan unless flagged otherwise, since the brief
+   doesn't mention support mode.

--- a/.claude/plans/unified-timer-homepage-plan.md
+++ b/.claude/plans/unified-timer-homepage-plan.md
@@ -168,13 +168,21 @@ Add `label_activity` action to `ActivityTimerViewSet`:
 - Derive `isUnlabelled = isActive && !(currentActivity?.name ??
   currentActivity?.text ?? "").trim()` for the new components to consume.
 - Add click-to-edit support (Design decision 6): local `isEditingLabel`
-  state plus `startEditingLabel()` and `handleLabelBlur()`. `startEditingLabel`
-  pre-fills `name` with `currentActivity.name` and sets `isEditingLabel =
-  true`; `handleLabelBlur` calls `handleUnifiedSubmit(name)` (which always
-  reaches `labelActivity` since `isActive` is true here, even for an empty
-  trimmed value — clearing the label is a valid outcome, see Edge cases),
-  then sets `isEditingLabel = false` unconditionally. The rendered UI state
-  is `isUnlabelled || isEditingLabel`, so once `labelActivity` resolves,
+  state plus `startEditingLabel()`, `handleLabelBlur()`, and
+  `handleLabelCancel()`. `startEditingLabel` pre-fills `name` with
+  `currentActivity.name` and sets `isEditingLabel = true`; `handleLabelBlur`
+  calls `handleUnifiedSubmit(name)` (which always reaches `labelActivity`
+  since `isActive` is true here, even for an empty trimmed value — clearing
+  the label is a valid outcome, see Edge cases), then sets `isEditingLabel =
+  false` unconditionally. `handleLabelCancel` (wired to the input's Escape
+  key, see Design decision 6) resets `name` back to `currentActivity.name`
+  and sets `isEditingLabel = false` *without* calling `labelActivity` — no
+  network call, no server-side change, the label edit is simply discarded.
+  The input's `onKeyDown` must check for Escape before `onBlur` fires (blur
+  the input first via `event.currentTarget.blur()` inside the Escape
+  handler so focus-out doesn't also trigger `handleLabelBlur`'s commit
+  path). The rendered UI state is `isUnlabelled || isEditingLabel`, so once
+  either handler resolves,
   `currentActivity.name` drives the real state and `isEditingLabel` no
   longer matters.
 - These are net-new exports from the hook; `ActivityInput.tsx` (legacy)
@@ -301,6 +309,16 @@ blur always resolves to a real state (`isUnlabelled` becomes true or false
 based on the post-write name), so `isEditingLabel` never needs manual
 resetting logic beyond "set to false after the blur handler runs."
 
+Escape cancels rather than commits: `handleLabelCancel` restores `name` to
+`currentActivity.name` and exits edit mode without calling `labelActivity`,
+so an accidental click on the label followed by Escape is a true no-op
+(no request, no rename). This is the standard inline-edit convention
+(Escape discards, blur/Enter commits) and needed an explicit `onKeyDown`
+handler on the input rather than relying on `onBlur` alone, since Escape
+doesn't reliably blur an input on its own — the handler blurs it manually
+after resetting state so the subsequent native blur event doesn't also fire
+`handleLabelBlur`'s commit logic.
+
 **7. List container: fixed min-height sized for `maxVisibleRows = 4`.**
 Alternative considered: let the container size to content (0–N rows).
 Rejected because the list's row count changes on every keystroke while
@@ -334,6 +352,12 @@ reserved height with empty space rather than collapsing.
   still calls `labelActivity` with the same name — an unnecessary network
   call but harmless (idempotent rename). Not worth special-casing for a
   first pass; flag as a possible follow-up optimization if it proves noisy.
+- **Click-to-edit label, Escape pressed**: per Design decision 6, discards
+  the edit entirely — no `labelActivity` call, `name` resets to
+  `currentActivity.name`, layout returns to Running-labelled with the
+  original name untouched. The Escape handler must blur the input itself
+  (`event.currentTarget.blur()`) after resetting state so the native blur
+  that follows doesn't re-trigger `handleLabelBlur`'s commit path.
 - **`label_activity` called after the timer already completed** (e.g. a
   queued UI event fires after Stop): the new action should check
   `timer.status in {"active", "waiting"}` server-side and return a 409/no-op
@@ -430,16 +454,9 @@ reserved height with empty space rather than collapsing.
 
 ## 8. Open questions
 
-All four open questions from the previous draft are resolved (relabelling
-always applies while active — Assumption 3; mode suggestions parked —
-Assumption 4; default-list cap is 4 — Design decision 7; support-flow
-activities render as Running-labelled automatically — Assumption 6). One new
-item surfaced while designing click-to-edit:
-
-1. Should pressing **Escape** while editing a label cancel back to the
-   original name instead of committing whatever's currently typed (browsers
-   don't fire `blur` on Escape by default unless the input also loses
-   focus)? Not specified in the brief; current plan only wires `onBlur`, so
-   Escape today would just leave the input focused/unsaved until the user
-   clicks away. Worth a product call before Phase 6, but doesn't block
-   earlier phases.
+All open questions from previous drafts are resolved: relabelling always
+applies while active (Assumption 3); mode suggestions parked (Assumption 4);
+default-list cap is 4 (Design decision 7); support-flow activities render as
+Running-labelled automatically (Assumption 6); Escape cancels a label edit
+without committing (Design decision 6). None outstanding — implementation
+can proceed through Phase 6 without further product input.

--- a/.claude/plans/unified-timer-homepage-plan.md
+++ b/.claude/plans/unified-timer-homepage-plan.md
@@ -24,14 +24,21 @@ plan depends on them:
 3. "Attaches the selected label to the running timer" applies whenever a
    timer is active, regardless of whether it already has a label — i.e.
    picking a different list item while a *labelled* timer is running
-   relabels it in place, not just the unlabelled→labelled case. (Flagged
-   again under Open Questions in case that's not the intent.)
-4. Mode suggestion buttons ("Task planning", "Free text") are presentational
-   triggers only for this plan — their exact behaviour needs product input
-   (see Open Questions) and is scoped to a late, isolated phase so the rest
-   of the work isn't blocked on it.
+   relabels it in place, not just the unlabelled→labelled case. **Confirmed.**
+   This also covers the new click-to-edit interaction (Design decision 6).
+4. Mode suggestion buttons ("Task planning", "Free text") are **parked —
+   out of scope for this plan.** No phase implements them; `UnifiedTimerHome`
+   is built so they can be slotted into the Running-unlabelled state later
+   without restructuring anything.
 5. No existing animation library is present in `frontend/package.json`, so
    "a single animation system" requires adding one (Design decision 5).
+6. Support-flow-started activities need no special-casing: `useSupportFlow`'s
+   `onStartActivity` always calls `startActivity` with a non-blank
+   `activityText` (`useActivityInput.ts:193-214`), so `currentActivity.name`
+   is never blank for a support activity. The existing `isUnlabelled`
+   derivation (Phase 4) is `false` in that case, so it renders in
+   Running-labelled automatically — **confirmed as the desired behaviour**,
+   no extra work needed.
 
 ---
 
@@ -98,8 +105,7 @@ No model or migration changes — `rename_activity`/`change_task` already exist
 | File | Change | Exists? |
 |---|---|---|
 | `frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx` | New: three-state layout, uses shared hooks | New |
-| `frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss` | New | New |
-| `frontend/src/components/UnifiedTimerHome/ModeSuggestions.tsx` | New, isolated (Phase 5) | New |
+| `frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss` | New (incl. fixed-height list container, Design decision 7) | New |
 | `frontend/src/pages/Game2/ActivityTimelinePage.tsx` | Branch on `useFeatureFlag("unified_homepage")` | Yes, extend |
 | `frontend/package.json` | Add animation dependency (Design decision 5) | Yes, extend |
 
@@ -161,17 +167,30 @@ Add `label_activity` action to `ActivityTimerViewSet`:
   Assumption 3).
 - Derive `isUnlabelled = isActive && !(currentActivity?.name ??
   currentActivity?.text ?? "").trim()` for the new components to consume.
+- Add click-to-edit support (Design decision 6): local `isEditingLabel`
+  state plus `startEditingLabel()` and `handleLabelBlur()`. `startEditingLabel`
+  pre-fills `name` with `currentActivity.name` and sets `isEditingLabel =
+  true`; `handleLabelBlur` calls `handleUnifiedSubmit(name)` (which always
+  reaches `labelActivity` since `isActive` is true here, even for an empty
+  trimmed value — clearing the label is a valid outcome, see Edge cases),
+  then sets `isEditingLabel = false` unconditionally. The rendered UI state
+  is `isUnlabelled || isEditingLabel`, so once `labelActivity` resolves,
+  `currentActivity.name` drives the real state and `isEditingLabel` no
+  longer matters.
 - These are net-new exports from the hook; `ActivityInput.tsx` (legacy)
   doesn't call them, so its behaviour is unchanged. Unit tests for the new
-  branch logic.
+  branch logic, including click-to-edit → blur-with-value and
+  blur-with-empty-value.
 
 **Phase 5 — extend `EntitySearchInput` for a persistent/default list**
 - Add optional props: `alwaysOpen?: boolean`, `defaultResults?:
-  SearchEntity[]`, `emptyMessage?: string`.
+  SearchEntity[]`, `emptyMessage?: string`, `maxVisibleRows?: number`.
 - When `alwaysOpen` is true and the query is blank, render `defaultResults`
   (fed by `useDefaultActivityEntries` from the call site) instead of hiding
   the dropdown; when there's a query, existing Fuse-based `results` take
-  over unchanged.
+  over, sliced to `maxVisibleRows` when set (list container sizing, Design
+  decision 7) — `MAX_RESULTS = 8` internal to `useEntitySearchInput` is
+  unchanged, this is a display-layer cap on top of it.
 - Existing callers (`ActivityInput.tsx`) don't pass these props, so nothing
   changes for them. Unit/RTL tests for the new prop combination.
 
@@ -180,21 +199,25 @@ Add `label_activity` action to `ActivityTimerViewSet`:
   Running-labelled) using: `useActivityInput()` (extended),
   `useDefaultActivityEntries()`, extended `EntitySearchInput`, and the
   existing `Button` component for Start/Stop.
+- Render the running-labelled activity name as a clickable element wired to
+  `startEditingLabel()`/`handleLabelBlur()` (Design decision 6) so it drops
+  into the same Running-unlabelled layout, pre-filled, on click.
+- List container gets a fixed min-height sized for `maxVisibleRows = 4`
+  (Design decision 7) — reserved regardless of actual item count, so
+  switching between 0–4 rows (or fewer default entries) never shifts
+  surrounding layout.
 - Add the animation dependency (Design decision 5) and use it only inside
   this new tree.
 - Branch `ActivityTimelinePage.tsx` on `useFeatureFlag("unified_homepage")`:
   render `UnifiedTimerHome` instead of `CurrentActivity` + `ActivityTimeline`
   when on. This is the only edit to a shared file in the whole plan, and
   it's a pure conditional — flag off renders byte-identical output to today.
-- Component/RTL tests for state transitions; manual QA against real backend.
+- Component/RTL tests for state transitions, including click-to-edit;
+  manual QA against real backend.
+- Mode suggestion buttons are explicitly not built here (Assumption 4) —
+  layout leaves room for them but no component ships.
 
-**Phase 7 — mode suggestion buttons (isolated, needs Open Questions resolved)**
-- Add `ModeSuggestions.tsx`: dismissible buttons shown only in
-  Running-unlabelled state, per Assumption 4. Kept as its own commit since
-  its actual behaviour is unresolved (see Open Questions) and everything
-  else in the plan works without it.
-
-**Phase 8 — polish**
+**Phase 7 — polish**
 - Accessibility pass (`aria-live` on the timer, focus management across
   state transitions, list `role`/labelling consistency with existing
   `EntitySearchInput`/`List` patterns).
@@ -260,6 +283,35 @@ to maintain version of the same thing. Framer Motion is a natural fit for
 React 19 and has no dependency conflicts with the existing stack. Scoping it
 to `UnifiedTimerHome` only avoids any risk to the legacy tree.
 
+**6. Click-to-edit label: transient `isEditingLabel` flag, not a new derived
+state off `currentActivity`.**
+Clicking the running-labelled activity name needs to force the
+Running-unlabelled layout even though `currentActivity.name` is still
+populated (nothing has changed server-side yet). Alternative considered:
+optimistically clear `currentActivity.name` on click and restore it on
+cancel — rejected, because it would make the *displayed* current activity
+briefly diverge from the *actual* one for reasons (a UI edit hasn't been
+committed) unrelated to what `currentActivity` is supposed to represent
+elsewhere in the app (XP displays, auto-stop completion name, etc). A
+separate boolean that only affects which of the two running layouts renders
+keeps `currentActivity` as the single source of truth for "what is the
+timer actually tracking," while still giving the UI its edit-mode view.
+Chosen because it reuses the existing `labelActivity` write path unchanged —
+blur always resolves to a real state (`isUnlabelled` becomes true or false
+based on the post-write name), so `isEditingLabel` never needs manual
+resetting logic beyond "set to false after the blur handler runs."
+
+**7. List container: fixed min-height sized for `maxVisibleRows = 4`.**
+Alternative considered: let the container size to content (0–N rows).
+Rejected because the list's row count changes on every keystroke while
+filtering and on every state transition (Input ↔ Running-unlabelled), which
+would constantly reflow the Start/Stop button and timer display beneath it.
+A fixed-height container sized for 4 rows (matching the default-list cap
+already carried over from the reference branch, Design decision — see
+Phase 3/5) avoids layout jank without introducing a new number to justify
+separately. If fewer than 4 rows are available, the container keeps its
+reserved height with empty space rather than collapsing.
+
 ---
 
 ## 5. Edge cases
@@ -269,8 +321,19 @@ to `UnifiedTimerHome` only avoids any risk to the legacy tree.
   same pattern (disable Start while `status !== "empty"`/`!== "waiting"`)
   applies to the new blank-start button.
 - **Select/submit while a *labelled* timer is running**: per Assumption 3,
-  relabels in place rather than being a no-op — confirm this is the
-  intended reading before implementing Phase 4.
+  relabels in place rather than being a no-op.
+- **Click-to-edit label, blur with an empty input**: per the confirmed
+  behaviour, this clears the label — `handleLabelBlur` still calls
+  `labelActivity("")`, which the backend already tolerates (blank
+  `PlayerActivity.name` is valid, Design decision 2). The timer stays
+  active and running; the UI simply reflects the now-true `isUnlabelled`
+  state after the write resolves. This keeps server state and UI state in
+  sync rather than leaving a stale non-blank name on the server while the
+  UI shows blank.
+- **Click-to-edit label, blur with the value unchanged**: `handleUnifiedSubmit`
+  still calls `labelActivity` with the same name — an unnecessary network
+  call but harmless (idempotent rename). Not worth special-casing for a
+  first pass; flag as a possible follow-up optimization if it proves noisy.
 - **`label_activity` called after the timer already completed** (e.g. a
   queued UI event fires after Stop): the new action should check
   `timer.status in {"active", "waiting"}` server-side and return a 409/no-op
@@ -352,34 +415,31 @@ to `UnifiedTimerHome` only avoids any risk to the legacy tree.
 - **New animation dependency**: first use of Framer Motion in this repo —
   bundle size and unfamiliarity risk. Mitigated by scoping usage to one
   component tree and by the flag itself (fully reversible by toggling off).
-- **Default-list cap and dataset mismatch**: `useDefaultActivityEntries`
-  (ported, cap of 4, sourced from `useGame().playerActivities/
-  characterActivities`) and the Fuse-based filtered results (cap of 8,
-  sourced from `useEntitySearchCache`'s full-history query) are different
-  datasets with different caps. This is fine per the task brief's "single
-  source for both default and filtered list results" (they share the same
-  *component* and *search mechanism*, not literally the same array), but an
-  implementer should not assume they can be trivially merged into one
-  `useMemo`.
+- **Default-list and filtered-list dataset mismatch**: `useDefaultActivityEntries`
+  (ported, sourced from `useGame().playerActivities/characterActivities`)
+  and the Fuse-based filtered results (sourced from `useEntitySearchCache`'s
+  full-history query) are different underlying datasets — both are now
+  display-capped to 4 rows (`maxVisibleRows`, Design decision 7), but that
+  cap is cosmetic, not a sign they're the same data. This is fine per the
+  task brief's "single source for both default and filtered list results"
+  (they share the same *component* and *search mechanism*, not literally
+  the same array), but an implementer should not assume they can be
+  trivially merged into one `useMemo`.
 
 ---
 
 ## 8. Open questions
 
-1. Does relabelling apply to an already-labelled running timer (spec says
-   "otherwise attaches the selected label to the running timer" with no
-   unlabelled/labelled distinction), or should selecting a new item while a
-   labelled timer is running be a no-op? (Assumption 3 currently reads it as
-   "always relabels.")
-2. What do the mode suggestion buttons ("Task planning", "Free text")
-   actually do when clicked — prefill the input, open the existing
-   `SupportFlowModal`, or something else? Phase 7 is isolated specifically
-   so this can be resolved without blocking the rest of the plan.
-3. Is there a target row count for the default/persistent list, or is the
-   reference branch's `MAX_DEFAULT_ENTRIES = 4` acceptable to carry over
-   as-is?
-4. Any specific requirement for what happens to `handleUnifiedSelect` when
-   the running timer is a *support-flow* activity (`useSupportFlow`
-   integration in `useActivityInput.ts:185-215` has its own start path) —
-   out of scope for this plan unless flagged otherwise, since the brief
-   doesn't mention support mode.
+All four open questions from the previous draft are resolved (relabelling
+always applies while active — Assumption 3; mode suggestions parked —
+Assumption 4; default-list cap is 4 — Design decision 7; support-flow
+activities render as Running-labelled automatically — Assumption 6). One new
+item surfaced while designing click-to-edit:
+
+1. Should pressing **Escape** while editing a label cancel back to the
+   original name instead of committing whatever's currently typed (browsers
+   don't fire `blur` on Escape by default unless the input also loses
+   focus)? Not specified in the brief; current plan only wires `onBlur`, so
+   Escape today would just leave the input focused/unsaved until the user
+   clicks away. Worth a product call before Phase 6, but doesn't block
+   earlier phases.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "@vitejs/plugin-react": "^5.2.0",
         "axios": "^1.16.0",
         "classnames": "^2.5.1",
+        "framer-motion": "^12.42.2",
         "fuse.js": "^7.0.0",
         "jsdom": "^27.1.0",
         "jwt-decode": "^4.0.0",
@@ -6330,6 +6331,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7534,6 +7562,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,7 +37,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.0",
         "@eslint/js": "^9.29.0",
-        "@playwright/test": "^1.60.0",
+        "@playwright/test": "^1.61.1",
         "@storybook/addon-a11y": "^10.4.6",
         "@storybook/addon-docs": "^10.4.6",
         "@storybook/addon-vitest": "^10.4.6",
@@ -2345,53 +2345,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.60.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/@polka/url": {
@@ -7952,6 +7918,7 @@
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.0",
     "@eslint/js": "^9.29.0",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.61.1",
     "@storybook/addon-a11y": "^10.4.6",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-vitest": "^10.4.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "@vitejs/plugin-react": "^5.2.0",
     "axios": "^1.16.0",
     "classnames": "^2.5.1",
+    "framer-motion": "^12.42.2",
     "fuse.js": "^7.0.0",
     "jsdom": "^27.1.0",
     "jwt-decode": "^4.0.0",

--- a/frontend/src/components/ActivityInput/useActivityInput.test.ts
+++ b/frontend/src/components/ActivityInput/useActivityInput.test.ts
@@ -202,6 +202,23 @@ describe('useActivityInput unified handlers', () => {
     expect(result.current.isEditingLabel).toBe(true);
   });
 
+  it('inputValue reflects a fully-cleared name while editing, instead of falling back to the old committed name', () => {
+    mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+
+    const { result } = renderHook(() => useActivityInput());
+
+    act(() => {
+      result.current.startEditingLabel();
+    });
+
+    // Simulates selecting all text in the input and pressing Backspace/Delete.
+    act(() => {
+      result.current.setName('');
+    });
+
+    expect(result.current.inputValue).toBe('');
+  });
+
   it('handleLabelCancel restores the original name without calling labelActivity', () => {
     mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
 

--- a/frontend/src/components/ActivityInput/useActivityInput.test.ts
+++ b/frontend/src/components/ActivityInput/useActivityInput.test.ts
@@ -1,0 +1,241 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useActivityInput } from './useActivityInput';
+
+const mockUseGame = vi.fn();
+const mockUseSupportFlow = vi.fn();
+const mockUseEntitySearchCache = vi.fn();
+const fetchPlayerAndCharacter = vi.fn();
+const fetchCharacterCurrent = vi.fn();
+const fetchActivities = vi.fn();
+const clearAutoStopCompletion = vi.fn();
+const stop = vi.fn();
+const startActivity = vi.fn();
+const labelActivity = vi.fn();
+const addEntityToCache = vi.fn();
+
+vi.mock('../../hooks/useGame', () => ({
+  useGame: () => mockUseGame(),
+}));
+
+vi.mock('../../hooks/useSupportFlow', () => ({
+  useSupportFlow: (...args: unknown[]) => mockUseSupportFlow(...args),
+}));
+
+vi.mock('../../hooks/useEntitySearchCache', () => ({
+  useEntitySearchCache: (...args: unknown[]) => mockUseEntitySearchCache(...args),
+}));
+
+vi.mock('../../utils/sounds', () => ({
+  playLimitReachedSound: vi.fn(),
+  primeAudio: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>();
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  };
+});
+
+function mockGame(activityTimerOverrides: Record<string, unknown> = {}, gameOverrides: Record<string, unknown> = {}) {
+  mockUseGame.mockReturnValue({
+    activityTimer: {
+      currentActivity: null,
+      status: 'empty',
+      stop,
+      startActivity,
+      labelActivity,
+      elapsed: 0,
+      limitSeconds: null,
+      limitReached: false,
+      autoStopCompletion: null,
+      clearAutoStopCompletion,
+      ...activityTimerOverrides,
+    },
+    fetchPlayerAndCharacter,
+    fetchCharacterCurrent,
+    fetchActivities,
+    loginState: 'none',
+    loginStreak: 0,
+    loginEventAt: null,
+    player: { is_premium: false },
+    freeTimerLimitSeconds: 15,
+    ...gameOverrides,
+  });
+}
+
+describe('useActivityInput unified handlers', () => {
+  beforeEach(() => {
+    mockUseSupportFlow.mockReset();
+    mockUseEntitySearchCache.mockReset();
+    fetchPlayerAndCharacter.mockReset().mockResolvedValue(null);
+    fetchCharacterCurrent.mockReset().mockResolvedValue(null);
+    fetchActivities.mockReset().mockResolvedValue(null);
+    clearAutoStopCompletion.mockReset();
+    stop.mockReset();
+    startActivity.mockReset();
+    labelActivity.mockReset();
+    addEntityToCache.mockReset();
+
+    mockUseSupportFlow.mockReturnValue({
+      openWelcomeMessage: vi.fn(),
+      openActivityReward: vi.fn(),
+      openSupportMode: vi.fn(),
+      flowState: { isOpen: false },
+      flowDispatch: vi.fn(),
+      handleConfirmActivity: vi.fn(),
+    });
+
+    mockUseEntitySearchCache.mockReturnValue({
+      entities: [],
+      addEntityToCache,
+    });
+
+    mockGame();
+  });
+
+  it('handleBlankStart starts a timer with allowBlank and no text', async () => {
+    const { result } = renderHook(() => useActivityInput());
+
+    await act(async () => {
+      await result.current.handleBlankStart();
+    });
+
+    expect(startActivity).toHaveBeenCalledWith({
+      text: '',
+      allowBlank: true,
+      limitSeconds: 15,
+    });
+  });
+
+  it('isUnlabelled is true when active with a blank current activity name', () => {
+    mockGame({ status: 'active', currentActivity: { name: '' } });
+
+    const { result } = renderHook(() => useActivityInput());
+
+    expect(result.current.isUnlabelled).toBe(true);
+  });
+
+  it('isUnlabelled is false when active with a real current activity name', () => {
+    mockGame({ status: 'active', currentActivity: { name: 'Write docs' } });
+
+    const { result } = renderHook(() => useActivityInput());
+
+    expect(result.current.isUnlabelled).toBe(false);
+  });
+
+  it('handleUnifiedSelect starts a new timer when nothing is running', async () => {
+    const { result } = renderHook(() => useActivityInput());
+
+    await act(async () => {
+      await result.current.handleUnifiedSelect({ name: 'Washing dishes', id: 1, source: 'activity' });
+    });
+
+    expect(startActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Washing dishes', limitSeconds: 15 })
+    );
+    expect(labelActivity).not.toHaveBeenCalled();
+  });
+
+  it('handleUnifiedSelect labels the running timer instead of starting a new one', async () => {
+    mockGame({ status: 'active', currentActivity: { name: '' } });
+
+    const { result } = renderHook(() => useActivityInput());
+
+    await act(async () => {
+      await result.current.handleUnifiedSelect({ name: 'Deep work', id: 1, source: 'activity' });
+    });
+
+    expect(labelActivity).toHaveBeenCalledWith('Deep work', null);
+    expect(startActivity).not.toHaveBeenCalled();
+  });
+
+  it('handleUnifiedSelect resolves a task-linked selection into a taskId when relabelling', async () => {
+    mockGame({ status: 'active', currentActivity: { name: '' } });
+
+    const { result } = renderHook(() => useActivityInput());
+
+    await act(async () => {
+      await result.current.handleUnifiedSelect({ name: 'Ship it', id: 7, source: 'task' });
+    });
+
+    expect(labelActivity).toHaveBeenCalledWith('Ship it', 7);
+  });
+
+  it('handleUnifiedSubmit is a no-op for blank text when nothing is running', async () => {
+    const { result } = renderHook(() => useActivityInput());
+
+    await act(async () => {
+      await result.current.handleUnifiedSubmit('   ');
+    });
+
+    expect(startActivity).not.toHaveBeenCalled();
+    expect(labelActivity).not.toHaveBeenCalled();
+  });
+
+  it('handleUnifiedSubmit relabels the running timer even with blank text (clears the label)', async () => {
+    mockGame({ status: 'active', currentActivity: { name: 'Old label' } });
+
+    const { result } = renderHook(() => useActivityInput());
+
+    await act(async () => {
+      await result.current.handleUnifiedSubmit('   ');
+    });
+
+    expect(labelActivity).toHaveBeenCalledWith('', null);
+    expect(startActivity).not.toHaveBeenCalled();
+  });
+
+  it('startEditingLabel pre-fills the input with the current activity name', () => {
+    mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+
+    const { result } = renderHook(() => useActivityInput());
+
+    act(() => {
+      result.current.startEditingLabel();
+    });
+
+    expect(result.current.name).toBe('Deep work');
+    expect(result.current.isEditingLabel).toBe(true);
+  });
+
+  it('handleLabelCancel restores the original name without calling labelActivity', () => {
+    mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+
+    const { result } = renderHook(() => useActivityInput());
+
+    act(() => {
+      result.current.startEditingLabel();
+      result.current.setName('Something typed');
+    });
+
+    act(() => {
+      result.current.handleLabelCancel();
+    });
+
+    expect(result.current.name).toBe('Deep work');
+    expect(result.current.isEditingLabel).toBe(false);
+    expect(labelActivity).not.toHaveBeenCalled();
+  });
+
+  it('handleLabelBlur commits the edited name and exits editing mode', async () => {
+    mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+
+    const { result } = renderHook(() => useActivityInput());
+
+    act(() => {
+      result.current.startEditingLabel();
+      result.current.setName('Deeper work');
+    });
+
+    await act(async () => {
+      await result.current.handleLabelBlur();
+    });
+
+    expect(labelActivity).toHaveBeenCalledWith('Deeper work', null);
+    expect(result.current.isEditingLabel).toBe(false);
+  });
+});

--- a/frontend/src/components/ActivityInput/useActivityInput.ts
+++ b/frontend/src/components/ActivityInput/useActivityInput.ts
@@ -173,7 +173,7 @@ export function useActivityInput() {
     freeTimerLimitSeconds,
   } = useGame();
 
-  const { currentActivity, status, stop, startActivity, elapsed, limitSeconds, autoStopCompletion, clearAutoStopCompletion } =
+  const { currentActivity, status, stop, startActivity, labelActivity, elapsed, limitSeconds, autoStopCompletion, clearAutoStopCompletion } =
     activityTimer;
 
   const isPremium = Boolean(player?.is_premium);
@@ -181,6 +181,7 @@ export function useActivityInput() {
   const { addEntityToCache } = useEntitySearchCache("activity");
 
   const [name, setName] = useState("");
+  const [isEditingLabel, setIsEditingLabel] = useState(false);
 
   const {
     openWelcomeMessage,
@@ -216,6 +217,7 @@ export function useActivityInput() {
 
   const isActive = status === "active";
   const inputValue = isActive ? name || currentActivity?.name || "" : name;
+  const isUnlabelled = isActive && !(currentActivity?.name ?? currentActivity?.text ?? "").trim();
 
   useWelcomeMessageEffect({
     loginState,
@@ -318,6 +320,15 @@ export function useActivityInput() {
     stop,
   ]);
 
+  const handleBlankStart = useCallback(async () => {
+    primeAudio();
+    await startActivity({
+      text: "",
+      allowBlank: true,
+      limitSeconds: isPremium ? null : freeTimerLimitSeconds,
+    });
+  }, [freeTimerLimitSeconds, isPremium, startActivity]);
+
   const handleSelectActivity = useCallback(
     async (activity: SelectedEntity) => {
       setName(activity.name);
@@ -342,6 +353,65 @@ export function useActivityInput() {
     },
     [addEntityToCache, freeTimerLimitSeconds, isPremium, startActivity]
   );
+
+  // Selecting a list item: starts a timer if none is running, otherwise
+  // attaches (or re-attaches) the selected label to the running timer —
+  // covers both unlabelled->labelled and relabelling an already-labelled
+  // timer, and is also what click-to-edit's blur/select path uses.
+  const handleUnifiedSelect = useCallback(
+    async (activity: SelectedEntity) => {
+      if (!isActive) {
+        await handleSelectActivity(activity);
+        return;
+      }
+
+      setName(activity.name);
+      addEntityToCache(activity as unknown as Partial<PlayerActivity>);
+      await labelActivity(activity.name, resolveSelectedTaskId(activity));
+      setIsEditingLabel(false);
+    },
+    [addEntityToCache, handleSelectActivity, isActive, labelActivity]
+  );
+
+  // Submitting free text: starts a timer if none is running, otherwise
+  // relabels the running timer (including clearing the label if blank —
+  // see handleLabelBlur).
+  const handleUnifiedSubmit = useCallback(
+    async (activityName: string) => {
+      const trimmedName = activityName.trim();
+
+      if (!isActive) {
+        if (!trimmedName) return;
+        await handleCreateActivity(trimmedName);
+        return;
+      }
+
+      setName(trimmedName);
+      if (trimmedName) addEntityToCache(trimmedName);
+      await labelActivity(trimmedName, null);
+      setIsEditingLabel(false);
+    },
+    [addEntityToCache, handleCreateActivity, isActive, labelActivity]
+  );
+
+  // Click-to-edit: clicking the running-labelled activity name pre-fills
+  // the input with the current name and drops into the unlabelled layout.
+  const startEditingLabel = useCallback(() => {
+    setName(currentActivity?.name ?? currentActivity?.text ?? "");
+    setIsEditingLabel(true);
+  }, [currentActivity?.name, currentActivity?.text]);
+
+  const handleLabelBlur = useCallback(async () => {
+    await handleUnifiedSubmit(name);
+    setIsEditingLabel(false);
+  }, [handleUnifiedSubmit, name]);
+
+  // Escape discards the edit — no labelActivity call, name reverts to
+  // whatever the timer is currently actually labelled.
+  const handleLabelCancel = useCallback(() => {
+    setName(currentActivity?.name ?? currentActivity?.text ?? "");
+    setIsEditingLabel(false);
+  }, [currentActivity?.name, currentActivity?.text]);
 
   // Called when user confirms the "submit active timer?" AlertDialog in ActivityInput.
   const submitAndOpenSupport = useCallback(async () => {
@@ -403,6 +473,8 @@ export function useActivityInput() {
     name,
     setName,
     isActive,
+    isUnlabelled,
+    isEditingLabel,
     inputValue,
     minutes,
     seconds,
@@ -412,8 +484,14 @@ export function useActivityInput() {
     flowDispatch,
     handleConfirmActivity,
     handleToggle,
+    handleBlankStart,
     handleSelectActivity,
     handleCreateActivity,
+    handleUnifiedSelect,
+    handleUnifiedSubmit,
+    startEditingLabel,
+    handleLabelBlur,
+    handleLabelCancel,
     submitAndOpenSupport,
     openSupportMode,
     isPremium,

--- a/frontend/src/components/ActivityInput/useActivityInput.ts
+++ b/frontend/src/components/ActivityInput/useActivityInput.ts
@@ -216,7 +216,14 @@ export function useActivityInput() {
   });
 
   const isActive = status === "active";
-  const inputValue = isActive ? name || currentActivity?.name || "" : name;
+  // While actively editing (click-to-edit), `name` is the single source of
+  // truth — including when the user has deleted it down to "". Falling back
+  // to `currentActivity?.name` unconditionally here meant selecting all text
+  // in the input and pressing Backspace/Delete would visibly "undo" itself:
+  // `name` became "", so this fell back to the still-uncommitted old name.
+  // Outside of active editing, the fallback is still needed (e.g. showing
+  // the labelled activity's name before edit mode's own state has caught up).
+  const inputValue = isActive ? (isEditingLabel ? name : name || currentActivity?.name || "") : name;
   const isUnlabelled = isActive && !(currentActivity?.name ?? currentActivity?.text ?? "").trim();
 
   useWelcomeMessageEffect({

--- a/frontend/src/components/EntitySearchInput/EntitySearchInput.module.scss
+++ b/frontend/src/components/EntitySearchInput/EntitySearchInput.module.scss
@@ -82,3 +82,10 @@
 .optionButtonActive {
   background: rgba(c.$color-border-primary, 0.14);
 }
+
+.emptyMessage {
+  margin: v.$spacing-xs 0 0;
+  padding: v.$spacing-sm v.$padding-base;
+  color: rgba(c.$color-text-body, 0.6);
+  @include t.apply-text-style(t.$text-body);
+}

--- a/frontend/src/components/EntitySearchInput/EntitySearchInput.module.scss
+++ b/frontend/src/components/EntitySearchInput/EntitySearchInput.module.scss
@@ -46,6 +46,28 @@
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
 }
 
+// Persistent (alwaysOpen) mode is a permanent inline list, not a transient
+// overlay: it sits in normal document flow (so it can't float above a modal
+// or steal clicks from layout below it) and drops the floating-panel
+// styling (shadow, tooltip-level z-index) that implies "this will vanish
+// when you look away."
+.dropdownPersistent {
+  position: static;
+  top: auto;
+  left: auto;
+  right: auto;
+  z-index: v.$z-indexdropdown;
+  margin-top: v.$spacing-xs;
+  border-color: rgba(c.$color-border-primary, 0.12);
+  background: rgba(c.$color-bg, 0.6);
+  box-shadow: none;
+  box-sizing: border-box;
+  // Reserve room for maxVisibleRows so the list settling to fewer rows (or
+  // switching between the default and filtered result sets) doesn't reflow
+  // whatever sits below it.
+  min-height: var(--entity-search-persistent-min-height, auto);
+}
+
 .optionItem {
   margin: 0;
 }
@@ -87,5 +109,7 @@
   margin: v.$spacing-xs 0 0;
   padding: v.$spacing-sm v.$padding-base;
   color: rgba(c.$color-text-body, 0.6);
+  box-sizing: border-box;
+  min-height: var(--entity-search-persistent-min-height, auto);
   @include t.apply-text-style(t.$text-body);
 }

--- a/frontend/src/components/EntitySearchInput/EntitySearchInput.test.tsx
+++ b/frontend/src/components/EntitySearchInput/EntitySearchInput.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import EntitySearchInput from "./EntitySearchInput";
+import type { SearchEntity } from "./useEntitySearchInput";
 
 interface MockEntity {
   id: string | number;
@@ -23,9 +24,17 @@ vi.mock("../../hooks/useEntitySearchCache", () => ({
 function Harness({
   type = "activity",
   onCreate,
+  defaultResults,
+  alwaysOpen,
+  maxVisibleRows,
+  emptyMessage,
 }: {
   type?: "task" | "activity";
   onCreate?: (name: string) => void;
+  defaultResults?: SearchEntity[];
+  alwaysOpen?: boolean;
+  maxVisibleRows?: number;
+  emptyMessage?: string;
 }) {
   const [value, setValue] = useState("");
   return (
@@ -35,6 +44,10 @@ function Harness({
       onChange={setValue}
       onCreate={onCreate}
       ariaLabel="task search"
+      defaultResults={defaultResults}
+      alwaysOpen={alwaysOpen}
+      maxVisibleRows={maxVisibleRows}
+      emptyMessage={emptyMessage}
     />
   );
 }
@@ -91,5 +104,71 @@ describe("EntitySearchInput", () => {
 
     expect(onCreate).toHaveBeenCalledWith("Plan offsite");
     expect(addEntityToCache).toHaveBeenCalledWith("Plan offsite");
+  });
+
+  it("does not open a persistent list without alwaysOpen (legacy behaviour unchanged)", () => {
+    render(<Harness defaultResults={[{ id: "d1", name: "Default row", taskId: null, source: "activity" }]} />);
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("shows defaultResults as a persistent list when alwaysOpen is set and the query is blank", () => {
+    render(
+      <Harness
+        alwaysOpen
+        defaultResults={[
+          { id: "d1", name: "Washing dishes", taskId: null, source: "activity" },
+          { id: "d2", name: "Ship it", taskId: 7, source: "task" },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Washing dishes" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Ship it" })).toBeInTheDocument();
+  });
+
+  it("switches from defaultResults to Fuse results once a query is typed", async () => {
+    const user = userEvent.setup();
+    mockEntities = [{ id: "a1", name: "Write report", taskId: null, source: "activity" }];
+
+    render(
+      <Harness
+        alwaysOpen
+        defaultResults={[{ id: "d1", name: "Washing dishes", taskId: null, source: "activity" }]}
+      />
+    );
+
+    expect(screen.getByRole("option", { name: "Washing dishes" })).toBeInTheDocument();
+
+    await user.type(screen.getByRole("combobox"), "write");
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "Write report" })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("option", { name: "Washing dishes" })).not.toBeInTheDocument();
+  });
+
+  it("caps combined rows to maxVisibleRows", () => {
+    render(
+      <Harness
+        alwaysOpen
+        maxVisibleRows={2}
+        defaultResults={[
+          { id: "d1", name: "Row one", taskId: null, source: "activity" },
+          { id: "d2", name: "Row two", taskId: null, source: "activity" },
+          { id: "d3", name: "Row three", taskId: null, source: "activity" },
+        ]}
+      />
+    );
+
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+  });
+
+  it("shows emptyMessage instead of the list when alwaysOpen has no rows", () => {
+    render(<Harness alwaysOpen defaultResults={[]} emptyMessage="Nothing yet" />);
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.getByText("Nothing yet")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/EntitySearchInput/EntitySearchInput.tsx
+++ b/frontend/src/components/EntitySearchInput/EntitySearchInput.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import classNames from "classnames";
 
 import {
@@ -71,6 +72,16 @@ export default function EntitySearchInput({
     maxVisibleRows,
   });
 
+  // Persistent mode reserves room for maxVisibleRows (worst case: both group
+  // labels shown) so the list settling to fewer rows, or falling back to
+  // emptyMessage, doesn't reflow whatever sits below it.
+  const persistentMinHeightStyle =
+    alwaysOpen && typeof maxVisibleRows === "number"
+      ? ({
+          "--entity-search-persistent-min-height": `calc(${maxVisibleRows} * 2.75rem + 2 * 1.75rem)`,
+        } as CSSProperties)
+      : undefined;
+
   return (
     <div ref={rootRef} className={classNames(styles.root, className)}>
       <input
@@ -92,9 +103,10 @@ export default function EntitySearchInput({
       {isDropdownOpen && (
         <ul
           id={`${type}-entity-search-results`}
-          className={styles.dropdown}
+          className={classNames(styles.dropdown, { [styles.dropdownPersistent]: alwaysOpen })}
           role="listbox"
           aria-label={`${type} suggestions`}
+          style={persistentMinHeightStyle}
         >
           {(() => {
             const renderItem = (entity: SearchEntity, index: number) => {
@@ -142,7 +154,9 @@ export default function EntitySearchInput({
       )}
 
       {alwaysOpen && !isDropdownOpen && emptyMessage && (
-        <p className={styles.emptyMessage}>{emptyMessage}</p>
+        <p className={styles.emptyMessage} style={persistentMinHeightStyle}>
+          {emptyMessage}
+        </p>
       )}
     </div>
   );

--- a/frontend/src/components/EntitySearchInput/EntitySearchInput.tsx
+++ b/frontend/src/components/EntitySearchInput/EntitySearchInput.tsx
@@ -18,6 +18,14 @@ interface EntitySearchInputProps {
   inputClassName?: string;
   disabled?: boolean;
   searchEnabled?: boolean;
+  /** Shown in place of Fuse results when the query is blank. */
+  defaultResults?: SearchEntity[];
+  /** Keep the dropdown open regardless of focus (persistent list mode). */
+  alwaysOpen?: boolean;
+  /** Cap the combined (task + activity) rows rendered, regardless of source. */
+  maxVisibleRows?: number;
+  /** Shown instead of the list when alwaysOpen is set and there are no rows. */
+  emptyMessage?: string;
 }
 
 export default function EntitySearchInput({
@@ -32,6 +40,10 @@ export default function EntitySearchInput({
   inputClassName,
   disabled = false,
   searchEnabled = true,
+  defaultResults,
+  alwaysOpen = false,
+  maxVisibleRows,
+  emptyMessage,
 }: EntitySearchInputProps) {
   const {
     rootRef,
@@ -54,6 +66,9 @@ export default function EntitySearchInput({
     onCreate,
     disabled,
     searchEnabled,
+    defaultResults,
+    alwaysOpen,
+    maxVisibleRows,
   });
 
   return (
@@ -124,6 +139,10 @@ export default function EntitySearchInput({
             );
           })()}
         </ul>
+      )}
+
+      {alwaysOpen && !isDropdownOpen && emptyMessage && (
+        <p className={styles.emptyMessage}>{emptyMessage}</p>
       )}
     </div>
   );

--- a/frontend/src/components/EntitySearchInput/useEntitySearchInput.ts
+++ b/frontend/src/components/EntitySearchInput/useEntitySearchInput.ts
@@ -24,6 +24,12 @@ interface UseEntitySearchInputProps {
   onCreate?: (name: string) => void | Promise<void>;
   disabled?: boolean;
   searchEnabled?: boolean;
+  /** Shown in place of Fuse results when the query is blank. */
+  defaultResults?: SearchEntity[];
+  /** Keep the dropdown open regardless of focus (persistent list mode). */
+  alwaysOpen?: boolean;
+  /** Cap the combined (task + activity) rows rendered, regardless of source. */
+  maxVisibleRows?: number;
 }
 
 function normalizeQuery(value: string | undefined): string {
@@ -38,10 +44,14 @@ function useEntitySearchResults({
   entities,
   value,
   canSearch,
+  defaultResults,
+  maxVisibleRows,
 }: {
   entities: SearchEntity[];
   value: string;
   canSearch: boolean;
+  defaultResults?: SearchEntity[];
+  maxVisibleRows?: number;
 }) {
   const [debouncedQuery, setDebouncedQuery] = useState(value);
 
@@ -75,6 +85,7 @@ function useEntitySearchResults({
     if (!canSearch) return [];
 
     const query = normalizeQuery(debouncedQuery);
+    if (!query) return defaultResults ?? [];
     if (query.length < MIN_QUERY_LENGTH) return [];
 
     const queryKey = getEntityNameKey(query);
@@ -120,7 +131,7 @@ function useEntitySearchResults({
       });
 
     return uniqueResults.slice(0, MAX_RESULTS);
-  }, [canSearch, debouncedQuery, fuse, normalizedValue, searchableEntities]);
+  }, [canSearch, debouncedQuery, defaultResults, fuse, normalizedValue, searchableEntities]);
 
   const results = useMemo(() => {
     const taskResults = rawResults.filter((result) => result.source === "task");
@@ -129,8 +140,9 @@ function useEntitySearchResults({
       (result) => result.source !== "task" && !taskNames.has(result.nameKey ?? "")
     );
 
-    return [...taskResults, ...activityResults];
-  }, [rawResults]);
+    const combined = [...taskResults, ...activityResults];
+    return typeof maxVisibleRows === "number" ? combined.slice(0, maxVisibleRows) : combined;
+  }, [rawResults, maxVisibleRows]);
 
   const taskItems = useMemo(() => results.filter((result) => result.source === "task"), [results]);
   const activityItems = useMemo(
@@ -177,6 +189,9 @@ export function useEntitySearchInput({
   onCreate,
   disabled = false,
   searchEnabled = true,
+  defaultResults,
+  alwaysOpen = false,
+  maxVisibleRows,
 }: UseEntitySearchInputProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const { entities, addEntityToCache } = useEntitySearchCache(type);
@@ -190,9 +205,11 @@ export function useEntitySearchInput({
     entities,
     value,
     canSearch,
+    defaultResults,
+    maxVisibleRows,
   });
 
-  const isDropdownOpen = isFocused && results.length > 0;
+  const isDropdownOpen = alwaysOpen ? results.length > 0 : isFocused && results.length > 0;
 
   const activeHighlightedIndex =
     highlightedIndex >= 0 && highlightedIndex < results.length ? highlightedIndex : -1;

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss
@@ -22,15 +22,46 @@ $row-control-height: 44px;
   animation: timerPulse 1.6s ease-in-out infinite;
 }
 
-.runningRow {
+// Two fixed rows, always in this order: controls (toggle + timer) on top,
+// the activity's identity (label or search) below. Neither row's own
+// position ever depends on the other's content, so swapping label<->search
+// (row 2) can't disturb the toggle/timer (row 1), and vice versa.
+.container {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: map.get(sp.$gap, sm);
 }
 
+.controlsRow {
+  // Centered while idle (button alone); once the timer appears, the pair
+  // sits together at the right (justify-content flips via inline style —
+  // see UnifiedTimerHome.tsx).
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: map.get(sp.$gap, sm);
+  min-height: $row-control-height;
+}
+
+.entityRow {
+  // AnimatePresence mode="popLayout" (label <-> search) makes the exiting
+  // element position:absolute against the nearest positioned ancestor while
+  // it fades out — without this, that's `.wrapper`, not this row, and the
+  // exiting element jumps to the wrong place instead of fading in place.
+  position: relative;
+}
+
 .activityLabel {
-  flex: 1 1 auto;
-  min-width: 0;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  // Matches .searchControl/.inputText's height so swapping between the label
+  // display and the search input (click-to-edit, and committing back out of
+  // it) never changes entityRow's own height — otherwise the `layout`
+  // animation on entityRow/container stretches the row on every focus/blur,
+  // which reads as a jump. Long names can still grow past this floor.
+  min-height: $row-control-height;
+  box-sizing: border-box;
   text-align: left;
   border: 2px solid transparent;
   background: transparent;
@@ -50,27 +81,9 @@ $row-control-height: 44px;
   @include m.focus-outline(c.$color-border-accent);
 }
 
-.inputRow {
-  display: flex;
-  flex-direction: column;
-  gap: map.get(sp.$gap, sm);
-}
-
-// Height of a single EntitySearchInput dropdown row (option button padding +
-// line height), used to reserve space below the input.
-$list-row-height: 2.75rem;
-$list-group-label-height: 1.75rem;
-
 .searchControl {
   width: 100%;
-  // The dropdown is position:absolute (EntitySearchInput.module.scss), so it
-  // doesn't push layout on its own — without this reserved space it floats
-  // over the Start/Stop controls below and steals their clicks. Sized for
-  // maxVisibleRows (4) plus both group labels (Tasks/Activities) as the
-  // worst case, per Design decision 7 (fixed-height list container).
-  min-height: calc(
-    #{$row-control-height} + 4 * #{$list-row-height} + 2 * #{$list-group-label-height}
-  );
+  min-height: $row-control-height;
 }
 
 .entitySearch {
@@ -84,22 +97,19 @@ $list-group-label-height: 1.75rem;
   font-size: 1.05rem;
 }
 
-.startControls,
-.runningControls {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: map.get(sp.$gap, sm);
-}
-
 .timerPill {
   display: flex;
   align-items: center;
+  justify-content: center;
   height: $row-control-height;
   @include m.border(rgba(c.$color-border-primary, 0.3));
   border-radius: v.$border-radius;
-  padding: 0 v.$padding-base;
-  line-height: 1;
+  // $padding-base is itself a 2-value shorthand ($padding-vertical
+  // $padding-horizontal) — `0 $padding-base` silently expanded to a 3-value
+  // padding (0 top, $padding-vertical left/right, $padding-horizontal
+  // bottom), which is what was pushing the digits off-center. Use the
+  // horizontal-only variable instead so this stays a clean 2-value shorthand.
+  padding: 0 v.$padding-horizontal;
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 1.1rem;
@@ -107,12 +117,6 @@ $list-group-label-height: 1.75rem;
 }
 
 .ctaButton {
-  height: $row-control-height;
-  display: flex;
-  align-items: center;
-}
-
-.blankStartButton {
   height: $row-control-height;
   display: flex;
   align-items: center;
@@ -149,8 +153,7 @@ $list-group-label-height: 1.75rem;
 
 @include m.respond-to(md, down) {
   .timerPill,
-  .ctaButton,
-  .blankStartButton {
+  .ctaButton {
     height: 40px;
   }
 
@@ -162,26 +165,12 @@ $list-group-label-height: 1.75rem;
 
 @include m.respond-to(sm, down) {
   .timerPill,
-  .ctaButton,
-  .blankStartButton {
+  .ctaButton {
     height: 38px;
   }
 
   .inputText {
     height: 38px;
     font-size: 0.9rem;
-  }
-
-  .runningRow {
-    flex-wrap: wrap;
-  }
-
-  .startControls,
-  .runningControls {
-    justify-content: stretch;
-
-    > * {
-      flex: 1 1 auto;
-    }
   }
 }

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss
@@ -56,11 +56,21 @@ $row-control-height: 44px;
   gap: map.get(sp.$gap, sm);
 }
 
+// Height of a single EntitySearchInput dropdown row (option button padding +
+// line height), used to reserve space below the input.
+$list-row-height: 2.75rem;
+$list-group-label-height: 1.75rem;
+
 .searchControl {
   width: 100%;
-  // Reserve space for up to maxVisibleRows (4) so the list opening/closing
-  // and filtering doesn't reflow the controls below it.
-  min-height: $row-control-height;
+  // The dropdown is position:absolute (EntitySearchInput.module.scss), so it
+  // doesn't push layout on its own — without this reserved space it floats
+  // over the Start/Stop controls below and steals their clicks. Sized for
+  // maxVisibleRows (4) plus both group labels (Tasks/Activities) as the
+  // worst case, per Design decision 7 (fixed-height list container).
+  min-height: calc(
+    #{$row-control-height} + 4 * #{$list-row-height} + 2 * #{$list-group-label-height}
+  );
 }
 
 .entitySearch {

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss
@@ -1,0 +1,177 @@
+@use '../../styles/utilities/mixins' as m;
+@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/typography' as t;
+@use '../../styles/semantic/colors' as c;
+@use '../../styles/semantic/spacing' as sp;
+@use 'sass:map';
+
+$row-control-height: 44px;
+
+.wrapper {
+  position: relative;
+  width: min(100%, 720px);
+  border: 1px solid rgba(c.$color-border-primary, 0.15);
+  border-radius: v.$border-radius;
+  padding: v.$padding-base;
+  background: rgba(c.$color-player, 0.14);
+}
+
+.isActive .timerPill {
+  border-color: rgba(c.$color-border-primary, 0.8);
+  box-shadow: 0 0 0 2px rgba(c.$color-border-primary, 0.25);
+  animation: timerPulse 1.6s ease-in-out infinite;
+}
+
+.runningRow {
+  display: flex;
+  align-items: center;
+  gap: map.get(sp.$gap, sm);
+}
+
+.activityLabel {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: left;
+  border: 2px solid transparent;
+  background: transparent;
+  border-radius: v.$border-radius;
+  padding: v.$padding-sm;
+  font-size: 1.05rem;
+  cursor: pointer;
+  color: c.$color-text-body;
+  overflow-wrap: anywhere;
+
+  &:hover,
+  &:focus-visible {
+    border-color: rgba(c.$color-border-accent, 0.5);
+    background: rgba(255, 255, 255, 0.6);
+  }
+
+  @include m.focus-outline(c.$color-border-accent);
+}
+
+.inputRow {
+  display: flex;
+  flex-direction: column;
+  gap: map.get(sp.$gap, sm);
+}
+
+.searchControl {
+  width: 100%;
+  // Reserve space for up to maxVisibleRows (4) so the list opening/closing
+  // and filtering doesn't reflow the controls below it.
+  min-height: $row-control-height;
+}
+
+.entitySearch {
+  width: 100%;
+}
+
+.inputText {
+  width: 100%;
+  height: $row-control-height;
+  box-sizing: border-box;
+  font-size: 1.05rem;
+}
+
+.startControls,
+.runningControls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: map.get(sp.$gap, sm);
+}
+
+.timerPill {
+  display: flex;
+  align-items: center;
+  height: $row-control-height;
+  @include m.border(rgba(c.$color-border-primary, 0.3));
+  border-radius: v.$border-radius;
+  padding: 0 v.$padding-base;
+  line-height: 1;
+  white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 1.1rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ctaButton {
+  height: $row-control-height;
+  display: flex;
+  align-items: center;
+}
+
+.blankStartButton {
+  height: $row-control-height;
+  display: flex;
+  align-items: center;
+}
+
+.limitWarning {
+  margin: v.$spacing-sm 0 0;
+  text-align: left;
+  color: c.$color-text-body;
+}
+
+.supportButtonRow {
+  display: flex;
+  justify-content: center;
+  padding-top: v.$spacing-md;
+}
+
+.supportModeButton {
+  max-width: 100%;
+  border: 1px solid rgba(c.$color-border-primary, 0.35);
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(2px);
+}
+
+@keyframes timerPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 2px rgba(c.$color-border-primary, 0.25);
+  }
+  50% {
+    box-shadow: 0 0 0 3px rgba(c.$color-border-primary, 0.4);
+  }
+}
+
+@include m.respond-to(md, down) {
+  .timerPill,
+  .ctaButton,
+  .blankStartButton {
+    height: 40px;
+  }
+
+  .inputText {
+    height: 40px;
+    font-size: 1rem;
+  }
+}
+
+@include m.respond-to(sm, down) {
+  .timerPill,
+  .ctaButton,
+  .blankStartButton {
+    height: 38px;
+  }
+
+  .inputText {
+    height: 38px;
+    font-size: 0.9rem;
+  }
+
+  .runningRow {
+    flex-wrap: wrap;
+  }
+
+  .startControls,
+  .runningControls {
+    justify-content: stretch;
+
+    > * {
+      flex: 1 1 auto;
+    }
+  }
+}

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx
@@ -190,6 +190,28 @@ describe('UnifiedTimerHome', () => {
     await user.click(screen.getByRole('button', { name: /Deep work/ }));
 
     expect(screen.getByRole('combobox', { name: 'Activity name' })).toHaveValue('Deep work');
+    expect(screen.getByRole('combobox', { name: 'Activity name' })).toHaveFocus();
+  });
+
+  it('Escape cancels click-to-edit without calling labelActivity', async () => {
+    const user = userEvent.setup();
+    mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+
+    render(<UnifiedTimerHome />);
+
+    await user.click(screen.getByRole('button', { name: /Deep work/ }));
+    await user.keyboard('{Escape}');
+
+    expect(labelActivity).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /Deep work/ })).toBeInTheDocument();
+  });
+
+  it('exposes a status message for screen readers reflecting the running state', () => {
+    mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+
+    render(<UnifiedTimerHome />);
+
+    expect(screen.getByText('Timer running: Deep work')).toBeInTheDocument();
   });
 
   it('shows the auto-stop warning near the limit', () => {

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx
@@ -46,19 +46,32 @@ vi.mock('../../utils/sounds', () => ({
 // Strip animation-only props so React doesn't warn about unknown DOM attrs,
 // and render children synchronously so tests don't need to await exit/enter
 // transitions.
+function stripMotionProps(props: Record<string, unknown>) {
+  const { layout, initial, animate, exit, transition, children, ...rest } = props;
+  void layout;
+  void initial;
+  void animate;
+  void exit;
+  void transition;
+  return { rest, children: children as React.ReactNode };
+}
+
 vi.mock('framer-motion', () => ({
   motion: {
     div: React.forwardRef<HTMLDivElement, Record<string, unknown>>((props, ref) => {
-      const { layout, initial, animate, exit, transition, children, ...rest } = props;
-      void layout;
-      void initial;
-      void animate;
-      void exit;
-      void transition;
+      const { rest, children } = stripMotionProps(props);
       return (
         <div ref={ref} {...rest}>
-          {children as React.ReactNode}
+          {children}
         </div>
+      );
+    }),
+    button: React.forwardRef<HTMLButtonElement, Record<string, unknown>>((props, ref) => {
+      const { rest, children } = stripMotionProps(props);
+      return (
+        <button ref={ref} {...rest}>
+          {children}
+        </button>
       );
     }),
   },
@@ -130,21 +143,21 @@ describe('UnifiedTimerHome', () => {
     mockGame();
   });
 
-  it('renders the input state by default with a Blank Start option', () => {
+  it('renders the input state by default with a single, always-enabled Start button', () => {
     render(<UnifiedTimerHome />);
 
     expect(screen.getByRole('combobox', { name: 'Activity name' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Start blank' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Start' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Start blank' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Start' })).toBeEnabled();
   });
 
-  it('Blank Start starts a timer and moves to the running-unlabelled state', async () => {
+  it('Start with an empty input starts a blank timer and moves to the running-unlabelled state', async () => {
     const user = userEvent.setup();
     startActivity.mockResolvedValue(null);
 
     const { rerender } = render(<UnifiedTimerHome />);
 
-    await user.click(screen.getByRole('button', { name: 'Start blank' }));
+    await user.click(screen.getByRole('button', { name: 'Start' }));
 
     expect(startActivity).toHaveBeenCalledWith({ text: '', allowBlank: true, limitSeconds: 15 });
 
@@ -154,6 +167,32 @@ describe('UnifiedTimerHome', () => {
 
     expect(screen.getByRole('combobox', { name: 'Activity name' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+  });
+
+  it('Start/Stop is the same persistent button element, not a swap', async () => {
+    const user = userEvent.setup();
+    startActivity.mockResolvedValue(null);
+
+    const { rerender } = render(<UnifiedTimerHome />);
+    const startButton = screen.getByRole('button', { name: 'Start' });
+
+    await user.click(startButton);
+    mockGame({ status: 'active', currentActivity: { name: '' } });
+    rerender(<UnifiedTimerHome />);
+
+    expect(screen.getByRole('button', { name: 'Stop' })).toBe(startButton);
+  });
+
+  it('Start with typed text starts a named timer instead of a blank one', async () => {
+    const user = userEvent.setup();
+    startActivity.mockResolvedValue(null);
+
+    render(<UnifiedTimerHome />);
+
+    await user.type(screen.getByRole('combobox', { name: 'Activity name' }), 'Deep work');
+    await user.click(screen.getByRole('button', { name: 'Start' }));
+
+    expect(startActivity).toHaveBeenCalledWith({ text: 'Deep work', limitSeconds: 15 });
   });
 
   it('selecting a suggestion while unlabelled-running labels the timer in place', async () => {

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import UnifiedTimerHome from './UnifiedTimerHome';
+
+const mockUseGame = vi.fn();
+const mockUseSupportFlow = vi.fn();
+const mockUseEntitySearchCache = vi.fn();
+const mockUseDefaultActivityEntries = vi.fn();
+const fetchPlayerAndCharacter = vi.fn();
+const fetchCharacterCurrent = vi.fn();
+const fetchActivities = vi.fn();
+const clearAutoStopCompletion = vi.fn();
+const stop = vi.fn();
+const startActivity = vi.fn();
+const labelActivity = vi.fn();
+const addEntityToCache = vi.fn();
+
+vi.mock('../../hooks/useGame', () => ({
+  useGame: () => mockUseGame(),
+}));
+
+vi.mock('../../hooks/useSupportFlow', () => ({
+  useSupportFlow: (...args: unknown[]) => mockUseSupportFlow(...args),
+}));
+
+vi.mock('../../hooks/useEntitySearchCache', () => ({
+  useEntitySearchCache: (...args: unknown[]) => mockUseEntitySearchCache(...args),
+}));
+
+vi.mock('../../hooks/useDefaultActivityEntries', () => ({
+  useDefaultActivityEntries: () => mockUseDefaultActivityEntries(),
+}));
+
+vi.mock('../SupportFlow/SupportFlowModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../utils/sounds', () => ({
+  playLimitReachedSound: vi.fn(),
+  primeAudio: vi.fn(),
+}));
+
+// Strip animation-only props so React doesn't warn about unknown DOM attrs,
+// and render children synchronously so tests don't need to await exit/enter
+// transitions.
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: React.forwardRef<HTMLDivElement, Record<string, unknown>>((props, ref) => {
+      const { layout, initial, animate, exit, transition, children, ...rest } = props;
+      void layout;
+      void initial;
+      void animate;
+      void exit;
+      void transition;
+      return (
+        <div ref={ref} {...rest}>
+          {children as React.ReactNode}
+        </div>
+      );
+    }),
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>();
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  };
+});
+
+function mockGame(activityTimerOverrides: Record<string, unknown> = {}) {
+  mockUseGame.mockReturnValue({
+    activityTimer: {
+      currentActivity: null,
+      status: 'empty',
+      stop,
+      startActivity,
+      labelActivity,
+      elapsed: 0,
+      limitSeconds: null,
+      limitReached: false,
+      autoStopCompletion: null,
+      clearAutoStopCompletion,
+      ...activityTimerOverrides,
+    },
+    fetchPlayerAndCharacter,
+    fetchCharacterCurrent,
+    fetchActivities,
+    loginState: 'none',
+    loginStreak: 0,
+    loginEventAt: null,
+    player: { is_premium: false },
+    freeTimerLimitSeconds: 15,
+  });
+}
+
+describe('UnifiedTimerHome', () => {
+  beforeEach(() => {
+    mockUseSupportFlow.mockReset();
+    mockUseEntitySearchCache.mockReset();
+    mockUseDefaultActivityEntries.mockReset().mockReturnValue([]);
+    fetchPlayerAndCharacter.mockReset().mockResolvedValue(null);
+    fetchCharacterCurrent.mockReset().mockResolvedValue(null);
+    fetchActivities.mockReset().mockResolvedValue(null);
+    clearAutoStopCompletion.mockReset();
+    stop.mockReset();
+    startActivity.mockReset();
+    labelActivity.mockReset();
+    addEntityToCache.mockReset();
+
+    mockUseSupportFlow.mockReturnValue({
+      openWelcomeMessage: vi.fn(),
+      openActivityReward: vi.fn(),
+      openSupportMode: vi.fn(),
+      flowState: { isOpen: false },
+      flowDispatch: vi.fn(),
+      handleConfirmActivity: vi.fn(),
+    });
+
+    mockUseEntitySearchCache.mockReturnValue({
+      entities: [],
+      addEntityToCache,
+    });
+
+    mockGame();
+  });
+
+  it('renders the input state by default with a Blank Start option', () => {
+    render(<UnifiedTimerHome />);
+
+    expect(screen.getByRole('combobox', { name: 'Activity name' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Start blank' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Start' })).toBeDisabled();
+  });
+
+  it('Blank Start starts a timer and moves to the running-unlabelled state', async () => {
+    const user = userEvent.setup();
+    startActivity.mockResolvedValue(null);
+
+    const { rerender } = render(<UnifiedTimerHome />);
+
+    await user.click(screen.getByRole('button', { name: 'Start blank' }));
+
+    expect(startActivity).toHaveBeenCalledWith({ text: '', allowBlank: true, limitSeconds: 15 });
+
+    // Reflect the timer now being active with a blank name.
+    mockGame({ status: 'active', currentActivity: { name: '' } });
+    rerender(<UnifiedTimerHome />);
+
+    expect(screen.getByRole('combobox', { name: 'Activity name' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+  });
+
+  it('selecting a suggestion while unlabelled-running labels the timer in place', async () => {
+    const user = userEvent.setup();
+    mockGame({ status: 'active', currentActivity: { name: '' } });
+    mockUseDefaultActivityEntries.mockReturnValue([
+      { id: 'activity-1', name: 'Washing dishes', taskId: null, source: 'activity' },
+    ]);
+
+    render(<UnifiedTimerHome />);
+
+    await user.click(screen.getByRole('option', { name: 'Washing dishes' }));
+
+    expect(labelActivity).toHaveBeenCalledWith('Washing dishes', null);
+    expect(startActivity).not.toHaveBeenCalled();
+  });
+
+  it('shows the running-labelled state with a clickable activity name', () => {
+    mockGame({ status: 'active', currentActivity: { name: 'Deep work' }, elapsed: 15 });
+
+    render(<UnifiedTimerHome />);
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Deep work/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+  });
+
+  it('clicking the running-labelled name switches to click-to-edit and pre-fills the input', async () => {
+    const user = userEvent.setup();
+    mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+
+    render(<UnifiedTimerHome />);
+
+    await user.click(screen.getByRole('button', { name: /Deep work/ }));
+
+    expect(screen.getByRole('combobox', { name: 'Activity name' })).toHaveValue('Deep work');
+  });
+
+  it('shows the auto-stop warning near the limit', () => {
+    mockGame({
+      status: 'active',
+      currentActivity: { name: 'Deep work' },
+      elapsed: 27,
+      limitSeconds: 30,
+    });
+
+    render(<UnifiedTimerHome />);
+
+    expect(
+      screen.getByText('This timer will stop automatically when it reaches 0:30.')
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
@@ -10,6 +10,14 @@ import { useActivityInput } from "../ActivityInput/useActivityInput";
 import { useDefaultActivityEntries } from "../../hooks/useDefaultActivityEntries";
 import styles from "./UnifiedTimerHome.module.scss";
 
+const fadeTransition = { duration: 0.18 };
+const fadeProps = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+  transition: fadeTransition,
+};
+
 export default function UnifiedTimerHome() {
   const {
     name,
@@ -38,7 +46,7 @@ export default function UnifiedTimerHome() {
 
   const defaultResults = useDefaultActivityEntries();
   const [submitConfirmOpen, setSubmitConfirmOpen] = useState(false);
-  const listWrapperRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Label display (clickable name) only shows for a labelled, non-editing
   // running timer; every other case shows the list/input (no timer running,
@@ -55,12 +63,20 @@ export default function UnifiedTimerHome() {
   // name is ready to be replaced/confirmed without an extra click.
   useEffect(() => {
     if (!isEditingLabel) return;
-    listWrapperRef.current?.querySelector("input")?.focus();
+    containerRef.current?.querySelector("input")?.focus();
   }, [isEditingLabel]);
 
-  const handleBlankStartClick = async () => {
+  // Single Start button: starts blank if the input is empty, otherwise
+  // starts (or labels) with whatever's typed — same distinction as before,
+  // just collapsed into one action instead of two buttons.
+  const handleStartClick = async () => {
+    if (name.trim()) {
+      await handleToggle();
+      return;
+    }
+
     await handleBlankStart();
-    listWrapperRef.current?.querySelector("input")?.focus();
+    containerRef.current?.querySelector("input")?.focus();
   };
 
   // The blur fired by `.blur()` below happens synchronously, before the
@@ -84,7 +100,7 @@ export default function UnifiedTimerHome() {
       return;
     }
     if (!isEditingLabel) return;
-    if (listWrapperRef.current?.contains(event.relatedTarget as Node)) return;
+    if (containerRef.current?.contains(event.relatedTarget as Node)) return;
     handleLabelBlur();
   };
 
@@ -96,92 +112,88 @@ export default function UnifiedTimerHome() {
           {statusMessage}
         </p>
 
-        <AnimatePresence mode="wait" initial={false}>
-          {showLabelDisplay ? (
-            <motion.div
-              key="labelled"
-              layout
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.18 }}
-              className={styles.runningRow}
-            >
-              <button
-                type="button"
-                className={styles.activityLabel}
-                onClick={startEditingLabel}
-                aria-label={`Editing label: ${inputValue || "Untitled activity"}. Click to change.`}
+        <motion.div
+          className={styles.container}
+          ref={containerRef}
+          onKeyDown={handleWrapperKeyDown}
+          onBlur={handleWrapperBlur}
+        >
+          {/* Row 1, fixed at the top regardless of state: the toggle button
+              is a single persistent element (same key, never unmounted) so
+              Start -> Stop is purely a label change the user perceives as
+              "the same button", not a swap. Centered while idle (alone);
+              once the timer fades in, the pair sits together at the right
+              — `layout` on the row and on the button's wrapper animates
+              that shift smoothly instead of jumping. Row 2 below is
+              unaffected either way. */}
+          <motion.div
+            layout
+            className={styles.controlsRow}
+            style={{ justifyContent: isActive ? "flex-end" : "center" }}
+          >
+            <motion.div layout>
+              <Button
+                onClick={isActive ? handleToggle : handleStartClick}
+                variant="primary"
+                className={styles.ctaButton}
               >
-                {inputValue || "Untitled activity"}
-              </button>
-
-              <div className={styles.timerPill}>
-                {minutes}:{seconds.toString().padStart(2, "0")}
-              </div>
-
-              <Button onClick={handleToggle} variant="primary" className={styles.ctaButton}>
-                Stop
+                {isActive ? "Stop" : "Start"}
               </Button>
             </motion.div>
-          ) : (
-            <motion.div
-              key="input"
-              layout
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.18 }}
-              className={styles.inputRow}
-              ref={listWrapperRef}
-              onKeyDown={handleWrapperKeyDown}
-              onBlur={handleWrapperBlur}
-            >
-              <div className={styles.searchControl}>
-                <EntitySearchInput
-                  type="activity"
-                  value={inputValue}
-                  onChange={setName}
-                  onSelect={handleUnifiedSelect}
-                  onCreate={handleUnifiedSubmit}
-                  placeholder="What are you working on? e.g. washing dishes"
-                  ariaLabel="Activity name"
-                  alwaysOpen
-                  defaultResults={defaultResults}
-                  maxVisibleRows={4}
-                  emptyMessage="No recent activities yet — type to create one."
-                  className={styles.entitySearch}
-                  inputClassName={styles.inputText}
-                />
-              </div>
 
-              {isActive ? (
-                <div className={styles.runningControls}>
-                  <div className={styles.timerPill}>
-                    {minutes}:{seconds.toString().padStart(2, "0")}
-                  </div>
-                  <Button onClick={handleToggle} variant="primary" className={styles.ctaButton}>
-                    Stop
-                  </Button>
-                </div>
-              ) : (
-                <div className={styles.startControls}>
-                  <Button
-                    onClick={handleToggle}
-                    variant="primary"
-                    disabled={!name.trim()}
-                    className={styles.ctaButton}
-                  >
-                    Start
-                  </Button>
-                  <Button onClick={handleBlankStartClick} variant="secondary" className={styles.blankStartButton}>
-                    Start blank
-                  </Button>
-                </div>
+            <AnimatePresence initial={false}>
+              {isActive && (
+                <motion.div key="timer" layout {...fadeProps} className={styles.timerPill}>
+                  {minutes}:{seconds.toString().padStart(2, "0")}
+                </motion.div>
               )}
-            </motion.div>
-          )}
-        </AnimatePresence>
+            </AnimatePresence>
+          </motion.div>
+
+          {/* Row 2: the activity's identity — either its label (clickable to
+              edit) or the search input used to pick/type one. These are
+              mutually exclusive, genuinely different elements, so they
+              cross-fade; row 1 above is entirely unaffected by this swap. */}
+          <motion.div className={styles.entityRow}>
+            <AnimatePresence mode="popLayout" initial={false}>
+              {showLabelDisplay ? (
+                <motion.button
+                  key="label"
+                  {...fadeProps}
+                  type="button"
+                  className={styles.activityLabel}
+                  onClick={startEditingLabel}
+                  aria-label={`Editing label: ${inputValue || "Untitled activity"}. Click to change.`}
+                >
+                  {inputValue || "Untitled activity"}
+                </motion.button>
+              ) : (
+                <motion.div key="search" {...fadeProps} className={styles.searchControl}>
+                  <EntitySearchInput
+                    type="activity"
+                    value={inputValue}
+                    onChange={setName}
+                    onSelect={handleUnifiedSelect}
+                    onCreate={handleUnifiedSubmit}
+                    placeholder="What are you working on? e.g. washing dishes"
+                    ariaLabel="Activity name"
+                    // Always persistent/in-flow (not a floating overlay): a
+                    // floating dropdown here bled outside the wrapper card
+                    // and overlapped the support button below it. Reserving
+                    // its space in-flow lets the card grow to actually
+                    // contain the list instead.
+                    alwaysOpen
+                    defaultResults={defaultResults}
+                    maxVisibleRows={4}
+                    emptyMessage="Looking for a match..."
+                    className={styles.entitySearch}
+                    inputClassName={styles.inputText}
+                  />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </motion.div>
+        </motion.div>
 
         {showAutoStopWarning && (
           <p className={styles.limitWarning}>

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
 
@@ -45,14 +45,44 @@ export default function UnifiedTimerHome() {
   // an unlabelled running timer, or an in-progress click-to-edit).
   const showLabelDisplay = isActive && !isUnlabelled && !isEditingLabel;
 
+  const statusMessage = showLabelDisplay
+    ? `Timer running: ${inputValue || "Untitled activity"}`
+    : isActive
+      ? "Timer running, unlabelled"
+      : "Timer stopped";
+
+  // Click-to-edit needs the input focused immediately so the pre-filled
+  // name is ready to be replaced/confirmed without an extra click.
+  useEffect(() => {
+    if (!isEditingLabel) return;
+    listWrapperRef.current?.querySelector("input")?.focus();
+  }, [isEditingLabel]);
+
+  const handleBlankStartClick = async () => {
+    await handleBlankStart();
+    listWrapperRef.current?.querySelector("input")?.focus();
+  };
+
+  // The blur fired by `.blur()` below happens synchronously, before the
+  // setIsEditingLabel(false) from handleLabelCancel has flushed — so
+  // handleWrapperBlur's `isEditingLabel` closure would still read `true`
+  // and wrongly commit the cancelled edit. This ref sidesteps the stale
+  // closure without waiting on a render.
+  const justCancelledRef = useRef(false);
+
   const handleWrapperKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Escape" && isEditingLabel) {
+      justCancelledRef.current = true;
       handleLabelCancel();
       (event.target as HTMLElement).blur();
     }
   };
 
   const handleWrapperBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    if (justCancelledRef.current) {
+      justCancelledRef.current = false;
+      return;
+    }
     if (!isEditingLabel) return;
     if (listWrapperRef.current?.contains(event.relatedTarget as Node)) return;
     handleLabelBlur();
@@ -60,11 +90,11 @@ export default function UnifiedTimerHome() {
 
   return (
     <>
-      <section
-        className={classNames(styles.wrapper, { [styles.isActive]: isActive })}
-        aria-live="polite"
-      >
+      <section className={classNames(styles.wrapper, { [styles.isActive]: isActive })}>
         <h2 className="sr-only">Activity timer</h2>
+        <p className="sr-only" aria-live="polite">
+          {statusMessage}
+        </p>
 
         <AnimatePresence mode="wait" initial={false}>
           {showLabelDisplay ? (
@@ -144,7 +174,7 @@ export default function UnifiedTimerHome() {
                   >
                     Start
                   </Button>
-                  <Button onClick={handleBlankStart} variant="secondary" className={styles.blankStartButton}>
+                  <Button onClick={handleBlankStartClick} variant="secondary" className={styles.blankStartButton}>
                     Start blank
                   </Button>
                 </div>

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
@@ -141,7 +141,7 @@ export default function UnifiedTimerHome() {
               </Button>
             </motion.div>
 
-            <AnimatePresence initial={false}>
+            <AnimatePresence mode="popLayout" initial={false}>
               {isActive && (
                 <motion.div key="timer" layout {...fadeProps} className={styles.timerPill}>
                   {minutes}:{seconds.toString().padStart(2, "0")}

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
@@ -1,0 +1,200 @@
+import React, { useRef, useState } from "react";
+import classNames from "classnames";
+import { AnimatePresence, motion } from "framer-motion";
+
+import Button from "../Button/Button";
+import AlertDialog from "../AlertDialog/AlertDialog";
+import EntitySearchInput from "../EntitySearchInput/EntitySearchInput";
+import SupportFlowModal from "../SupportFlow/SupportFlowModal";
+import { useActivityInput } from "../ActivityInput/useActivityInput";
+import { useDefaultActivityEntries } from "../../hooks/useDefaultActivityEntries";
+import styles from "./UnifiedTimerHome.module.scss";
+
+export default function UnifiedTimerHome() {
+  const {
+    name,
+    setName,
+    isActive,
+    isUnlabelled,
+    isEditingLabel,
+    inputValue,
+    minutes,
+    seconds,
+    formattedLimit,
+    showAutoStopWarning,
+    flowState,
+    flowDispatch,
+    handleConfirmActivity,
+    handleToggle,
+    handleBlankStart,
+    handleUnifiedSelect,
+    handleUnifiedSubmit,
+    startEditingLabel,
+    handleLabelBlur,
+    handleLabelCancel,
+    submitAndOpenSupport,
+    openSupportMode,
+  } = useActivityInput();
+
+  const defaultResults = useDefaultActivityEntries();
+  const [submitConfirmOpen, setSubmitConfirmOpen] = useState(false);
+  const listWrapperRef = useRef<HTMLDivElement>(null);
+
+  // Label display (clickable name) only shows for a labelled, non-editing
+  // running timer; every other case shows the list/input (no timer running,
+  // an unlabelled running timer, or an in-progress click-to-edit).
+  const showLabelDisplay = isActive && !isUnlabelled && !isEditingLabel;
+
+  const handleWrapperKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape" && isEditingLabel) {
+      handleLabelCancel();
+      (event.target as HTMLElement).blur();
+    }
+  };
+
+  const handleWrapperBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    if (!isEditingLabel) return;
+    if (listWrapperRef.current?.contains(event.relatedTarget as Node)) return;
+    handleLabelBlur();
+  };
+
+  return (
+    <>
+      <section
+        className={classNames(styles.wrapper, { [styles.isActive]: isActive })}
+        aria-live="polite"
+      >
+        <h2 className="sr-only">Activity timer</h2>
+
+        <AnimatePresence mode="wait" initial={false}>
+          {showLabelDisplay ? (
+            <motion.div
+              key="labelled"
+              layout
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.18 }}
+              className={styles.runningRow}
+            >
+              <button
+                type="button"
+                className={styles.activityLabel}
+                onClick={startEditingLabel}
+                aria-label={`Editing label: ${inputValue || "Untitled activity"}. Click to change.`}
+              >
+                {inputValue || "Untitled activity"}
+              </button>
+
+              <div className={styles.timerPill}>
+                {minutes}:{seconds.toString().padStart(2, "0")}
+              </div>
+
+              <Button onClick={handleToggle} variant="primary" className={styles.ctaButton}>
+                Stop
+              </Button>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="input"
+              layout
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.18 }}
+              className={styles.inputRow}
+              ref={listWrapperRef}
+              onKeyDown={handleWrapperKeyDown}
+              onBlur={handleWrapperBlur}
+            >
+              <div className={styles.searchControl}>
+                <EntitySearchInput
+                  type="activity"
+                  value={inputValue}
+                  onChange={setName}
+                  onSelect={handleUnifiedSelect}
+                  onCreate={handleUnifiedSubmit}
+                  placeholder="What are you working on? e.g. washing dishes"
+                  ariaLabel="Activity name"
+                  alwaysOpen
+                  defaultResults={defaultResults}
+                  maxVisibleRows={4}
+                  emptyMessage="No recent activities yet — type to create one."
+                  className={styles.entitySearch}
+                  inputClassName={styles.inputText}
+                />
+              </div>
+
+              {isActive ? (
+                <div className={styles.runningControls}>
+                  <div className={styles.timerPill}>
+                    {minutes}:{seconds.toString().padStart(2, "0")}
+                  </div>
+                  <Button onClick={handleToggle} variant="primary" className={styles.ctaButton}>
+                    Stop
+                  </Button>
+                </div>
+              ) : (
+                <div className={styles.startControls}>
+                  <Button
+                    onClick={handleToggle}
+                    variant="primary"
+                    disabled={!name.trim()}
+                    className={styles.ctaButton}
+                  >
+                    Start
+                  </Button>
+                  <Button onClick={handleBlankStart} variant="secondary" className={styles.blankStartButton}>
+                    Start blank
+                  </Button>
+                </div>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {showAutoStopWarning && (
+          <p className={styles.limitWarning}>
+            This timer will stop automatically when it reaches {formattedLimit}.
+          </p>
+        )}
+
+        <div className={styles.supportButtonRow}>
+          <Button
+            onClick={() => {
+              if (isActive) {
+                setSubmitConfirmOpen(true);
+              } else {
+                openSupportMode();
+              }
+            }}
+            variant="secondary"
+            className={styles.supportModeButton}
+            ariaLabel="Open support mode"
+          >
+            Need support?
+          </Button>
+        </div>
+      </section>
+
+      <AlertDialog
+        open={submitConfirmOpen}
+        title="Submit active timer?"
+        description="You already have a timer running. Submit it before opening Task Support?"
+        confirmLabel="Submit & continue"
+        cancelLabel="Cancel"
+        onCancel={() => setSubmitConfirmOpen(false)}
+        onConfirm={() => {
+          setSubmitConfirmOpen(false);
+          submitAndOpenSupport();
+        }}
+      />
+
+      <SupportFlowModal
+        state={flowState}
+        dispatch={flowDispatch}
+        onConfirmActivity={handleConfirmActivity}
+      />
+    </>
+  );
+}

--- a/frontend/src/featureFlags.ts
+++ b/frontend/src/featureFlags.ts
@@ -11,6 +11,7 @@ const featureFlags: Record<FeatureFlagKey, FeatureFlagValue> = {
   skillsPage: ['all'],
   projectsPage: ['all'],
   toastsFeature: [],
+  unified_homepage: [],
 };
 
 export default featureFlags;

--- a/frontend/src/hooks/useActivityTimer.test.tsx
+++ b/frontend/src/hooks/useActivityTimer.test.tsx
@@ -143,4 +143,128 @@ describe('useActivityTimer', () => {
 
     expect(mockPlayActivityStartedSound).toHaveBeenCalledTimes(1);
   });
+
+  it('rejects a blank start without allowBlank', async () => {
+    const { result } = renderHook(() => useActivityTimer());
+
+    await act(async () => {
+      const outcome = await result.current.startActivity({ text: '' });
+      expect(outcome).toBeNull();
+    });
+
+    expect(mockApiFetch).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('empty');
+  });
+
+  it('starts an unlabelled timer when allowBlank is set', async () => {
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url === '/activity_timers/set_activity/') {
+        return Promise.resolve({
+          activity_timer: { activity: { id: 1, name: '' } },
+        });
+      }
+
+      if (url === '/activity_timers/start/') {
+        return Promise.resolve({ success: true });
+      }
+
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    const { result } = renderHook(() => useActivityTimer());
+
+    await act(async () => {
+      await result.current.startActivity({ text: '', allowBlank: true });
+    });
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/activity_timers/set_activity/',
+      expect.objectContaining({
+        body: JSON.stringify({ activityName: '', task_id: null, duration: 0 }),
+      })
+    );
+    expect(result.current.status).toBe('active');
+    expect(result.current.currentActivity?.name).toBe('');
+  });
+
+  it('labelActivity renames the running activity without resetting elapsed time', async () => {
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url === '/activity_timers/set_activity/') {
+        return Promise.resolve({
+          activity_timer: { activity: { id: 1, name: '' } },
+        });
+      }
+
+      if (url === '/activity_timers/start/') {
+        return Promise.resolve({ success: true });
+      }
+
+      if (url === '/activity_timers/label_activity/') {
+        return Promise.resolve({
+          activity_timer: { activity: { id: 1, name: 'Deep work' } },
+        });
+      }
+
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    const { result } = renderHook(() => useActivityTimer());
+
+    await act(async () => {
+      await result.current.startActivity({ text: '', allowBlank: true });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    const elapsedBeforeLabel = result.current.elapsed;
+    expect(elapsedBeforeLabel).toBeGreaterThan(0);
+
+    await act(async () => {
+      await result.current.labelActivity('Deep work');
+    });
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/activity_timers/label_activity/',
+      expect.objectContaining({
+        body: JSON.stringify({ activityName: 'Deep work', task_id: null }),
+      })
+    );
+    expect(result.current.currentActivity?.name).toBe('Deep work');
+    expect(result.current.status).toBe('active');
+    expect(result.current.elapsed).toBe(elapsedBeforeLabel);
+  });
+
+  it('labelActivity rolls back the optimistic name on failure', async () => {
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url === '/activity_timers/set_activity/') {
+        return Promise.resolve({
+          activity_timer: { activity: { id: 1, name: 'Original' } },
+        });
+      }
+
+      if (url === '/activity_timers/start/') {
+        return Promise.resolve({ success: true });
+      }
+
+      if (url === '/activity_timers/label_activity/') {
+        return Promise.reject(new Error('network error'));
+      }
+
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    const { result } = renderHook(() => useActivityTimer());
+
+    await act(async () => {
+      await result.current.startActivity({ text: 'Original' });
+    });
+
+    await act(async () => {
+      await expect(result.current.labelActivity('New name')).rejects.toThrow('network error');
+    });
+
+    expect(result.current.currentActivity?.name).toBe('Original');
+  });
 });

--- a/frontend/src/hooks/useActivityTimer.ts
+++ b/frontend/src/hooks/useActivityTimer.ts
@@ -98,17 +98,19 @@ export default function useActivityTimer(): ActivityTimerReturn {
 
 
   const startActivity = useCallback(async (newActivity: StartActivityInput | string): Promise<unknown> => {
-    const { text, taskId, limitSeconds: newLimit, limitReason = null } =
+    const { text, taskId, limitSeconds: newLimit, limitReason = null, allowBlank = false } =
       typeof newActivity === "string"
-        ? { text: newActivity, taskId: null, limitSeconds: null, limitReason: null }
+        ? { text: newActivity, taskId: null, limitSeconds: null, limitReason: null, allowBlank: false }
         : newActivity || {};
 
-    if (!text?.trim()) return null;
+    if (!text?.trim() && !allowBlank) return null;
+
+    const trimmedText = (text ?? "").trim();
 
     primeAudio(); // unlock AudioContext while still in user-gesture context
 
     // Optimistic local state
-    setCurrentActivity({ text: text.trim(), taskId });
+    setCurrentActivity({ text: trimmedText, taskId });
     setStatus("active");
     setElapsed(0);
     pausedTimeRef.current = 0;
@@ -135,7 +137,7 @@ export default function useActivityTimer(): ActivityTimerReturn {
       const setData = await apiFetch<{ activity_timer?: { activity?: CurrentActivity } }>(`/activity_timers/set_activity/`, {
         method: "POST",
         body: JSON.stringify({
-          activityName: text.trim(),
+          activityName: trimmedText,
           task_id: taskId ?? null,
           duration: 0,
         }),
@@ -181,6 +183,40 @@ export default function useActivityTimer(): ActivityTimerReturn {
       throw err;
     }
   }, [normalizeLimitSeconds, tickMain]);
+
+
+  // ----------------------------
+  // Label (rename in place) the running activity
+  // ----------------------------
+
+
+  const labelActivity = useCallback(async (name: string, taskId: number | null = null): Promise<unknown> => {
+    const trimmedName = (name ?? "").trim();
+    const previousActivity = currentActivityRef.current;
+
+    // Optimistic local update — unlike startActivity, elapsed/status/timer
+    // refs are left untouched so in-progress timing isn't lost.
+    setCurrentActivity((prev) => ({ ...(prev ?? {}), name: trimmedName, text: trimmedName, taskId }));
+
+    try {
+      const data = await apiFetch<{ activity_timer?: { activity?: CurrentActivity } }>(`/activity_timers/label_activity/`, {
+        method: "POST",
+        body: JSON.stringify({
+          activityName: trimmedName,
+          task_id: taskId ?? null,
+        }),
+      });
+
+      const serverActivity = data?.activity_timer?.activity;
+      if (serverActivity) setCurrentActivity({ taskId, ...serverActivity });
+
+      return data;
+    } catch (err) {
+      console.error("Failed to label activity:", err);
+      setCurrentActivity(previousActivity);
+      throw err;
+    }
+  }, []);
 
 
   // ----------------------------
@@ -379,6 +415,7 @@ export default function useActivityTimer(): ActivityTimerReturn {
     autoStopCompletion,
     currentActivity,
     startActivity,
+    labelActivity,
     stop,
     loadFromServer,
     clearAutoStopCompletion,

--- a/frontend/src/hooks/useDefaultActivityEntries.test.ts
+++ b/frontend/src/hooks/useDefaultActivityEntries.test.ts
@@ -1,0 +1,132 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDefaultActivityEntries } from "./useDefaultActivityEntries";
+
+const mockUseGame = vi.fn();
+const mockUseTasks = vi.fn();
+const mockUseFeatureFlag = vi.fn();
+
+vi.mock("./useGame", () => ({
+  useGame: () => mockUseGame(),
+}));
+
+vi.mock("./useTasks", () => ({
+  useTasks: (...args: unknown[]) => mockUseTasks(...args),
+}));
+
+vi.mock("./useFeatureFlag", () => ({
+  useFeatureFlag: () => mockUseFeatureFlag(),
+}));
+
+describe("useDefaultActivityEntries", () => {
+  beforeEach(() => {
+    mockUseGame.mockReset();
+    mockUseTasks.mockReset();
+    mockUseFeatureFlag.mockReset();
+    mockUseFeatureFlag.mockReturnValue(true);
+  });
+
+  it("collapses activities linked to an incomplete task into a single task row", () => {
+    mockUseGame.mockReturnValue({
+      playerActivities: [
+        { id: 1, name: "Write report", task: 10, completed_at: "2026-01-01T00:00:00Z" },
+        { id: 2, name: "Write report", task: 10, completed_at: "2026-01-03T00:00:00Z" },
+      ],
+      characterActivities: [],
+    });
+    mockUseTasks.mockReturnValue({
+      data: [{ id: 10, name: "Write report", is_complete: false, completed_at: null, last_worked_on: null, created_at: "2025-12-01T00:00:00Z" }],
+    });
+
+    const { result } = renderHook(() => useDefaultActivityEntries());
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({ name: "Write report", source: "task", taskId: 10 });
+  });
+
+  it("shows unlinked activities as themselves and drops activities linked to a completed task", () => {
+    mockUseGame.mockReturnValue({
+      playerActivities: [
+        { id: 1, name: "Washing dishes", task: null, completed_at: "2026-01-01T00:00:00Z" },
+        { id: 2, name: "Old finished task work", task: 99, completed_at: "2026-01-02T00:00:00Z" },
+      ],
+      characterActivities: [],
+    });
+    mockUseTasks.mockReturnValue({
+      data: [{ id: 99, name: "Old finished task", is_complete: true, completed_at: "2026-01-02T00:00:00Z", last_worked_on: null, created_at: "2025-12-01T00:00:00Z" }],
+    });
+
+    const { result } = renderHook(() => useDefaultActivityEntries());
+
+    expect(result.current.map((entry) => entry.name)).toEqual(["Washing dishes"]);
+    expect(result.current.every((entry) => entry.source === "activity")).toBe(true);
+  });
+
+  it("includes incomplete tasks that have no activity history yet", () => {
+    mockUseGame.mockReturnValue({ playerActivities: [], characterActivities: [] });
+    mockUseTasks.mockReturnValue({
+      data: [{ id: 5, name: "Brand new task", is_complete: false, completed_at: null, last_worked_on: null, created_at: "2026-01-05T00:00:00Z" }],
+    });
+
+    const { result } = renderHook(() => useDefaultActivityEntries());
+
+    expect(result.current).toEqual([
+      expect.objectContaining({ name: "Brand new task", source: "task", taskId: 5 }),
+    ]);
+  });
+
+  it("sorts entries by recency, most recent first", () => {
+    mockUseGame.mockReturnValue({
+      playerActivities: [
+        { id: 1, name: "Older activity", task: null, completed_at: "2026-01-01T00:00:00Z" },
+        { id: 2, name: "Newer activity", task: null, completed_at: "2026-01-10T00:00:00Z" },
+      ],
+      characterActivities: [],
+    });
+    mockUseTasks.mockReturnValue({ data: [] });
+
+    const { result } = renderHook(() => useDefaultActivityEntries());
+
+    expect(result.current.map((entry) => entry.name)).toEqual(["Newer activity", "Older activity"]);
+  });
+
+  it("caps the default view to the 4 most recent entries", () => {
+    mockUseGame.mockReturnValue({
+      playerActivities: [
+        { id: 1, name: "Activity 1", task: null, completed_at: "2026-01-01T00:00:00Z" },
+        { id: 2, name: "Activity 2", task: null, completed_at: "2026-01-02T00:00:00Z" },
+        { id: 3, name: "Activity 3", task: null, completed_at: "2026-01-03T00:00:00Z" },
+        { id: 4, name: "Activity 4", task: null, completed_at: "2026-01-04T00:00:00Z" },
+        { id: 5, name: "Activity 5", task: null, completed_at: "2026-01-05T00:00:00Z" },
+      ],
+      characterActivities: [],
+    });
+    mockUseTasks.mockReturnValue({ data: [] });
+
+    const { result } = renderHook(() => useDefaultActivityEntries());
+
+    expect(result.current.map((entry) => entry.name)).toEqual([
+      "Activity 5",
+      "Activity 4",
+      "Activity 3",
+      "Activity 2",
+    ]);
+  });
+
+  it("includes character activities as standalone entries", () => {
+    mockUseGame.mockReturnValue({
+      playerActivities: [],
+      characterActivities: [
+        { id: 1, name: "", kind: "training", completed_at: "2026-01-01T00:00:00Z" },
+      ],
+    });
+    mockUseTasks.mockReturnValue({ data: [] });
+
+    const { result } = renderHook(() => useDefaultActivityEntries());
+
+    expect(result.current).toEqual([
+      expect.objectContaining({ name: "training", source: "activity", taskId: null }),
+    ]);
+  });
+});

--- a/frontend/src/hooks/useDefaultActivityEntries.test.ts
+++ b/frontend/src/hooks/useDefaultActivityEntries.test.ts
@@ -114,6 +114,23 @@ describe("useDefaultActivityEntries", () => {
     ]);
   });
 
+  it("collapses repeated standalone activities with the same name into one row", () => {
+    mockUseGame.mockReturnValue({
+      playerActivities: [
+        { id: 1, name: "Flow test activity", task: null, completed_at: "2026-01-01T00:00:00Z" },
+        { id: 2, name: "Flow test activity", task: null, completed_at: "2026-01-05T00:00:00Z" },
+        { id: 3, name: "flow test activity", task: null, completed_at: "2026-01-03T00:00:00Z" },
+      ],
+      characterActivities: [],
+    });
+    mockUseTasks.mockReturnValue({ data: [] });
+
+    const { result } = renderHook(() => useDefaultActivityEntries());
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({ name: "Flow test activity", source: "activity" });
+  });
+
   it("includes character activities as standalone entries", () => {
     mockUseGame.mockReturnValue({
       playerActivities: [],

--- a/frontend/src/hooks/useDefaultActivityEntries.ts
+++ b/frontend/src/hooks/useDefaultActivityEntries.ts
@@ -49,7 +49,20 @@ export function useDefaultActivityEntries(): SearchEntity[] {
       });
     });
 
-    const standalone: RankedEntity[] = [];
+    // Repeated activities (same name, different PlayerActivity/CharacterActivity
+    // rows — e.g. "Washing dishes" done on separate days) collapse into one
+    // row keyed by name, keeping whichever occurrence is most recent.
+    const standaloneByName = new Map<string, RankedEntity>();
+
+    function upsertStandalone(entry: RankedEntity) {
+      const key = entry.nameKey ?? "";
+      const existing = standaloneByName.get(key);
+      if (existing) {
+        if (entry.recency > existing.recency) existing.recency = entry.recency;
+        return;
+      }
+      standaloneByName.set(key, entry);
+    }
 
     (playerActivities ?? []).forEach((activity: PlayerActivity) => {
       const name = (activity.name || "").trim();
@@ -64,7 +77,7 @@ export function useDefaultActivityEntries(): SearchEntity[] {
         return;
       }
 
-      standalone.push({
+      upsertStandalone({
         id: `activity-${activity.id}`,
         name,
         nameKey: toNameKey(name),
@@ -78,7 +91,7 @@ export function useDefaultActivityEntries(): SearchEntity[] {
       const name = (activity.name || activity.kind || "").trim();
       if (!name) return;
 
-      standalone.push({
+      upsertStandalone({
         id: `character-activity-${activity.id}`,
         name,
         nameKey: toNameKey(name),
@@ -88,7 +101,7 @@ export function useDefaultActivityEntries(): SearchEntity[] {
       });
     });
 
-    return [...rowsByTaskId.values(), ...standalone]
+    return [...rowsByTaskId.values(), ...standaloneByName.values()]
       .sort((a, b) => b.recency - a.recency)
       .slice(0, MAX_DEFAULT_ENTRIES)
       .map((entity): SearchEntity => ({

--- a/frontend/src/hooks/useDefaultActivityEntries.ts
+++ b/frontend/src/hooks/useDefaultActivityEntries.ts
@@ -1,0 +1,102 @@
+import { useMemo } from "react";
+
+import { useGame } from "./useGame";
+import { useTasks } from "./useTasks";
+import { useFeatureFlag } from "./useFeatureFlag";
+import type { SearchEntity } from "../components/EntitySearchInput/useEntitySearchInput";
+import type { CharacterActivity, PlayerActivity, Task } from "../types";
+
+function toEpoch(value: string | null | undefined): number {
+  return value ? new Date(value).getTime() : 0;
+}
+
+function toNameKey(name: string): string {
+  return name.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+type RankedEntity = SearchEntity & { recency: number };
+
+/** How many rows the default (empty-query) view shows, most recent first. */
+const MAX_DEFAULT_ENTRIES = 4;
+
+/**
+ * Builds the default (empty-query) view for the unified activity list:
+ * incomplete tasks (collapsing any activities linked to them), plus
+ * standalone activities that aren't linked to an incomplete task, sorted
+ * by recency and capped to the most recent MAX_DEFAULT_ENTRIES rows.
+ */
+export function useDefaultActivityEntries(): SearchEntity[] {
+  const { playerActivities, characterActivities } = useGame();
+  const hasTasksFeature = useFeatureFlag("tasksFeature");
+  const { data: tasks } = useTasks({ enabled: hasTasksFeature });
+
+  return useMemo(() => {
+    const rowsByTaskId = new Map<number, RankedEntity>();
+    const completedTaskIds = new Set<number>();
+
+    (tasks ?? []).forEach((task: Task) => {
+      if (task.is_complete || task.completed_at) {
+        completedTaskIds.add(task.id);
+        return;
+      }
+      rowsByTaskId.set(task.id, {
+        id: `task-${task.id}`,
+        name: task.name,
+        nameKey: toNameKey(task.name),
+        taskId: task.id,
+        source: "task",
+        recency: toEpoch(task.last_worked_on ?? task.created_at),
+      });
+    });
+
+    const standalone: RankedEntity[] = [];
+
+    (playerActivities ?? []).forEach((activity: PlayerActivity) => {
+      const name = (activity.name || "").trim();
+      if (!name) return;
+      if (activity.task != null && completedTaskIds.has(activity.task)) return;
+
+      const recency = toEpoch(activity.completed_at ?? activity.last_updated ?? activity.created_at);
+      const linkedRow = activity.task != null ? rowsByTaskId.get(activity.task) : undefined;
+
+      if (linkedRow) {
+        if (recency > linkedRow.recency) linkedRow.recency = recency;
+        return;
+      }
+
+      standalone.push({
+        id: `activity-${activity.id}`,
+        name,
+        nameKey: toNameKey(name),
+        taskId: null,
+        source: "activity",
+        recency,
+      });
+    });
+
+    (characterActivities ?? []).forEach((activity: CharacterActivity) => {
+      const name = (activity.name || activity.kind || "").trim();
+      if (!name) return;
+
+      standalone.push({
+        id: `character-activity-${activity.id}`,
+        name,
+        nameKey: toNameKey(name),
+        taskId: null,
+        source: "activity",
+        recency: toEpoch(activity.completed_at ?? activity.last_updated ?? activity.created_at),
+      });
+    });
+
+    return [...rowsByTaskId.values(), ...standalone]
+      .sort((a, b) => b.recency - a.recency)
+      .slice(0, MAX_DEFAULT_ENTRIES)
+      .map((entity): SearchEntity => ({
+        id: entity.id,
+        name: entity.name,
+        nameKey: entity.nameKey,
+        taskId: entity.taskId,
+        source: entity.source,
+      }));
+  }, [playerActivities, characterActivities, tasks]);
+}

--- a/frontend/src/pages/Game2/ActivityTimelinePage.tsx
+++ b/frontend/src/pages/Game2/ActivityTimelinePage.tsx
@@ -1,18 +1,27 @@
 import React from "react";
 import ActivityTimeline from "../../components/ActivityTimeline/ActivityTimeline";
 import CurrentActivity from "../../components/CurrentActivity/CurrentActivity";
+import UnifiedTimerHome from "../../components/UnifiedTimerHome/UnifiedTimerHome";
 import Infobar from "../../layout/Infobar/Infobar";
+import { useFeatureFlag } from "../../hooks/useFeatureFlag";
 import styles from "./ActivityTimelinePage.module.scss";
 
 export default function ActivityTimelinePage(): React.ReactElement {
+  const isUnifiedHomepage = useFeatureFlag("unified_homepage");
 
   return (
     <div className={styles.page}>
       <div className={styles.content}>
         <h1 className="sr-only">Timer</h1>
         <Infobar />
-        <CurrentActivity />
-        <ActivityTimeline />
+        {isUnifiedHomepage ? (
+          <UnifiedTimerHome />
+        ) : (
+          <>
+            <CurrentActivity />
+            <ActivityTimeline />
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/types/enums.ts
+++ b/frontend/src/types/enums.ts
@@ -19,7 +19,8 @@ export type FeatureFlagKey =
   | "categoriesPage"
   | "skillsPage"
   | "projectsPage"
-  | "toastsFeature";
+  | "toastsFeature"
+  | "unified_homepage";
 
 // ---------------------------------------------------------------------------
 // Timer statuses (Timer.STATUS_CHOICES in gameplay/models.py)

--- a/frontend/src/types/timers.ts
+++ b/frontend/src/types/timers.ts
@@ -77,6 +77,8 @@ export interface StartActivityInput {
   limitSeconds?: number | null;
   /** Human-readable reason for the limit (shown in auto-stop notification) */
   limitReason?: string | null;
+  /** Explicitly allow starting with blank/empty text (e.g. "Blank Start") */
+  allowBlank?: boolean;
 }
 
 /**
@@ -104,6 +106,12 @@ export interface ActivityTimerReturn {
   autoStopCompletion: AutoStopCompletion | null;
   currentActivity: CurrentActivity | null;
   startActivity: (newActivity: StartActivityInput | string) => Promise<unknown>;
+  /**
+   * Rename (and optionally re-link to a task) the activity already assigned
+   * to a running/waiting timer, in place — unlike startActivity, this does
+   * not reset elapsed time or status.
+   */
+  labelActivity: (name: string, taskId?: number | null) => Promise<unknown>;
   stop: (opts?: {
     activityName?: string;
     elapsedSeconds?: number;

--- a/frontend/tests/flows/unified-timer-home.spec.ts
+++ b/frontend/tests/flows/unified-timer-home.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test';
+import { stabilizeTimerPage } from '../utils/authenticatedPage';
+
+test.describe('Unified timer homepage (flag on)', () => {
+  test.use({ storageState: 'playwright/.auth/user.json' });
+
+  test('blank start, label, click-to-edit, and stop happy path', async ({ page }) => {
+    await stabilizeTimerPage(page, { unifiedHomepage: true });
+
+    try {
+      await page.goto('/timer');
+      await expect(page.getByRole('heading', { name: 'Activity timer' })).toBeAttached();
+
+      const section = page.locator('section').filter({
+        has: page.getByRole('heading', { name: 'Activity timer' }),
+      });
+
+      // Legacy "Recent activities" feed is not rendered under the flag.
+      await expect(page.getByRole('heading', { name: 'Recent activities' })).toHaveCount(0);
+
+      await section.getByRole('button', { name: 'Start blank' }).click();
+      await expect(section.getByRole('button', { name: 'Stop' })).toBeVisible();
+
+      const input = section.getByRole('combobox', { name: 'Activity name' });
+      await expect(input).toBeVisible();
+      await input.fill('Flow test activity');
+      await input.press('Enter');
+
+      const labelButton = section.getByRole('button', { name: /Flow test activity/ });
+      await expect(labelButton).toBeVisible();
+      await expect(section.getByRole('combobox')).toHaveCount(0);
+
+      // Click-to-edit: re-opens the input pre-filled with the current label.
+      await labelButton.click();
+      const editInput = section.getByRole('combobox', { name: 'Activity name' });
+      await expect(editInput).toHaveValue('Flow test activity');
+
+      // Escape cancels — no request, label unchanged.
+      await editInput.press('Escape');
+      await expect(section.getByRole('button', { name: /Flow test activity/ })).toBeVisible();
+
+      await section.getByRole('button', { name: 'Stop' }).click();
+
+      // Stopping opens the activity-complete reward dialog (shared with the
+      // legacy flow via useSupportFlow) — dismiss it to get back to the input state.
+      await page.getByRole('button', { name: 'Back to timer' }).click();
+
+      await expect(section.getByRole('button', { name: 'Start blank' })).toBeVisible();
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
+  });
+});
+
+test.describe('Unified timer homepage (flag off regression guard)', () => {
+  test.use({ storageState: 'playwright/.auth/user.json' });
+
+  test('renders the legacy timer + activity feed unchanged', async ({ page }) => {
+    await stabilizeTimerPage(page, { unifiedHomepage: false });
+
+    try {
+      await page.goto('/timer');
+      await expect(page.getByRole('heading', { name: 'Activity timer' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Recent activities' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Start blank' })).toHaveCount(0);
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
+  });
+});

--- a/frontend/tests/flows/unified-timer-home.spec.ts
+++ b/frontend/tests/flows/unified-timer-home.spec.ts
@@ -3,6 +3,10 @@ import { stabilizeTimerPage } from '../utils/authenticatedPage';
 
 test.describe('Unified timer homepage (flag on)', () => {
   test.use({ storageState: 'playwright/.auth/user.json' });
+  // Both tests below drive the same seeded test user's single activity timer
+  // against the real backend — running them concurrently races Start/Stop
+  // calls against each other, so force this suite to run serially.
+  test.describe.configure({ mode: 'serial' });
 
   test('blank start, label, click-to-edit, and stop happy path', async ({ page }) => {
     await stabilizeTimerPage(page, { unifiedHomepage: true });
@@ -18,7 +22,10 @@ test.describe('Unified timer homepage (flag on)', () => {
       // Legacy "Recent activities" feed is not rendered under the flag.
       await expect(page.getByRole('heading', { name: 'Recent activities' })).toHaveCount(0);
 
-      await section.getByRole('button', { name: 'Start blank' }).click();
+      // A single Start button, always enabled — starts blank when the input is empty.
+      const startButton = section.getByRole('button', { name: 'Start' });
+      await expect(startButton).toBeEnabled();
+      await startButton.click();
       await expect(section.getByRole('button', { name: 'Stop' })).toBeVisible();
 
       const input = section.getByRole('combobox', { name: 'Activity name' });
@@ -35,6 +42,14 @@ test.describe('Unified timer homepage (flag on)', () => {
       const editInput = section.getByRole('combobox', { name: 'Activity name' });
       await expect(editInput).toHaveValue('Flow test activity');
 
+      // Select-all + Backspace should actually clear the field, not silently
+      // revert to the still-uncommitted original name.
+      await editInput.click();
+      await editInput.press('ControlOrMeta+a');
+      await editInput.press('Backspace');
+      await expect(editInput).toHaveValue('');
+      await editInput.fill('Flow test activity');
+
       // Escape cancels — no request, label unchanged.
       await editInput.press('Escape');
       await expect(section.getByRole('button', { name: /Flow test activity/ })).toBeVisible();
@@ -45,7 +60,29 @@ test.describe('Unified timer homepage (flag on)', () => {
       // legacy flow via useSupportFlow) — dismiss it to get back to the input state.
       await page.getByRole('button', { name: 'Back to timer' }).click();
 
-      await expect(section.getByRole('button', { name: 'Start blank' })).toBeVisible();
+      await expect(section.getByRole('button', { name: 'Start' })).toBeVisible();
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
+  });
+
+  test('the reward dialog opened from Stop is never covered by the persistent list', async ({ page }) => {
+    await stabilizeTimerPage(page, { unifiedHomepage: true });
+
+    try {
+      await page.goto('/timer');
+      const section = page.locator('section').filter({
+        has: page.getByRole('heading', { name: 'Activity timer' }),
+      });
+
+      await section.getByRole('button', { name: 'Start' }).click();
+      await section.getByRole('button', { name: 'Stop' }).click();
+
+      const dialog = page.getByRole('dialog', { name: 'Activity complete!' });
+      await expect(dialog).toBeVisible();
+      // The persistent list must not paint above the modal overlay.
+      await expect(dialog.getByRole('button', { name: 'Back to timer' })).toBeInViewport();
+      await dialog.getByRole('button', { name: 'Back to timer' }).click();
     } finally {
       await page.unrouteAll({ behavior: 'ignoreErrors' });
     }
@@ -62,7 +99,8 @@ test.describe('Unified timer homepage (flag off regression guard)', () => {
       await page.goto('/timer');
       await expect(page.getByRole('heading', { name: 'Activity timer' })).toBeVisible();
       await expect(page.getByRole('heading', { name: 'Recent activities' })).toBeVisible();
-      await expect(page.getByRole('button', { name: 'Start blank' })).toHaveCount(0);
+      // Legacy search is a transient dropdown, not a persistent list.
+      await expect(page.getByRole('listbox')).toHaveCount(0);
     } finally {
       await page.unrouteAll({ behavior: 'ignoreErrors' });
     }

--- a/frontend/tests/utils/authenticatedPage.ts
+++ b/frontend/tests/utils/authenticatedPage.ts
@@ -75,7 +75,7 @@ function withSettledTimerBootstrap(payload: unknown): unknown {
   };
 }
 
-function withStableAppConfig(payload: unknown): unknown {
+function withStableAppConfig(payload: unknown, opts: { unifiedHomepage?: boolean } = {}): unknown {
   if (!isJsonRecord(payload)) {
     return payload;
   }
@@ -101,6 +101,7 @@ function withStableAppConfig(payload: unknown): unknown {
       categoriesPage: ['all'],
       skillsPage: ['all'],
       activityList: ['all'],
+      unified_homepage: opts.unifiedHomepage ? ['all'] : [],
     },
   };
 }
@@ -145,7 +146,7 @@ export async function stabilizeAuthenticatedPlayer(page: Page) {
   });
 }
 
-export async function stabilizeTimerPage(page: Page) {
+export async function stabilizeTimerPage(page: Page, opts: { unifiedHomepage?: boolean } = {}) {
   await page.route('**/fetch_info/', async (route) => {
     await fulfillPatchedRoute(route, withSettledTimerBootstrap);
   });
@@ -155,7 +156,7 @@ export async function stabilizeTimerPage(page: Page) {
   });
 
   await page.route('**/app_config/', async (route) => {
-    await fulfillPatchedRoute(route, withStableAppConfig);
+    await fulfillPatchedRoute(route, (payload) => withStableAppConfig(payload, opts));
   });
 }
 

--- a/gameplay/tests/test_views.py
+++ b/gameplay/tests/test_views.py
@@ -1,0 +1,97 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from progression.models import Task
+
+User = get_user_model()
+
+
+class LabelActivityViewTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="label-activity@example.com", password="testpass123"
+        )
+        self.player = self.user.player
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse("activitytimer-label-activity")
+
+    def start_timer(self, name="Focus time"):
+        timer = self.player.activity_timer
+        timer.new_activity(name=name)
+        timer.start()
+        return timer
+
+    def test_renames_running_activity_without_resetting_progress(self):
+        timer = self.start_timer()
+        timer.elapsed_time = 42
+        timer.save(update_fields=["elapsed_time"])
+        original_start_time = timer.start_time
+
+        response = self.client.post(self.url, {"activityName": "Deep work"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        timer.refresh_from_db()
+        timer.activity.refresh_from_db()
+        self.assertEqual(timer.activity.name, "Deep work")
+        self.assertEqual(timer.status, "active")
+        self.assertEqual(timer.elapsed_time, 42)
+        self.assertEqual(timer.start_time, original_start_time)
+
+    def test_can_clear_the_label_back_to_blank(self):
+        self.start_timer(name="Something")
+
+        response = self.client.post(self.url, {"activityName": ""})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        timer = self.player.activity_timer
+        timer.activity.refresh_from_db()
+        self.assertEqual(timer.activity.name, "")
+
+    def test_attaches_task_alongside_rename(self):
+        task = Task.objects.create(player=self.player, name="Ship the feature")
+        self.start_timer()
+
+        response = self.client.post(
+            self.url, {"activityName": "Ship the feature", "task_id": task.id}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        timer = self.player.activity_timer
+        timer.activity.refresh_from_db()
+        self.assertEqual(timer.activity.name, "Ship the feature")
+        self.assertEqual(timer.activity.task_id, task.id)
+
+    def test_rejects_task_owned_by_another_player(self):
+        other_user = User.objects.create_user(
+            email="other-player@example.com", password="testpass123"
+        )
+        other_task = Task.objects.create(player=other_user.player, name="Not yours")
+        self.start_timer()
+
+        response = self.client.post(
+            self.url, {"activityName": "Focus time", "task_id": other_task.id}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_no_op_when_no_timer_is_running(self):
+        response = self.client.post(self.url, {"activityName": "Too late"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_no_op_when_timer_already_completed(self):
+        timer = self.start_timer()
+        timer.complete()
+
+        response = self.client.post(self.url, {"activityName": "Too late"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+
+        response = self.client.post(self.url, {"activityName": "Nope"})
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/gameplay/views.py
+++ b/gameplay/views.py
@@ -160,6 +160,34 @@ class ActivityTimerViewSet(BaseTimerViewSet):
         updated.refresh_from_db()
         return Response({"success": True, "activity_timer": self.serialize(updated)})
 
+    @action(detail=False, methods=["post"])
+    def label_activity(self, request):
+        """
+        Rename (and optionally re-link to a task) the activity already
+        assigned to a running/waiting timer, in place — unlike
+        set_activity, this does not reset elapsed time or status.
+        """
+        timer = self.get_timer(request)
+
+        if timer.status not in ("active", "waiting") or not timer.activity:
+            return Response(
+                {"error": "No running timer to label."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        name = request.data.get("activityName")
+        if not name:
+            name = ""
+
+        task_id = request.data.get("task_id")
+        if task_id:
+            task = get_object_or_404(Task, pk=task_id, player=request.user.player)
+            timer.change_task(task)
+
+        timer.rename_activity(name)
+
+        return Response({"success": True, "activity_timer": self.serialize(timer)})
+
 
 class QuestTimerViewSet(BaseTimerViewSet):
     serializer_class = QuestTimerSerializer


### PR DESCRIPTION
## Summary
- Adds a redesigned, feature-flagged (`unified_homepage`) timer homepage: single persistent Start/Stop button, blank-start timers, click-to-edit activity labels, and a persistent task-grouped activity search list (replacing the floating dropdown + separate label input).
- New `label_activity` endpoint to relabel a running timer in place without stopping it.
- Iterated through several rounds of animation/layout polish (Framer Motion): eliminated a focus/blur height-jump, fixed the persistent list floating outside its card, removed unnecessary `layout` props that caused input jitter while typing, and fixed a jerky Stop transition where the timer pill slid sideways instead of fading in place.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint src` clean (no new issues)
- [x] `vitest run` — 330/330 passing
- [x] `playwright test tests/flows/unified-timer-home.spec.ts` — 3/3 passing (happy path, reward-dialog z-index regression, flag-off regression guard)
- [x] Manually verified in-browser: click-to-edit, blank start, Start/Stop animation smoothness, persistent list containment

🤖 Generated with [Claude Code](https://claude.com/claude-code)