### PR TITLE
Signup abuse prevention

### DIFF
--- a/.claude/plans/issue-505-signup-abuse-prevention-plan.md
+++ b/.claude/plans/issue-505-signup-abuse-prevention-plan.md
@@ -1,0 +1,138 @@
+# Plan: Signup Abuse Prevention (#505)
+
+## 1. High-level strategy
+
+Three independent, additive protections layered onto the existing self-serve
+registration flow (`CustomRegisterView` / `CustomRegisterSerializer`,
+`RegistrationStatusAPIView`), each shippable as its own commit:
+
+1. **IP rate limiting** on `POST /api/v1/auth/registration/`, reusing the
+   `django_ratelimit` pattern already applied to `WaitlistSignupAPIView` /
+   `WaitlistJoinAPIView`.
+2. **Email-verification gating of the cap**: switch the registration-cap
+   count (used both in `CustomRegisterSerializer.validate` and
+   `RegistrationStatusAPIView.get`) from "all users" to "verified users",
+   via one shared helper.
+3. **Disposable-email blocklist**: reject known burner domains in
+   `CustomRegisterSerializer.validate_email`, using the maintained
+   `disposable-email-domains` PyPI package (mirrors the widely-used
+   `disposable-email-domains` npm/list project, updated frequently).
+
+CAPTCHA is already implemented (Cloudflare Turnstile, `_verify_turnstile` in
+`api/serializers.py`) — out of scope here, not part of this issue's AC.
+
+No new models, endpoints, or services are needed; all three protections plug
+into existing files.
+
+---
+
+## 2. Files likely to change
+
+| File | Change | New? |
+|---|---|---|
+| `api/views.py` | Add `ratelimit` decorator to `CustomRegisterView.create`; change cap check in `RegistrationStatusAPIView.get` to use verified-count helper | existing |
+| `api/serializers.py` | Change cap check in `CustomRegisterSerializer.validate` to use verified-count helper; add disposable-domain check in `validate_email` | existing |
+| `users/services/registration_services.py` | Add `verified_user_count()` helper (single source of truth for both call sites) | existing |
+| `requirements.in` / `requirements.txt` | Add `disposable-email-domains` | existing |
+| `users/tests/test_waitlist.py` (or a new `users/tests/test_registration_abuse.py`) | Tests for all three protections | existing / possibly new |
+
+A new test file is only warranted if `test_waitlist.py` is already large/unfocused — see Tests section.
+
+---
+
+## 3. Implementation plan
+
+**Commit 1 — IP rate limiting**
+- Add `@method_decorator(ratelimit(key="ip", rate="5/h", method="POST", block=True))` to `CustomRegisterView.create`, matching the existing waitlist views' style.
+- Rate chosen tighter than waitlist's `10/h` since account creation is higher-value abuse target; confirm with existing conventions rather than inventing a new scheme.
+
+**Commit 2 — Email verification gating of the cap**
+- Add `verified_user_count()` to `users/services/registration_services.py`: `User.objects.filter(is_confirmed=True).count()`.
+- Replace `User.objects.count()` in `CustomRegisterSerializer.validate` and `get_user_model().objects.count()` in `RegistrationStatusAPIView.get` with this helper.
+- Behavior change: unconfirmed signups no longer consume a cap slot, so registration stays "open" longer and fewer real users get pushed to the waitlist by abandoned/bot signups.
+
+**Commit 3 — Gate admin auto-confirm on registration mode**
+- In `CustomUserAdmin.save_model`, only auto-set `is_confirmed = True` for newly-created users when `GameSettings.current().self_serve_registration` is `False`.
+
+**Commit 4 — Disposable email domain blocklist (registration + waitlist)**
+- Add `disposable-email-domains` to `requirements.in`, regenerate `requirements.txt` (and `dev-requirements.txt` if it also pins it — check after `pip-compile`).
+- Add a shared `reject_disposable_email(value)` validator (likely `users/validators.py`, alongside other field-level validators already there e.g. `clean_player_name`) checking the domain against `disposable_email_domains.blocklist`.
+- Wire it into `CustomRegisterSerializer.validate_email`, `WaitlistSignupRequestSerializer`, and `WaitlistJoinRequestSerializer`.
+
+**Commit 5 — Tests**
+- Cover all three protections plus the dev/self-serve confirmation fix (see Tests section).
+
+---
+
+## 4. Design decisions
+
+**Rate limit key/scope** — confirmed: `5/h` per IP.
+- Chosen: `key="ip"`, matching `WaitlistSignupAPIView`/`WaitlistJoinAPIView` exactly, for consistency.
+- Alternative: rate-limit by email instead of/alongside IP — rejected because the issue explicitly asks for IP rate limiting, and email-based limiting is trivially bypassed by an attacker rotating addresses (which is the same attack this endpoint already blocks via the cap/disposable-domain checks).
+
+**Cap-count helper location**
+- Chosen: one helper in `users/services/registration_services.py`, used by both `api/serializers.py` and `api/views.py`, instead of duplicating the `EmailAddress` query in each.
+- Alternative: inline the query in both places — rejected, it's the same business rule ("what counts toward the cap") and duplicating it risks the two call sites drifting.
+
+**Verified-count definition**
+- Chosen: `User.objects.filter(is_confirmed=True).count()`. `is_confirmed` already exists on the `User` model and is kept correctly in sync by `users/signals.py:set_user_confirmed`, which listens for allauth's `email_confirmed` signal — no need to query `EmailAddress` separately.
+- Alternative: query `EmailAddress.objects.filter(verified=True)` directly — rejected as redundant; `is_confirmed` is the existing denormalized projection of exactly that state and is already used elsewhere (`UserSerializer`).
+
+**Disposable domain package**
+- Chosen: `disposable-email-domains` (PyPI), which mirrors the actively-maintained `disposable-email-domains` community blocklist — satisfies the AC's "maintained package/list, not hand-rolled."
+- Alternative: `django-disposable-email-checker` (adds a Django validator/field) — rejected as unnecessary abstraction; we only need a set-membership check in one place, not a reusable Django field type.
+
+**Scope of the disposable-domain check** — confirmed: applies to both registration and waitlist.
+- Chosen: a single shared validator (e.g. `users/validators.py::reject_disposable_email(value)`), called from `CustomRegisterSerializer.validate_email` **and** from `WaitlistSignupRequestSerializer`/`WaitlistJoinRequestSerializer`'s `email` field validation.
+- Alternative: duplicate the blocklist check inline in each of the three serializers — rejected, same rule in three places invites drift the same way the cap-count logic would.
+
+**Admin-created users auto-confirmed regardless of registration mode**
+- Discovered issue: `users/admin.py`'s `CustomUserAdmin.save_model` unconditionally sets `obj.is_confirmed = True` for every new user created via `/admin/` (`if not change: obj.is_confirmed = True`). This is a deliberate concierge-era convenience — staff vouches for the account, no email loop needed — but it is unconditional today, so it stays true even once self-serve registration is live, which is inconsistent with the rest of this issue's "only real confirmation counts" intent.
+- Chosen approach: gate that auto-confirm on `GameSettings.current().self_serve_registration` being `False`. While self-serve is off (concierge mode), admin-created users keep being auto-confirmed as today. Once self-serve is on, admin-created users get `is_confirmed=False` like any other signup, unless a staff member deliberately ticks the box in the admin form.
+- Alternative: leave admin behavior untouched and only rely on documentation/convention — rejected per explicit user instruction to tie it to the toggle.
+- Confirmed with user: `users/admin.py:save_model` is the correct target (not `dev.py`'s `ACCOUNT_EMAIL_VERIFICATION` setting, which was considered and ruled out — the custom registration view bypasses allauth's `complete_signup`, so that global setting doesn't affect `is_confirmed` during self-serve/invite signup at all).
+
+---
+
+## 5. Edge cases
+
+- **Invite-token/invite-code signups**: these bypass the cap check already (existing behavior, unchanged) — verified-count gating only affects the `self_serve_registration` branch's cap comparison.
+- **Rate limit + concurrent requests**: `django_ratelimit` with `block=True` returns 403 by default on limit breach; confirm this doesn't collide with the CAPTCHA/turnstile 400 responses in a way that's confusing to the frontend (frontend currently reads `non_field_errors` for the error message — a ratelimit 403 won't have that shape, so `RegisterPage`'s generic fallback message will show, which is acceptable).
+- **Verified-count query cost**: `EmailAddress` table is small relative to `User`; a `.distinct().count()` per registration attempt and per `registration_status` poll is fine at current scale, no caching needed.
+- **Disposable-domain false positives**: legitimate users on blocked domains get a validation error with no override path — acceptable per AC, but worth a clear error message ("Please use a permanent email address.") rather than a generic one.
+- **Package staleness**: pin `disposable-email-domains` without an upper bound cap issue — it's a data-only package released frequently; treat like any other dependency bump going forward (`dev-requirements.txt` note doesn't apply since it's a runtime dep, not a dev one).
+
+---
+
+## 6. Tests
+
+New/updated tests, likely appended to `users/tests/test_waitlist.py` (already covers registration+waitlist interplay) unless it's already unwieldy, in which case split into `users/tests/test_registration_abuse.py`:
+
+- **Rate limiting**: POST to `auth/registration/` beyond the configured rate from the same IP returns 403/429 and does not create a user; requires overriding `RATELIMIT_ENABLE`/cache in test settings the same way existing waitlist rate-limit tests do (check `test_waitlist.py` for the pattern already used there).
+- **Cap gating by verification**:
+  - Unverified users at/above `registration_cap` do not block new self-serve signups (registration stays open).
+  - Verified users at `registration_cap` do block new self-serve signups (existing behavior preserved).
+  - `RegistrationStatusAPIView` reflects `registration_open=True`/`False` consistently with the above.
+- **Disposable domain blocklist**:
+  - Signup with a known disposable domain (e.g. one from the package's list) is rejected with a clear validation error.
+  - Signup with a normal domain is unaffected.
+  - Same two cases repeated for `WaitlistSignupAPIView` and `WaitlistJoinAPIView`.
+- **Admin auto-confirm gating**: creating a user via `CustomUserAdmin` sets `is_confirmed=True` when `self_serve_registration` is off, and `is_confirmed=False` when it's on.
+
+---
+
+## 7. Risks
+
+- Forgetting to update **both** call sites (`serializers.py` cap check and `views.py` status check) consistently — mitigated by extracting the shared helper in Commit 2.
+- Picking a rate limit that's too aggressive for legitimate shared-IP scenarios (school/office NAT, mobile carrier CGNAT) — worth confirming the chosen `5/h` figure against any existing product expectations before merging.
+- Test flakiness from `django_ratelimit`'s cache backend if the test settings don't isolate/reset the rate-limit cache between tests (same risk already exists for the waitlist tests — reuse whatever fixture/pattern they use).
+- Silently changing `RegistrationStatusAPIView` semantics (verified vs. total count) is a behavior change visible to the frontend (`registration_open`) — should be called out in the PR description, not just buried in a diff.
+
+---
+
+## 8. Open questions
+
+All prior open questions were resolved with the user before implementation:
+rate limit set at `5/h`/IP, disposable-domain check applies to registration
+and both waitlist endpoints, and the admin auto-confirm gating targets
+`users/admin.py:CustomUserAdmin.save_model`.

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -14,8 +14,11 @@ from rest_framework_simplejwt.tokens import RefreshToken
 
 from core.models import GameSettings
 from users.models import Player, InviteCode, UserLogin, Waitlist
-from users.services.registration_services import ensure_player_setup_for_user
-from users.validators import clean_player_name
+from users.services.registration_services import (
+    ensure_player_setup_for_user,
+    verified_user_count,
+)
+from users.validators import clean_player_name, reject_disposable_email
 
 from django.contrib.auth import get_user_model
 
@@ -186,6 +189,13 @@ class DeleteAccountResponseSerializer(serializers.Serializer):
 class WaitlistSignupRequestSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True)
 
+    def validate_email(self, value):
+        try:
+            reject_disposable_email(value)
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc)) from exc
+        return value
+
 
 class WaitlistSignupResponseSerializer(serializers.Serializer):
     detail = serializers.CharField()
@@ -200,6 +210,13 @@ class RegistrationStatusResponseSerializer(serializers.Serializer):
 
 class WaitlistJoinRequestSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True)
+
+    def validate_email(self, value):
+        try:
+            reject_disposable_email(value)
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc)) from exc
+        return value
 
 
 class WaitlistJoinResponseSerializer(serializers.Serializer):
@@ -302,6 +319,10 @@ class CustomRegisterSerializer(RegisterSerializer):
     def validate_email(self, value):
         if User.objects.filter(email=value).exists():
             raise serializers.ValidationError("A user with that email already exists.")
+        try:
+            reject_disposable_email(value)
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc)) from exc
         return value
 
     def validate_timezone(self, value):
@@ -323,7 +344,9 @@ class CustomRegisterSerializer(RegisterSerializer):
                 )
             # Self-serve signups must respect the cap; invite holders bypass
             # it because their invite is proof of a slot at invite time.
-            if User.objects.count() >= game_settings.registration_cap:
+            # Only confirmed users count, so unconfirmed/abandoned signups
+            # can't exhaust the cap and block real users.
+            if verified_user_count() >= game_settings.registration_cap:
                 raise serializers.ValidationError(
                     "Registration is currently full. Please join the waitlist."
                 )

--- a/api/views.py
+++ b/api/views.py
@@ -1,7 +1,7 @@
 # api/views.py
 from asgiref.sync import async_to_sync
 from django.conf import settings
-from django.contrib.auth import login, logout, get_user_model
+from django.contrib.auth import login, logout
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import send_mail
 from django.db import transaction, IntegrityError
@@ -76,6 +76,7 @@ from progression.serializers import PlayerActivitySerializer
 
 from users.models import Player, TutorialStep, Waitlist
 from users.serializers import PlayerSerializer, TutorialStepSerializer
+from users.services.registration_services import verified_user_count
 from users.utils import send_email_to_users
 
 from progress_rpg.settings.utils import get_build_number
@@ -150,9 +151,7 @@ class RegistrationStatusAPIView(APIView):
 
     def get(self, request):
         game_settings = GameSettings.current()
-        registration_open = (
-            get_user_model().objects.count() < game_settings.registration_cap
-        )
+        registration_open = verified_user_count() < game_settings.registration_cap
         return Response(
             {
                 "registration_open": registration_open,
@@ -371,6 +370,7 @@ class TutorialStepViewSet(viewsets.ReadOnlyModelViewSet):
 class CustomRegisterView(RegisterView):
     serializer_class = CustomRegisterSerializer
 
+    @method_decorator(ratelimit(key="ip", rate="5/h", method="POST", block=True))
     def create(self, request, *args, **kwargs):
         if not GameSettings.current().registration_enabled:
             return Response(

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -112,6 +112,8 @@ defusedxml==0.7.1
     # via
     #   -r requirements.in
     #   python3-openid
+disposable-email-domains==0.0.217
+    # via -r requirements.in
 distlib==0.4.3
     # via virtualenv
 dj-database-url==3.1.2
@@ -426,7 +428,9 @@ virtualenv==21.5.1
 wcwidth==0.8.2
     # via prompt-toolkit
 websocket-client==1.9.0
-    # via python-socketio
+    # via
+    #   -r dev-requirements.in
+    #   python-socketio
 werkzeug==3.1.8
     # via
     #   flask

--- a/requirements.in
+++ b/requirements.in
@@ -14,6 +14,7 @@ cron-descriptor
 cryptography
 daphne
 defusedxml
+disposable-email-domains
 dj-database-url
 dj-rest-auth
 Django>=5.2.14,<6

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,6 +93,8 @@ defusedxml==0.7.1
     # via
     #   -r requirements.in
     #   python3-openid
+disposable-email-domains==0.0.217
+    # via -r requirements.in
 dj-database-url==3.1.2
     # via -r requirements.in
 dj-rest-auth==7.2.0

--- a/users/admin.py
+++ b/users/admin.py
@@ -16,6 +16,7 @@ from .models import (
 )
 from .services import waitlist_service
 from character.models import PlayerCharacterLink, Character
+from core.models import GameSettings
 from payments.models import UserSubscription
 
 # Register your models here.
@@ -237,7 +238,11 @@ class CustomUserAdmin(UserAdmin):
         return queryset
 
     def save_model(self, request, obj, form, change):
-        if not change:
+        if not change and not GameSettings.current().self_serve_registration:
+            # Concierge-mode convenience: staff vouches for the account, so
+            # skip the email-confirmation loop. Once self-serve is live,
+            # admin-created users go through the same is_confirmed=False
+            # path as everyone else, keeping the registration cap accurate.
             obj.is_confirmed = True
         super().save_model(request, obj, form, change)
 

--- a/users/services/registration_services.py
+++ b/users/services/registration_services.py
@@ -3,6 +3,17 @@ from users.models import Player
 from users.validators import generate_default_player_name
 
 
+def verified_user_count():
+    """Count users who have completed email confirmation.
+
+    Used for the registration cap so unconfirmed signups (bots, abandoned
+    signups) can't exhaust it and block real users.
+    """
+    from django.contrib.auth import get_user_model
+
+    return get_user_model().objects.filter(is_confirmed=True).count()
+
+
 def ensure_player_setup_for_user(user, raw=False):
     """Ensure player setup exists for a user unless raw mode is requested."""
     if raw:

--- a/users/services/waitlist_service.py
+++ b/users/services/waitlist_service.py
@@ -1,11 +1,11 @@
 import secrets
 from datetime import timedelta
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.utils import timezone
 
 from users.models import Waitlist
+from users.services.registration_services import verified_user_count
 from users.utils import send_email_to_users
 
 NUDGE_SCHEDULE = [
@@ -70,7 +70,7 @@ def invite_up_to_headroom() -> int:
 
     with transaction.atomic():
         registration_cap = GameSettings.current().registration_cap
-        registered = get_user_model().objects.count()
+        registered = verified_user_count()
         headroom = registration_cap - registered
         if headroom <= 0:
             return 0

--- a/users/tests/test_waitlist.py
+++ b/users/tests/test_waitlist.py
@@ -30,12 +30,24 @@ class RegistrationStatusAPITest(APITestCase):
         self.assertTrue(res.json()["registration_open"])
 
     def test_registration_closed_at_cap(self):
-        User.objects.create_user(email="a@example.com", password="testpassword123")
+        user = User.objects.create_user(
+            email="a@example.com", password="testpassword123"
+        )
+        user.is_confirmed = True
+        user.save(update_fields=["is_confirmed"])
         self.settings.registration_cap = User.objects.count()
         self.settings.save()
         res = self.client.get("/api/v1/registration_status/")
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertFalse(res.json()["registration_open"])
+
+    def test_registration_open_ignores_unconfirmed_users_at_cap(self):
+        User.objects.create_user(email="a@example.com", password="testpassword123")
+        self.settings.registration_cap = User.objects.count()
+        self.settings.save()
+        res = self.client.get("/api/v1/registration_status/")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertTrue(res.json()["registration_open"])
 
     def test_endpoint_requires_no_auth(self):
         res = self.client.get("/api/v1/registration_status/")
@@ -68,10 +80,14 @@ class RegistrationStatusAPITest(APITestCase):
 
 class RegistrationKillSwitchTest(APITestCase):
     def setUp(self):
+        cache.clear()
         GameSettings.objects.all().delete()
         self.settings = GameSettings.current()
         InviteCode.objects.create(code="TESTCODE")
         mail.outbox.clear()
+
+    def tearDown(self):
+        cache.clear()
 
     def _post_registration(self):
         with patch("api.serializers._verify_turnstile", return_value=True):
@@ -177,6 +193,12 @@ class WaitlistJoinAPITest(APITestCase):
 
 
 class SignupIgnoresCapTest(APITestCase):
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
     def test_signup_succeeds_even_when_cap_already_exceeded(self):
         from users.models import InviteCode
 
@@ -419,8 +441,12 @@ class WaitlistInviteTaskTest(TestCase):
 
 class WaitlistRegistrationRedemptionTest(APITestCase):
     def setUp(self):
+        cache.clear()
         GameSettings.objects.all().delete()
         GameSettings.current()
+
+    def tearDown(self):
+        cache.clear()
 
     def _register_payload(self, email, invite_token):
         return {
@@ -766,8 +792,12 @@ class WaitlistRemovalAcceptanceCriteriaTest(TestCase):
 
 class SelfServeRegistrationTest(APITestCase):
     def setUp(self):
+        cache.clear()
         GameSettings.objects.all().delete()
         self.settings = GameSettings.current()
+
+    def tearDown(self):
+        cache.clear()
 
     def _register_payload(self, email, **extra):
         return {
@@ -808,12 +838,25 @@ class SelfServeRegistrationTest(APITestCase):
 
     def test_self_serve_respects_registration_cap(self):
         self._enable_self_serve()
-        User.objects.create_user(email="a@example.com", password="testpassword123")
+        existing = User.objects.create_user(
+            email="a@example.com", password="testpassword123"
+        )
+        existing.is_confirmed = True
+        existing.save(update_fields=["is_confirmed"])
         self.settings.registration_cap = User.objects.count()
         self.settings.save()
         res = self._post_register(self._register_payload("solo@example.com"))
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(User.objects.filter(email="solo@example.com").exists())
+
+    def test_self_serve_ignores_unconfirmed_users_for_cap(self):
+        self._enable_self_serve()
+        User.objects.create_user(email="a@example.com", password="testpassword123")
+        self.settings.registration_cap = User.objects.count()
+        self.settings.save()
+        res = self._post_register(self._register_payload("solo@example.com"))
+        self.assertIn(res.status_code, [status.HTTP_200_OK, status.HTTP_201_CREATED])
+        self.assertTrue(User.objects.filter(email="solo@example.com").exists())
 
     def test_invite_token_still_bypasses_cap_when_self_serve_enabled(self):
         self._enable_self_serve()
@@ -867,3 +910,136 @@ class SelfServeRegistrationTest(APITestCase):
         res = self._post_register(self._register_payload("solo@example.com"))
         self.assertEqual(res.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
         self.assertFalse(User.objects.filter(email="solo@example.com").exists())
+
+
+class RegistrationRateLimitTest(APITestCase):
+    def setUp(self):
+        cache.clear()
+        GameSettings.objects.all().delete()
+        GameSettings.current()
+        InviteCode.objects.create(code="RATELIMITCODE")
+
+    def tearDown(self):
+        cache.clear()
+
+    def _register_payload(self, email):
+        return {
+            "email": email,
+            "password1": "SuperSecret123!",
+            "password2": "SuperSecret123!",
+            "invite_code": "RATELIMITCODE",
+            "agree_to_terms": True,
+            "turnstile_token": "test-token",
+        }
+
+    def test_sixth_registration_from_same_ip_is_rate_limited(self):
+        with patch("api.serializers._verify_turnstile", return_value=True):
+            for i in range(5):
+                res = self.client.post(
+                    "/api/v1/auth/registration/",
+                    self._register_payload(f"rl{i}@example.com"),
+                )
+                self.assertIn(
+                    res.status_code,
+                    [status.HTTP_200_OK, status.HTTP_201_CREATED],
+                )
+
+            res = self.client.post(
+                "/api/v1/auth/registration/",
+                self._register_payload("rl5@example.com"),
+            )
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(User.objects.filter(email="rl5@example.com").exists())
+
+
+class DisposableEmailBlocklistTest(APITestCase):
+    DISPOSABLE_EMAIL = "someone@mailinator.com"
+
+    def setUp(self):
+        cache.clear()
+        GameSettings.objects.all().delete()
+        self.settings = GameSettings.current()
+        self.settings.self_serve_registration = True
+        self.settings.save()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_registration_rejects_disposable_domain(self):
+        with patch("api.serializers._verify_turnstile", return_value=True):
+            res = self.client.post(
+                "/api/v1/auth/registration/",
+                {
+                    "email": self.DISPOSABLE_EMAIL,
+                    "password1": "SuperSecret123!",
+                    "password2": "SuperSecret123!",
+                    "agree_to_terms": True,
+                    "turnstile_token": "test-token",
+                },
+            )
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(User.objects.filter(email=self.DISPOSABLE_EMAIL).exists())
+
+    def test_registration_accepts_normal_domain(self):
+        with patch("api.serializers._verify_turnstile", return_value=True):
+            res = self.client.post(
+                "/api/v1/auth/registration/",
+                {
+                    "email": "someone@example.com",
+                    "password1": "SuperSecret123!",
+                    "password2": "SuperSecret123!",
+                    "agree_to_terms": True,
+                    "turnstile_token": "test-token",
+                },
+            )
+        self.assertIn(res.status_code, [status.HTTP_200_OK, status.HTTP_201_CREATED])
+
+    def test_waitlist_signup_rejects_disposable_domain(self):
+        with patch("api.views.subscribe_email_to_waitlist") as mock_subscribe:
+            res = self.client.post(
+                "/api/v1/waitlist_signup/", {"email": self.DISPOSABLE_EMAIL}
+            )
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_subscribe.assert_not_called()
+
+    def test_waitlist_join_rejects_disposable_domain(self):
+        res = self.client.post(
+            "/api/v1/waitlist_join/", {"email": self.DISPOSABLE_EMAIL}
+        )
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(Waitlist.objects.filter(email=self.DISPOSABLE_EMAIL).exists())
+
+
+class AdminAutoConfirmGatingTest(TestCase):
+    def setUp(self):
+        from django.contrib.admin.sites import AdminSite
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.test import RequestFactory
+        from users.admin import CustomUserAdmin
+
+        GameSettings.objects.all().delete()
+        self.settings = GameSettings.current()
+        self.admin = CustomUserAdmin(User, AdminSite())
+        request = RequestFactory().post("/admin/")
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        self.request = request
+
+    def _save_new_user(self, email):
+        user = User(email=email)
+        user.set_password("testpassword123")
+        form = MagicMock()
+        self.admin.save_model(self.request, user, form, change=False)
+        return user
+
+    def test_concierge_mode_auto_confirms_new_admin_user(self):
+        self.settings.self_serve_registration = False
+        self.settings.save()
+        user = self._save_new_user("concierge@example.com")
+        self.assertTrue(user.is_confirmed)
+
+    def test_self_serve_mode_does_not_auto_confirm_new_admin_user(self):
+        self.settings.self_serve_registration = True
+        self.settings.save()
+        user = self._save_new_user("selfserve@example.com")
+        self.assertFalse(user.is_confirmed)

--- a/users/validators.py
+++ b/users/validators.py
@@ -1,5 +1,15 @@
 import re
 
+from disposable_email_domains import blocklist
+
+DISPOSABLE_EMAIL_ERROR_MESSAGE = "Please use a permanent email address."
+
+
+def reject_disposable_email(value: str) -> None:
+    domain = value.rsplit("@", 1)[-1].lower()
+    if domain in blocklist:
+        raise ValueError(DISPOSABLE_EMAIL_ERROR_MESSAGE)
+
 
 PLAYER_NAME_MIN_LENGTH = 3
 PLAYER_NAME_MAX_LENGTH = 20


### PR DESCRIPTION
## Summary
Implements #505: abuse prevention on the self-serve signup path ahead of launch.

- IP rate limiting (`5/h`) on `POST /api/v1/auth/registration/`, matching the existing waitlist endpoints' pattern.
- The registration cap (`CustomRegisterSerializer.validate`, `RegistrationStatusAPIView`) and the waitlist invite-headroom calculation (`waitlist_service.invite_up_to_headroom`) now count only **confirmed** users, via a new `verified_user_count()` helper — unconfirmed/abandoned/bot signups can no longer exhaust the cap or suppress waitlist invites.
- `CustomUserAdmin.save_model`'s auto-confirm-on-create convenience is now gated on `GameSettings.self_serve_registration`: still auto-confirms in concierge mode, but not once self-serve is live, so admin-created accounts don't silently bypass the verified-cap logic above.
- Disposable/burner email domains are blocked using the maintained `disposable-email-domains` package, applied to registration, `waitlist_signup`, and `waitlist_join`.

Plan: `.claude/plans/issue-505-signup-abuse-prevention-plan.md`.

## Test plan
- [x] `pre-commit` (black) passes
- [x] `python manage.py check` passes
- [x] New/updated tests in `users/tests/test_waitlist.py` cover: rate limiting, verified-cap gating (registration status + self-serve registration), admin auto-confirm gating under both registration modes, disposable-domain rejection on all three endpoints
- [x] Full Django test suite run by the requester — reported passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)