### PR TITLE
Extend deploy checks to all required prod env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,6 @@ EXPOSE 8000
 ENV PORT=8000
 ENV DJANGO_SETTINGS_MODULE=progress_rpg.settings.prod
 
-RUN SECRET_KEY=dummy DATABASE_URL=postgres://dummy:dummy@localhost/dummy RESEND_API_KEY=dummy python manage.py collectstatic --noinput --clear
+RUN SECRET_KEY=dummy DATABASE_URL=postgres://dummy:dummy@localhost/dummy python manage.py collectstatic --noinput --clear
 
 CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "progress_rpg.asgi:application"]

--- a/core/apps.py
+++ b/core/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class CoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "core"
+
+    def ready(self):
+        import core.checks  # noqa

--- a/core/checks.py
+++ b/core/checks.py
@@ -1,0 +1,51 @@
+from django.conf import settings
+from django.core.checks import Error, Tags, register
+from django.core.exceptions import ImproperlyConfigured
+
+# Settings that read a secret from the environment with a silent empty-string
+# fallback (`os.environ.get(name, "")`), so a missing value doesn't crash at
+# import time — it just makes the dependent feature fail at runtime instead.
+# Only checked under `manage.py check --deploy`, so unrelated commands
+# (migrate, shell, Celery worker/beat boot) aren't affected by a missing var.
+REQUIRED_PROD_SETTINGS = [
+    ("SECRET_KEY", "Required to sign sessions, cookies, and tokens."),
+    ("DATABASE_URL", "Required to connect to Postgres."),
+    (
+        "EMAIL_HOST_PASSWORD",
+        "Set via RESEND_API_KEY. Without it Django skips SMTP auth and Resend "
+        "rejects every email with '530 authentication Required'.",
+    ),
+    (
+        "STRIPE_SECRET_KEY",
+        "Required for server-side Stripe API calls (checkout, subscription sync, webhooks).",
+    ),
+    (
+        "STRIPE_PUBLISHABLE_KEY",
+        "Required for the frontend to initialize Stripe.js.",
+    ),
+    (
+        "STRIPE_WEBHOOK_SECRET",
+        "Required to verify Stripe webhook signatures; without it webhook events are rejected.",
+    ),
+]
+
+
+@register(Tags.security, deploy=True)
+def check_required_prod_settings(app_configs, **kwargs):
+    errors = []
+    for setting_name, hint in REQUIRED_PROD_SETTINGS:
+        try:
+            # SECRET_KEY raises ImproperlyConfigured on access when empty
+            # (Django validates it itself); treat that the same as unset.
+            value = getattr(settings, setting_name, "")
+        except ImproperlyConfigured:
+            value = ""
+        if not value:
+            errors.append(
+                Error(
+                    f"settings.{setting_name} is not set.",
+                    hint=hint,
+                    id="core.E001",
+                )
+            )
+    return errors

--- a/core/tests.py
+++ b/core/tests.py
@@ -2,11 +2,12 @@ from decimal import Decimal
 from unittest.mock import patch, PropertyMock
 
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from core.checks import REQUIRED_PROD_SETTINGS, check_required_prod_settings
 from core.models import GameSettings
 from users.services.login_services import (
     calculate_daily_login_reward,
@@ -231,3 +232,30 @@ class GameSettingsAPITest(APITestCase):
         self.client.force_authenticate(user=None)
         res = self.client.get("/api/v1/game_settings/")
         self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class RequiredProdSettingsCheckTest(SimpleTestCase):
+    def all_settings_present(self):
+        return {name: "set" for name, _hint in REQUIRED_PROD_SETTINGS}
+
+    def test_passes_when_all_settings_present(self):
+        with override_settings(**self.all_settings_present()):
+            errors = check_required_prod_settings(app_configs=None)
+        self.assertEqual(errors, [])
+
+    def test_reports_error_for_each_missing_setting(self):
+        overrides = self.all_settings_present()
+        overrides.update(SECRET_KEY="", STRIPE_SECRET_KEY="")
+        with override_settings(**overrides):
+            errors = check_required_prod_settings(app_configs=None)
+        messages = [error.msg for error in errors]
+        self.assertEqual(len(errors), 2)
+        self.assertIn("settings.SECRET_KEY is not set.", messages)
+        self.assertIn("settings.STRIPE_SECRET_KEY is not set.", messages)
+
+    def test_error_ids_are_scoped_to_core(self):
+        overrides = self.all_settings_present()
+        overrides.update(DATABASE_URL="")
+        with override_settings(**overrides):
+            errors = check_required_prod_settings(app_configs=None)
+        self.assertEqual(errors[0].id, "core.E001")

--- a/progress_rpg/settings/prod.py
+++ b/progress_rpg/settings/prod.py
@@ -8,7 +8,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 from .base import *
 from urllib.parse import quote
-from .utils import get_redis_url, get_required_env
+from .utils import get_redis_url
 
 LOGGING = {
     "version": 1,
@@ -93,11 +93,10 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False
 EMAIL_HOST_USER = "resend"  # Resend SMTP requires this literal string as the username
-EMAIL_HOST_PASSWORD = get_required_env(
-    "RESEND_API_KEY",
-    hint="Without it Django skips SMTP auth and Resend rejects every email "
-    "with '530 authentication Required'. Set it in the service's env group.",
-)
+# Validated by core.checks.check_required_prod_settings (manage.py check --deploy);
+# an unset key here just means Django skips SMTP auth and Resend rejects every
+# email with '530 authentication Required'.
+EMAIL_HOST_PASSWORD = os.environ.get("RESEND_API_KEY", "")
 
 print("DEBUG:", DEBUG, file=sys.stderr)
 

--- a/progress_rpg/settings/utils.py
+++ b/progress_rpg/settings/utils.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 import os
 
 
@@ -31,22 +30,6 @@ def get_redis_url(default_db="0"):
 
 def get_dev_email_backend():
     return os.getenv("EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend")
-
-
-def get_required_env(name, hint=""):
-    """
-    Read an env var that must be non-empty, failing at settings import so a
-    missing secret breaks the deploy instead of surfacing later at runtime
-    (e.g. an unset RESEND_API_KEY makes Django skip SMTP auth and every
-    outbound email fails with '530 authentication Required').
-    """
-    value = os.environ.get(name, "")
-    if not value:
-        message = f"{name} environment variable is not set"
-        if hint:
-            message = f"{message}. {hint}"
-        raise ImproperlyConfigured(message)
-    return value
 
 
 def get_build_number():

--- a/progress_rpg/tests/test_settings_utils.py
+++ b/progress_rpg/tests/test_settings_utils.py
@@ -1,10 +1,9 @@
 import os
 from unittest.mock import patch
 
-from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
-from progress_rpg.settings.utils import get_dev_email_backend, get_required_env
+from progress_rpg.settings.utils import get_dev_email_backend
 
 
 class DevEmailBackendSettingsTest(SimpleTestCase):
@@ -25,27 +24,3 @@ class DevEmailBackendSettingsTest(SimpleTestCase):
                 get_dev_email_backend(),
                 "django.core.mail.backends.smtp.EmailBackend",
             )
-
-
-class RequiredEnvSettingsTest(SimpleTestCase):
-    def test_returns_value_when_set(self):
-        with patch.dict(os.environ, {"RESEND_API_KEY": "re_123"}, clear=True):
-            self.assertEqual(get_required_env("RESEND_API_KEY"), "re_123")
-
-    def test_raises_when_missing(self):
-        with patch.dict(os.environ, {}, clear=True):
-            with self.assertRaises(ImproperlyConfigured):
-                get_required_env("RESEND_API_KEY")
-
-    def test_raises_when_empty(self):
-        with patch.dict(os.environ, {"RESEND_API_KEY": ""}, clear=True):
-            with self.assertRaises(ImproperlyConfigured):
-                get_required_env("RESEND_API_KEY")
-
-    def test_hint_is_appended_to_error(self):
-        with patch.dict(os.environ, {}, clear=True):
-            with self.assertRaisesMessage(
-                ImproperlyConfigured,
-                "RESEND_API_KEY environment variable is not set. Set it.",
-            ):
-                get_required_env("RESEND_API_KEY", hint="Set it.")

--- a/scripts/pre-deploy.sh
+++ b/scripts/pre-deploy.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 set -e
+python manage.py check --deploy
 python manage.py migrate


### PR DESCRIPTION
## Summary

Closes #555.

- Adds `core.checks.check_required_prod_settings`, a Django system check (`Tags.security`, `deploy=True`) that validates `SECRET_KEY`, `DATABASE_URL`, `EMAIL_HOST_PASSWORD` (`RESEND_API_KEY`), and the active Stripe keys (`STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_WEBHOOK_SECRET`) are non-empty.
- Registered via `core/apps.py`'s `ready()`, same pattern as `character/signals.py`.
- Wires `python manage.py check --deploy` into `scripts/pre-deploy.sh`, ahead of `migrate`.
- Reverts the eager `get_required_env()` validation added in #554 back to a plain `os.environ.get(..., "")` lookup for `RESEND_API_KEY` — that eager check ran at settings-import time and would crash *any* management command against prod settings (migrate, shell, Celery worker/beat boot), not just deploys. Validation now happens only under `check --deploy`.
- Drops the now-unneeded `RESEND_API_KEY=dummy` from the Dockerfile's `collectstatic` step.
- Removes `get_required_env` and its tests (superseded by the check); adds `RequiredProdSettingsCheckTest` in `core/tests.py`.

## Test plan
- [x] `manage.py test core.tests.RequiredProdSettingsCheckTest progress_rpg.tests.test_settings_utils` passes
- [x] Full test suite passes
- [x] Verified `SECRET_KEY` empty-string access raises `ImproperlyConfigured` in Django itself (not just returns falsy) — check handles that case explicitly