### PR TITLE
fix: economy_forecast crash when no days simulated

### DIFF
--- a/economy/management/commands/economy_forecast.py
+++ b/economy/management/commands/economy_forecast.py
@@ -368,9 +368,14 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"  First bread produced on simulated day {first_bread_day}."
             )
-        self.stdout.write(
-            f"  Minimum bread baked in a single day: {format_quantity('bread', min_bread)}"
-        )
+        if min_bread is None:
+            self.stdout.write(
+                "  Minimum bread baked in a single day: n/a (no days simulated)"
+            )
+        else:
+            self.stdout.write(
+                f"  Minimum bread baked in a single day: {format_quantity('bread', min_bread)}"
+            )
         self.stdout.write(
             f"  Worst hunger value reached by any character: {worst_hunger:.1f}"
         )


### PR DESCRIPTION
## Summary
- `economy_forecast --days 0` (or any run where bread never gets baked) crashed in `_print_verdict` because `min_bread` stayed `None` and `format_quantity('bread', None)` divides by it.
- Worse: the crash happened inside the `transaction.atomic()` block, before the `--commit` branch runs, so it silently rolled back the whole transaction — including `--seed-wheat` seeding — even though the command printed "Seeded ... wheat".

## Fix
Guard the "minimum bread baked" line to print `n/a (no days simulated)` when `min_bread is None`, instead of crashing.

## Test plan
- [x] `economy_forecast --seed-wheat 1000000 --days 0 --commit` completes and prints "Committed - simulated state persisted."
- [x] `economy_forecast --seed-wheat 10000000 --days 1 --commit` still works as before