### PR TITLE
Add Your Library page consolidating Tasks, Activities, Skills

### DIFF
--- a/.claude/plans/your-library-plan.md
+++ b/.claude/plans/your-library-plan.md
@@ -1,0 +1,125 @@
+# Your Library — Implementation Plan
+
+Branch: `feat/your-library-page` (off `development`)
+Feature flag: `your_library` (default `[]`, off)
+
+---
+
+## Assumptions
+
+- Scope is three tabs: **Tasks**, **Activities**, and **Skills** (Activities added after the original brief was found to have missed it — the Activity Timeline / activity history page was always meant to fold into Library alongside Tasks). Categories and Projects are dropped entirely for this pass — not built as placeholders, not referenced in nav or tabs. Can be added later as their own follow-up.
+- Tab order: Tasks, Activities, Skills — the two functional tabs first (matching their relative prominence in the current standalone nav), placeholder last.
+- `ActivitiesPage` folds in the same way as `TasksPage` — reused wholesale, unconditionally, with its own `<h1>` suppressed via the same `showHeading` prop pattern. The standalone `/activities` route and its nav link are hidden (not removed) once `your_library` is ON, exactly like `/tasks`.
+- `/tasks`, `/activities`, and `/projects` standalone routes are left in place, untouched, and still reachable by direct URL when `your_library` is ON. Only scope is nav + a new tabbed page; removing/redirecting old routes is out of scope.
+- No deep-linking to a specific tab (e.g. `/library/skills`); a single `/library` route with client-side tab state is sufficient — matches "information architecture refactor, not a redesign."
+- Tasks and Activities tabs are always usable inside Your Library regardless of the existing `tasksFeature` flag (Activities was never behind a flag) — Library is the new home for both and shouldn't be gated by the old flag.
+- Skills tab is **not** gated behind the existing `skillsPage` flag. That flag exists to stage rollout of the real Skills feature; the tab is currently a static, harmless "Coming soon" placeholder with nothing to stage. Tying tab visibility to `skillsPage` would just add a second switch that has to move in lockstep with `your_library` for no behavioural benefit — when real Skills functionality ships, `skillsPage` becomes relevant again for gating *that content*, not the tab itself. Skills tab is always visible whenever `your_library` is on.
+- Nav entry icon: reuse an unused emoji (📚) for "Your Library"; not specified in the brief, low-stakes, easy to change later.
+- "Coming soon" placeholder uses the existing `FeatureToggle` fallback card copy/style as visual precedent, but is implemented as a dedicated small component (see below) since it lives inside a tab, not behind `FeatureToggle`.
+
+---
+
+## 1. High-level strategy
+
+Add a new `LibraryPage` with Radix `Tabs` (already used in `ActivityInputScreen`) containing three tabs: Tasks, Activities, and Skills. The Tasks and Activities tabs mount the existing `TasksPage` and `ActivitiesPage` components verbatim — zero logic duplication. The Skills tab renders a new `ComingSoonPanel` placeholder component that mimics their layout shape (header + empty state box) so swapping in real CRUD later is a content change, not a structural one. Categories and Projects are out of scope for this pass (see assumptions).
+
+Route `/library` is gated by a new `your_library` feature flag via the existing `FeatureToggle` pattern. `Navbar`/`NavDrawer` conditionally show either the legacy "Tasks" + "Activities" links (flag off) or a single "Your Library" link (flag on) — never both.
+
+## 2. Files likely to change
+
+| File | Change | New? |
+|---|---|---|
+| `frontend/src/types/enums.ts` | add `"your_library"` to `FeatureFlagKey` | existing |
+| `frontend/src/featureFlags.ts` | add `your_library: []` | existing |
+| `frontend/src/routes/routePaths.js` | add `"/library"` | existing |
+| `frontend/src/routes/routesConfig.jsx` | add `/library` route, lazy-loaded, wrapped in `PrivateRoute` + `FeatureToggle flag="your_library"` | existing |
+| `frontend/src/layout/Navbar/Navbar.tsx` | conditional nav entry (desktop + mobile icon nav); also folds the standalone Activities link | existing |
+| `frontend/src/layout/NavDrawer/NavDrawer.tsx` | conditional nav entry; same Activities fold | existing |
+| `frontend/src/pages/ActivitiesPage.tsx` | add `showHeading` prop (same pattern as `TasksPage`), default `true` | existing |
+| `frontend/src/pages/LibraryPage/LibraryPage.tsx` | new tabbed container (Tasks + Activities + Skills) | new |
+| `frontend/src/pages/LibraryPage/LibraryPage.module.scss` | tab bar + page layout styles | new |
+| `frontend/src/pages/LibraryPage/LibraryPage.test.tsx` | tab behaviour tests | new |
+| `frontend/src/components/ComingSoonPanel/ComingSoonPanel.tsx` | placeholder for Skills tab, `itemLabelPlural` prop (kept generic so it's reusable if Categories/Projects are added later) | new |
+| `frontend/src/components/ComingSoonPanel/ComingSoonPanel.module.scss` | mirrors `TasksPage`/`ActivitiesPage` empty-state/header spacing | new |
+| `frontend/src/components/ComingSoonPanel/ComingSoonPanel.test.tsx` | renders label, no actions | new |
+| `frontend/src/layout/Navbar/Navbar.test.tsx` (if exists) | update for new flag branch | existing |
+| `frontend/src/layout/NavDrawer/NavDrawer.test.tsx` (if exists) | update for new flag branch | existing |
+
+No backend changes — this is a pure frontend IA refactor.
+
+## 3. Implementation plan
+
+**Phase 1 — flag + route + skeleton page (no nav change)**
+- Add `your_library` to `FeatureFlagKey` and `featureFlags.ts`.
+- Add `showHeading` prop to `ActivitiesPage` (mirrors `TasksPage`'s existing prop), default `true`.
+- Build `ComingSoonPanel` (label prop, header + "Coming soon" empty state — no CRUD affordances of any kind).
+- Build `LibraryPage`: Radix `Tabs.Root` (`defaultValue="tasks"`), `Tabs.List` with Tasks/Activities/Skills triggers, `Tabs.Content` per tab. Tasks tab renders `<TasksPage showHeading={false} />`, Activities tab renders `<ActivitiesPage showHeading={false} />`, both unconditionally (not gated by `tasksFeature`). Skills tab renders `<ComingSoonPanel itemLabelPlural="skills" />`, unconditionally (not gated by `skillsPage`).
+- Add `/library` route (`PrivateRoute` + `FeatureToggle flag="your_library"`), add path to `routePaths.js`.
+- Flag OFF: route inert (unreachable via nav, `FeatureToggle` fallback if visited directly). Flag ON: `/library` fully functional but not yet linked from nav. App behaviour otherwise unchanged either way.
+
+**Phase 2 — navigation wiring**
+- `Navbar.tsx`: compute `isLibraryEnabled = useFeatureFlag("your_library")`. When true, render a single "Your Library" link (`/library`, 📚) in place of both the existing Tasks link and the always-on Activities link; when false, both existing branches are untouched. Same for the mobile icon nav's active-state checks (`isTasksPage`/`isActivitiesPage` → also treat `/library` prefix as active for the Library entry).
+- `NavDrawer.tsx`: same conditional swap, folding both Tasks and Activities into the single Library entry.
+- Flag OFF: nav identical to today (Timer, Activities, Tasks-if-enabled, Account, Log out). Flag ON: nav shows Timer, Your Library, Account, Log out; page fully reachable and usable.
+
+**Phase 3 — tests & polish**
+- `LibraryPage.test.tsx`: default tab is Tasks; switching tabs renders the right panel (Activities, then Skills); placeholder tab renders no buttons/inputs.
+- `ComingSoonPanel.test.tsx`: renders label text, no interactive CRUD elements.
+- Update `Navbar`/`NavDrawer` tests for both flag states.
+- Manual a11y pass on the new tab bar (Radix handles roving tabindex/ARIA, but verify focus order and screen-reader labelling against existing patterns).
+
+Each phase leaves `main`/`development` buildable and behaviourally correct with the flag both ON and OFF.
+
+## 4. Design decisions
+
+**Reuse `TasksPage` and `ActivitiesPage` wholesale instead of extracting shared hooks/components**
+- Chosen: mount `<TasksPage />` and `<ActivitiesPage />` directly inside their respective `Tabs.Content`. Both are already self-contained (own data fetching, own `<h1>`; `TasksPage`'s only side effect is `navigate("/timer")` on start, which works from any parent route; `ActivitiesPage` has no navigation side effects at all).
+- Alternative: extract each page's hook + JSX into a shared presentational component consumed by both the standalone route and the Library tab. Rejected — `/tasks` and `/activities` stay as dormant standalone routes per assumptions, so a second consumer isn't needed yet; introducing an extraction layer now is speculative abstraction for two reuse sites that don't need it.
+- Minor cleanup needed for both: each page's own `<h1>` would duplicate the Library page's "Your Library" heading + tab label — suppress via a `showHeading` prop (already added to `TasksPage`; same small, justified change applied to `ActivitiesPage`) rather than fighting CSS-module scoping across files.
+
+**`ComingSoonPanel` as a standalone reusable component, not inline JSX in `LibraryPage`**
+- Chosen: small standalone component parameterized by label, even though only one tab (Skills) uses it right now.
+- Alternative: inline the placeholder markup directly in `LibraryPage`. Rejected — a named, parameterized component costs almost nothing and is the natural drop-in point if Categories/Projects (or other placeholders) are added later; inlining would mean re-extracting it at that point anyway.
+
+**Skills tab not gated behind the `skillsPage` flag**
+- Chosen: Skills tab visibility depends only on `your_library`; the placeholder is always shown once Library ships.
+- Alternative: also require `skillsPage` to be truthy before showing the tab. Rejected — `skillsPage` is meant to stage the *real* Skills feature's rollout; the placeholder has no functionality to stage, so gating it adds a second flag to keep in sync for no behavioural benefit. Revisit `skillsPage` when real Skills CRUD replaces the placeholder content.
+
+**Radix `Tabs` for tab navigation**
+- Chosen: already a project dependency, already used in `ActivityInputScreen.tsx`, accessible by default.
+- Alternative: custom tab implementation. Rejected — no reason to reinvent, inconsistent with existing pattern.
+
+**Nav entry replaces rather than supplements the Tasks and Activities links**
+- Chosen: when `your_library` is ON, "Your Library" fully replaces both "Tasks" and "Activities" in `Navbar` and `NavDrawer`.
+- Alternative: show all links side by side. Rejected — brief specifies "the main navigation entry should be Your Library," implying consolidation, not addition; keeping a redundant standalone Activities link defeats the point of folding it in.
+
+## 5. Edge cases
+
+- Direct navigation to `/library` with flag OFF → standard `FeatureToggle` fallback ("Coming soon" card), consistent with `tasksFeature`/`projectsPage` today.
+- `your_library` ON but `tasksFeature` OFF: Tasks tab must still work (Library's Tasks tab is intentionally independent of the legacy flag — see assumptions). Activities was never gated, so no equivalent concern there.
+- Nav active-state highlighting: `/library` (and any future sub-paths) should mark the "Your Library" nav item active, not "no item active." Both the old `isTasksPage` and `isActivitiesPage` checks are superseded by `isLibraryPage` when the flag is on.
+- No data/model changes, so no migration or backwards-compatibility concerns.
+- Existing `/tasks`, `/activities`, and `/projects` E2E/Playwright tests should keep passing unchanged since those routes/components aren't modified.
+
+## 6. Tests
+
+- New: `LibraryPage.test.tsx` — default tab is Tasks, tab switching shows Activities then Skills panels, Skills panel has no actionable controls.
+- New: `ComingSoonPanel.test.tsx` — renders given label, no buttons/inputs present.
+- Modify: `Navbar.test.tsx` / `NavDrawer.test.tsx` (if present) — assert Tasks+Activities links shown when `your_library` off, Your Library link shown when on, never both.
+- No changes needed to `TasksPage.test.tsx`, `ActivitiesPage.test.tsx`, `SkillsPage.test.tsx`, `CategoriesPage.test.tsx`, `ProjectsPage.test.tsx` — those components/routes are untouched (beyond the additive `showHeading` prop, which defaults to preserving current behaviour).
+- Consider one Playwright smoke test: flag on → `/library` loads, tabs switch, Tasks tab supports add/edit/delete (reusing existing Tasks E2E assertions if any exist).
+
+## 7. Risks
+
+- Forgetting to make the Tasks/Activities tabs independent of `tasksFeature` — would silently break Library for users who don't have the old flag, contradicting "reuse existing functionality."
+- Double `<h1>` / heading hierarchy issues from mounting `TasksPage`/`ActivitiesPage` inside `LibraryPage` — an a11y regression if not addressed with proper heading levels via `showHeading`.
+- Nav active-state logic drifting (e.g. `/library` not matching any `isXPage` check) — item never highlights as active, minor but noticeable.
+- Accidentally wiring `ComingSoonPanel` with a real add-form input that posts nowhere (must have zero CRUD affordances, per spec — no inputs/buttons, not just disabled ones, to avoid confusing "why doesn't this work" UX).
+- Conflating `skillsPage` and `your_library` flags during implementation (e.g. a stray `useFeatureFlag("skillsPage")` check creeping into the Skills tab) — would contradict the explicit decision above.
+- Forgetting to fold the *Activities* nav link specifically (easy to remember Tasks since it was already flag-gated, easier to overlook Activities since it's always-on today).
+
+## 8. Open questions
+
+- Confirm `📚` (or any icon) is acceptable for the "Your Library" nav entry, or if a specific icon/asset should be used.
+- Should the old `/tasks`/`/activities` routes eventually redirect to `/library` once this ships, or stay as separate dormant entry points indefinitely? (Out of scope for this plan either way — flagging for a future decision.)
+- When Categories/Projects are picked back up, do they get added as more `ComingSoonPanel` tabs in this same page, or reconsidered as part of a separate follow-up plan?

--- a/frontend/src/components/ComingSoonPanel/ComingSoonPanel.module.scss
+++ b/frontend/src/components/ComingSoonPanel/ComingSoonPanel.module.scss
@@ -1,0 +1,18 @@
+@use '../../styles/utilities/list-pages' as lp;
+@use '../../styles/base/variables' as v;
+
+.page {
+  width: min(100%, 720px);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: v.$spacing-lg;
+}
+
+.emptyState {
+  @include lp.list-page-empty-state;
+}

--- a/frontend/src/components/ComingSoonPanel/ComingSoonPanel.test.tsx
+++ b/frontend/src/components/ComingSoonPanel/ComingSoonPanel.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ComingSoonPanel from "./ComingSoonPanel";
+
+describe("ComingSoonPanel", () => {
+  it("renders the capitalized label and a coming-soon message", () => {
+    render(<ComingSoonPanel itemLabelPlural="skills" />);
+
+    expect(screen.getByRole("heading", { name: "Skills" })).toBeInTheDocument();
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+  });
+
+  it("renders no interactive CRUD controls", () => {
+    render(<ComingSoonPanel itemLabelPlural="skills" />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ComingSoonPanel/ComingSoonPanel.tsx
+++ b/frontend/src/components/ComingSoonPanel/ComingSoonPanel.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import styles from "./ComingSoonPanel.module.scss";
+
+interface ComingSoonPanelProps {
+  itemLabelPlural: string;
+}
+
+export default function ComingSoonPanel({ itemLabelPlural }: ComingSoonPanelProps): React.ReactElement {
+  const capitalized = itemLabelPlural.charAt(0).toUpperCase() + itemLabelPlural.slice(1);
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <h2>{capitalized}</h2>
+      </div>
+
+      <div className={styles.emptyState}>
+        <p>{capitalized} are coming soon! Stay tuned.</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/featureFlags.ts
+++ b/frontend/src/featureFlags.ts
@@ -12,6 +12,7 @@ const featureFlags: Record<FeatureFlagKey, FeatureFlagValue> = {
   projectsPage: [],
   toastsFeature: [],
   onlinePlayerCount: ['testers'],
+  your_library: [],
 };
 
 export default featureFlags;

--- a/frontend/src/layout/NavDrawer/NavDrawer.tsx
+++ b/frontend/src/layout/NavDrawer/NavDrawer.tsx
@@ -13,6 +13,7 @@ export default function NavDrawer({ drawerOpen, onClose }: NavDrawerProps) {
   const drawerRef = useRef<HTMLElement>(null);
   const { isAuthenticated } = useAuth();
   const isTasksEnabled = useFeatureFlag("tasksFeature");
+  const isLibraryEnabled = useFeatureFlag("your_library");
 
   const handleClose = useCallback(() => {
     const activeElement = document.activeElement as HTMLElement | null;
@@ -75,25 +76,39 @@ export default function NavDrawer({ drawerOpen, onClose }: NavDrawerProps) {
                   <span aria-hidden="true">⏱ </span>Timer
                 </Link>
               </li>
-              <li>
-                <Link
-                  to="/activities"
-                  onClick={handleClose}
-                  tabIndex={drawerOpen ? 0 : -1}
-                >
-                  <span aria-hidden="true">📋 </span>Activities
-                </Link>
-              </li>
-              {isTasksEnabled && (
+              {isLibraryEnabled ? (
                 <li>
                   <Link
-                    to="/tasks"
+                    to="/library"
                     onClick={handleClose}
                     tabIndex={drawerOpen ? 0 : -1}
                   >
-                    <span aria-hidden="true">✅ </span>Tasks
+                    <span aria-hidden="true">📚 </span>Your library
                   </Link>
                 </li>
+              ) : (
+                <>
+                  <li>
+                    <Link
+                      to="/activities"
+                      onClick={handleClose}
+                      tabIndex={drawerOpen ? 0 : -1}
+                    >
+                      <span aria-hidden="true">📋 </span>Activities
+                    </Link>
+                  </li>
+                  {isTasksEnabled && (
+                    <li>
+                      <Link
+                        to="/tasks"
+                        onClick={handleClose}
+                        tabIndex={drawerOpen ? 0 : -1}
+                      >
+                        <span aria-hidden="true">✅ </span>Tasks
+                      </Link>
+                    </li>
+                  )}
+                </>
               )}
             </>
           ) : (

--- a/frontend/src/layout/Navbar/Navbar.tsx
+++ b/frontend/src/layout/Navbar/Navbar.tsx
@@ -16,11 +16,13 @@ export default function Navbar({ onMenuClick, onHelpClick }: NavbarProps) {
   const location = useLocation();
 
   const isTasksEnabled = useFeatureFlag("tasksFeature");
+  const isLibraryEnabled = useFeatureFlag("your_library");
 
   const isTimerPage = location.pathname === "/timer";
   const isHomePage = location.pathname === "/";
   const isActivitiesPage = location.pathname === "/activities";
   const isTasksPage = location.pathname === "/tasks";
+  const isLibraryPage = location.pathname.startsWith("/library");
   const isAccountPage = location.pathname === "/account";
 
   return (
@@ -49,23 +51,36 @@ export default function Navbar({ onMenuClick, onHelpClick }: NavbarProps) {
 
           {isAuthenticated && (
             <>
-              <Link to="/activities" aria-label="Go to activities">
-                <Button
-                  variant={isActivitiesPage ? "primary" : "secondary"}
-                  className={styles.navLink}
-                >
-                  <span aria-hidden="true">📋 </span>Activities
-                </Button>
-              </Link>
-              {isTasksEnabled && (
-                <Link to="/tasks" aria-label="Go to tasks">
+              {isLibraryEnabled ? (
+                <Link to="/library" aria-label="Go to your library">
                   <Button
-                    variant={isTasksPage ? "primary" : "secondary"}
+                    variant={isLibraryPage ? "primary" : "secondary"}
                     className={styles.navLink}
                   >
-                    <span aria-hidden="true">✅ </span>Tasks
+                    <span aria-hidden="true">📚 </span>Your library
                   </Button>
                 </Link>
+              ) : (
+                <>
+                  <Link to="/activities" aria-label="Go to activities">
+                    <Button
+                      variant={isActivitiesPage ? "primary" : "secondary"}
+                      className={styles.navLink}
+                    >
+                      <span aria-hidden="true">📋 </span>Activities
+                    </Button>
+                  </Link>
+                  {isTasksEnabled && (
+                    <Link to="/tasks" aria-label="Go to tasks">
+                      <Button
+                        variant={isTasksPage ? "primary" : "secondary"}
+                        className={styles.navLink}
+                      >
+                        <span aria-hidden="true">✅ </span>Tasks
+                      </Button>
+                    </Link>
+                  )}
+                </>
               )}
             </>
           )}

--- a/frontend/src/pages/ActivitiesPage.tsx
+++ b/frontend/src/pages/ActivitiesPage.tsx
@@ -73,7 +73,11 @@ const getActivityDateCategory = (dateString: string): "today" | "yesterday" | "o
   return "older";
 };
 
-export default function ActivitiesPage(): React.ReactElement | null {
+interface ActivitiesPageProps {
+  showHeading?: boolean;
+}
+
+export default function ActivitiesPage({ showHeading = true }: ActivitiesPageProps = {}): React.ReactElement | null {
   const { data: activities, isLoading } = useActivities();
   const deleteActivity = useDeleteActivity();
   const updateActivity = useUpdateActivity();
@@ -147,9 +151,11 @@ export default function ActivitiesPage(): React.ReactElement | null {
   return (
     <div className={styles.page}>
       <div className={styles.content}>
-      <div className={styles.header}>
-        <h1>Activities</h1>
-      </div>
+      {showHeading && (
+        <div className={styles.header}>
+          <h1>Activities</h1>
+        </div>
+      )}
 
       {hasActivities && (
         <>

--- a/frontend/src/pages/LibraryPage/LibraryPage.module.scss
+++ b/frontend/src/pages/LibraryPage/LibraryPage.module.scss
@@ -1,0 +1,62 @@
+@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/colors' as c;
+@use '../../styles/semantic/typography' as t;
+
+.page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  margin: 0 auto;
+  padding: v.$padding-base;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: v.$spacing-lg;
+
+  h1 {
+    @include t.apply-text-style(t.$text-heading-1);
+  }
+}
+
+.tabsRoot {
+  width: min(100%, 720px);
+  display: flex;
+  flex-direction: column;
+}
+
+.tabBar {
+  display: flex;
+  justify-content: center;
+  gap: v.$spacing-sm;
+  border-bottom: 1px solid rgba(c.$color-border-primary, 0.25);
+  margin-bottom: v.$spacing-md;
+}
+
+.tab {
+  padding: v.$spacing-sm v.$spacing-md;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  background: transparent;
+  font-family: inherit;
+  font-size: 1em;
+  cursor: pointer;
+  color: c.$color-text-muted;
+  transition: color 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    color: c.$color-text-body;
+  }
+
+  &[data-state='active'] {
+    color: c.$color-text-body;
+    border-bottom-color: c.$color-border-primary;
+    font-weight: 600;
+  }
+}
+
+.tabContent {
+  width: 100%;
+}

--- a/frontend/src/pages/LibraryPage/LibraryPage.test.tsx
+++ b/frontend/src/pages/LibraryPage/LibraryPage.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import LibraryPage from "./LibraryPage";
+
+vi.mock("../TasksPage/TasksPage", () => ({
+  default: ({ showHeading }: { showHeading?: boolean }) => (
+    <div data-testid="tasks-panel" data-show-heading={String(showHeading)}>
+      Tasks panel
+    </div>
+  ),
+}));
+
+vi.mock("../ActivitiesPage", () => ({
+  default: ({ showHeading }: { showHeading?: boolean }) => (
+    <div data-testid="activities-panel" data-show-heading={String(showHeading)}>
+      Activities panel
+    </div>
+  ),
+}));
+
+vi.mock("../../components/ComingSoonPanel/ComingSoonPanel", () => ({
+  default: ({ itemLabelPlural }: { itemLabelPlural: string }) => (
+    <div data-testid="coming-soon-panel">{itemLabelPlural} coming soon</div>
+  ),
+}));
+
+describe("LibraryPage", () => {
+  it("defaults to the Tasks tab, rendering TasksPage without its own heading", () => {
+    render(<LibraryPage />);
+
+    expect(screen.getByRole("heading", { name: "Your library" })).toBeInTheDocument();
+    const tasksPanel = screen.getByTestId("tasks-panel");
+    expect(tasksPanel).toBeInTheDocument();
+    expect(tasksPanel).toHaveAttribute("data-show-heading", "false");
+    expect(screen.queryByTestId("coming-soon-panel")).not.toBeInTheDocument();
+  });
+
+  it("switches to the Activities tab, rendering ActivitiesPage without its own heading", async () => {
+    const user = userEvent.setup();
+    render(<LibraryPage />);
+
+    await user.click(screen.getByRole("tab", { name: "Activities" }));
+
+    const activitiesPanel = screen.getByTestId("activities-panel");
+    expect(activitiesPanel).toBeInTheDocument();
+    expect(activitiesPanel).toHaveAttribute("data-show-heading", "false");
+    expect(screen.queryByTestId("tasks-panel")).not.toBeInTheDocument();
+  });
+
+  it("switches to the Skills tab, showing the coming-soon placeholder", async () => {
+    const user = userEvent.setup();
+    render(<LibraryPage />);
+
+    await user.click(screen.getByRole("tab", { name: "Skills" }));
+
+    expect(screen.getByTestId("coming-soon-panel")).toHaveTextContent("skills coming soon");
+    expect(screen.queryByTestId("tasks-panel")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("activities-panel")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/LibraryPage/LibraryPage.tsx
+++ b/frontend/src/pages/LibraryPage/LibraryPage.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import * as Tabs from "@radix-ui/react-tabs";
+
+import TasksPage from "../TasksPage/TasksPage";
+import ActivitiesPage from "../ActivitiesPage";
+import ComingSoonPanel from "../../components/ComingSoonPanel/ComingSoonPanel";
+import styles from "./LibraryPage.module.scss";
+
+export default function LibraryPage(): React.ReactElement {
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <h1>Your library</h1>
+      </div>
+
+      <Tabs.Root className={styles.tabsRoot} defaultValue="tasks">
+        <Tabs.List className={styles.tabBar} aria-label="Your library sections">
+          <Tabs.Trigger value="tasks" className={styles.tab}>
+            Tasks
+          </Tabs.Trigger>
+          <Tabs.Trigger value="activities" className={styles.tab}>
+            Activities
+          </Tabs.Trigger>
+          <Tabs.Trigger value="skills" className={styles.tab}>
+            Skills
+          </Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value="tasks" className={styles.tabContent}>
+          <TasksPage showHeading={false} />
+        </Tabs.Content>
+
+        <Tabs.Content value="activities" className={styles.tabContent}>
+          <ActivitiesPage showHeading={false} />
+        </Tabs.Content>
+
+        <Tabs.Content value="skills" className={styles.tabContent}>
+          <ComingSoonPanel itemLabelPlural="skills" />
+        </Tabs.Content>
+      </Tabs.Root>
+    </div>
+  );
+}

--- a/frontend/src/pages/TasksPage/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage/TasksPage.tsx
@@ -7,7 +7,11 @@ import Tooltip from "../../components/Tooltip/Tooltip";
 import { isTaskComplete, taskSortOptions, useTasksPage, type ItemRecord } from "./useTasksPage";
 import styles from "./TasksPage.module.scss";
 
-export default function TasksPage(): React.ReactElement | null {
+interface TasksPageProps {
+  showHeading?: boolean;
+}
+
+export default function TasksPage({ showHeading = true }: TasksPageProps = {}): React.ReactElement | null {
   const {
     isLoading,
     newName,
@@ -30,9 +34,11 @@ export default function TasksPage(): React.ReactElement | null {
   return (
     <div className={styles.page}>
       <div className={styles.content}>
-      <div className={styles.header}>
-        <h1>Tasks</h1>
-      </div>
+      {showHeading && (
+        <div className={styles.header}>
+          <h1>Tasks</h1>
+        </div>
+      )}
 
       <form className={styles.addTaskForm} onSubmit={handleSubmitForm}>
         <EntitySearchInput

--- a/frontend/src/routes/routePaths.js
+++ b/frontend/src/routes/routePaths.js
@@ -18,5 +18,6 @@ export const routePaths = [
   "/edit-account",
   "/tasks",
   "/projects",
+  "/library",
   "/activities",
 ];

--- a/frontend/src/routes/routesConfig.jsx
+++ b/frontend/src/routes/routesConfig.jsx
@@ -23,6 +23,7 @@ const UnavailablePage = lazy(() => import("../pages/UnavailablePage"));
 const NotFoundPage = lazy(() => import("../pages/NotFoundPage/NotFoundPage"));
 // const SkillsPage = lazy(() => import("../pages/SkillsPage/SkillsPage"));
 const TasksPage = lazy(() => import("../pages/TasksPage/TasksPage"));
+const LibraryPage = lazy(() => import("../pages/LibraryPage/LibraryPage"));
 const ProjectsPage = lazy(() => import("../pages/ProjectsPage/ProjectsPage"));
 const ActivitiesPage = lazy(() => import("../pages/ActivitiesPage"));
 // const CategoriesPage = lazy(() => import("../pages/CategoriesPage/CategoriesPage"));
@@ -170,6 +171,16 @@ export const routes = [
       <PrivateRoute>
         <FeatureToggle flag="projectsPage">
           <ProjectsPage />
+        </FeatureToggle>
+      </PrivateRoute>
+    ),
+  },
+  {
+    path: "/library",
+    element: (
+      <PrivateRoute>
+        <FeatureToggle flag="your_library">
+          <LibraryPage />
         </FeatureToggle>
       </PrivateRoute>
     ),

--- a/frontend/src/types/enums.ts
+++ b/frontend/src/types/enums.ts
@@ -20,7 +20,8 @@ export type FeatureFlagKey =
   | "skillsPage"
   | "projectsPage"
   | "toastsFeature"
-  | "onlinePlayerCount";
+  | "onlinePlayerCount"
+  | "your_library";
 
 // ---------------------------------------------------------------------------
 // Timer statuses (Timer.STATUS_CHOICES in gameplay/models.py)


### PR DESCRIPTION
## Summary
- Adds a `your_library`-flagged `/library` page with tabs: **Tasks**, **Activities**, **Skills**.
- Tasks and Activities tabs reuse the existing `TasksPage`/`ActivitiesPage` components wholesale (no logic duplication) via a new `showHeading` prop that suppresses their own duplicate headings when embedded.
- Skills tab is a static "Coming soon" placeholder (`ComingSoonPanel`) with zero CRUD affordances — not gated behind the existing `skillsPage` flag, since there's nothing yet to stage.
- `Navbar`/`NavDrawer` fold the standalone "Tasks" and "Activities" links into a single "Your Library" entry when the flag is ON; nav is unchanged when it's OFF.
- Categories and Projects were dropped from this pass (see `.claude/plans/your-library-plan.md` for the full plan and reasoning).

Flag defaults to off (`your_library: []` in `featureFlags.ts`); the app also has a remote `your_library` flag in `GameSettings` which takes precedence when present.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all changed files
- [x] Unit tests pass (`LibraryPage`, `ComingSoonPanel`, `TasksPage`, `ActivitiesPage`, layout)
- [x] Manually verified in-browser with the flag ON: nav swap, tab switching, Tasks tab add/edit/delete, Activities tab renders real data, Skills tab shows placeholder with no controls
- [x] Manually verified with the flag OFF: nav and `/tasks`/`/activities` behave exactly as before; direct `/library` visit shows the standard `FeatureToggle` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)