### PR TITLE
Fix register page Turnstile validation (#425)

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -258,6 +258,7 @@ class RegistrationStatusResponseSerializer(serializers.Serializer):
     registration_open = serializers.BooleanField()
     registration_enabled = serializers.BooleanField()
     self_serve_registration = serializers.BooleanField()
+    turnstile_site_key = serializers.CharField(allow_blank=True)
 
 
 class WaitlistJoinRequestSerializer(serializers.Serializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -314,7 +314,12 @@ class CustomRegisterSerializer(RegisterSerializer):
         write_only=True, required=False, allow_blank=True
     )
     agree_to_terms = serializers.BooleanField(write_only=True, required=True)
-    turnstile_token = serializers.CharField(write_only=True, required=True)
+    # Blank is allowed so deployments without a Turnstile site key (local dev,
+    # tests) can still register; verification below rejects a blank token
+    # whenever a secret *is* configured.
+    turnstile_token = serializers.CharField(
+        write_only=True, required=True, allow_blank=True
+    )
     email = serializers.EmailField(required=True)
     timezone = serializers.CharField(write_only=True, required=False)
 

--- a/api/views.py
+++ b/api/views.py
@@ -177,6 +177,10 @@ class RegistrationStatusAPIView(APIView):
                 "registration_open": registration_open,
                 "registration_enabled": game_settings.registration_enabled,
                 "self_serve_registration": game_settings.self_serve_registration,
+                # The site key is public, and serving it here keeps it out of
+                # the frontend build: rotating the key or enabling Turnstile
+                # needs only a backend env change, no rebuild.
+                "turnstile_site_key": settings.CF_TURNSTILE_SITE_KEY or "",
             }
         )
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,7 +24,9 @@
     />
     <link rel="canonical" href="https://progressrpg.com/" />
     <title>Progress RPG | ADHD-Friendly Body Doubling Productivity Game</title>
-    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+    <!-- Explicit rendering: the widget is mounted by the React <Turnstile />
+         component, which can appear long after this script has loaded. -->
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/Form/Form.test.tsx
+++ b/frontend/src/components/Form/Form.test.tsx
@@ -57,6 +57,52 @@ describe("Form", () => {
     expect(screen.queryByText("This field is required")).not.toBeInTheDocument();
   });
 
+  it("validates required checkboxes against their checked state", async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <Form
+        title="Terms form"
+        onSubmit={(event) => event.preventDefault()}
+        fields={[
+          {
+            name: "agree_to_terms",
+            label: "I agree",
+            type: "checkbox",
+            checked: false,
+            onChange: vi.fn(),
+            required: true,
+          },
+        ]}
+      />
+    );
+
+    await user.click(screen.getByRole("checkbox"));
+    await user.tab();
+
+    expect(screen.getByText("This field is required")).toBeInTheDocument();
+
+    rerender(
+      <Form
+        title="Terms form"
+        onSubmit={(event) => event.preventDefault()}
+        fields={[
+          {
+            name: "agree_to_terms",
+            label: "I agree",
+            type: "checkbox",
+            checked: true,
+            onChange: vi.fn(),
+            required: true,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("checkbox")).toBeChecked();
+    expect(screen.queryByText("This field is required")).not.toBeInTheDocument();
+  });
+
   it("disables the submit button while submitting", () => {
     render(
       <Form

--- a/frontend/src/components/Form/Form.tsx
+++ b/frontend/src/components/Form/Form.tsx
@@ -10,6 +10,7 @@ interface FormField {
   label?: string;
   type?: string;
   value?: string;
+  checked?: boolean;
   onChange?: (value: string | boolean) => void;
   placeholder?: string;
   helpText?: string;
@@ -58,6 +59,11 @@ export default function Form({
 
     if (!touched[field.name]) return '';
 
+    // Checkboxes carry their state in `checked`, not `value`.
+    if (field.type === 'checkbox') {
+      return field.required && !field.checked ? 'This field is required' : '';
+    }
+
     if (field.required && !field.value) {
       return 'This field is required';
     }
@@ -93,6 +99,7 @@ export default function Form({
                 label={field.label || field.name}
                 type={field.type}
                 value={field.value}
+                checked={field.checked}
                 onChange={field.onChange}
                 placeholder={field.placeholder}
                 helpText={field.helpText}

--- a/frontend/src/components/Turnstile/Turnstile.test.tsx
+++ b/frontend/src/components/Turnstile/Turnstile.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+import Turnstile from './Turnstile';
+
+type Options = {
+  sitekey: string;
+  callback?: (token: string) => void;
+  'expired-callback'?: () => void;
+  'error-callback'?: () => void;
+};
+
+function installTurnstile() {
+  const rendered: { container: HTMLElement; options: Options; id: string }[] = [];
+  const remove = vi.fn();
+  let nextId = 0;
+  window.turnstile = {
+    render: (container: HTMLElement, options: Options) => {
+      const id = `widget-${nextId++}`;
+      rendered.push({ container, options, id });
+      return id;
+    },
+    remove,
+    reset: vi.fn(),
+  };
+  return { rendered, remove };
+}
+
+describe('Turnstile', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete window.turnstile;
+  });
+
+  it('renders the widget explicitly when the script is already loaded', () => {
+    const { rendered } = installTurnstile();
+
+    render(<Turnstile sitekey="test-key" onToken={vi.fn()} />);
+
+    expect(rendered).toHaveLength(1);
+    expect(rendered[0].options.sitekey).toBe('test-key');
+    expect(rendered[0].container).toBe(screen.getByTestId('turnstile'));
+  });
+
+  it('renders the widget once the async script becomes available', () => {
+    render(<Turnstile sitekey="test-key" onToken={vi.fn()} />);
+
+    // Script not loaded yet — nothing rendered, but the component keeps waiting.
+    const { rendered } = installTurnstile();
+    expect(rendered).toHaveLength(0);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(rendered).toHaveLength(1);
+  });
+
+  it('reports the token from the widget callback', () => {
+    const { rendered } = installTurnstile();
+    const onToken = vi.fn();
+
+    render(<Turnstile sitekey="test-key" onToken={onToken} />);
+    rendered[0].options.callback?.('tok-123');
+
+    expect(onToken).toHaveBeenCalledWith('tok-123');
+  });
+
+  it('clears the token when the widget expires or errors', () => {
+    const { rendered } = installTurnstile();
+    const onToken = vi.fn();
+
+    render(<Turnstile sitekey="test-key" onToken={onToken} />);
+    rendered[0].options.callback?.('tok-123');
+    rendered[0].options['expired-callback']?.();
+    expect(onToken).toHaveBeenLastCalledWith('');
+
+    rendered[0].options['error-callback']?.();
+    expect(onToken).toHaveBeenLastCalledWith('');
+  });
+
+  it('removes the widget on unmount', () => {
+    const { rendered, remove } = installTurnstile();
+
+    const { unmount } = render(<Turnstile sitekey="test-key" onToken={vi.fn()} />);
+    unmount();
+
+    expect(remove).toHaveBeenCalledWith(rendered[0].id);
+  });
+
+  it('stops polling after the timeout', () => {
+    render(<Turnstile sitekey="test-key" onToken={vi.fn()} />);
+
+    act(() => {
+      vi.advanceTimersByTime(20000);
+    });
+
+    const { rendered } = installTurnstile();
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(rendered).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/Turnstile/Turnstile.tsx
+++ b/frontend/src/components/Turnstile/Turnstile.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useRef } from 'react';
+
+interface TurnstileRenderOptions {
+  sitekey: string;
+  callback?: (token: string) => void;
+  'expired-callback'?: () => void;
+  'error-callback'?: () => void;
+  'timeout-callback'?: () => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        container: HTMLElement,
+        options: TurnstileRenderOptions
+      ) => string | undefined;
+      remove: (widgetId: string) => void;
+      reset: (widgetId?: string) => void;
+    };
+  }
+}
+
+interface TurnstileProps {
+  sitekey: string;
+  /** Called with the current token, or '' when it expires or errors. */
+  onToken: (token: string) => void;
+  className?: string;
+}
+
+// The Cloudflare script is loaded async from index.html, so it may not be
+// available yet when this component mounts. Poll for it rather than relying on
+// implicit rendering: implicit rendering only scans the DOM once, when the
+// script loads, which never matches a widget mounted later by SPA navigation.
+const POLL_INTERVAL_MS = 100;
+const POLL_TIMEOUT_MS = 15000;
+
+export default function Turnstile({
+  sitekey,
+  onToken,
+  className,
+}: TurnstileProps): React.ReactElement {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Keep the latest callback in a ref so re-renders don't re-render the widget.
+  const onTokenRef = useRef(onToken);
+  useEffect(() => {
+    onTokenRef.current = onToken;
+  }, [onToken]);
+
+  useEffect(() => {
+    let widgetId: string | undefined;
+    let pollTimer: ReturnType<typeof setInterval> | undefined;
+    let cancelled = false;
+    const startedAt = Date.now();
+
+    const renderWidget = () => {
+      const container = containerRef.current;
+      if (cancelled || !container || !window.turnstile) return false;
+
+      widgetId = window.turnstile.render(container, {
+        sitekey,
+        callback: (token: string) => onTokenRef.current(token),
+        'expired-callback': () => onTokenRef.current(''),
+        'error-callback': () => onTokenRef.current(''),
+        'timeout-callback': () => onTokenRef.current(''),
+      });
+      return true;
+    };
+
+    if (!renderWidget()) {
+      pollTimer = setInterval(() => {
+        if (renderWidget() || Date.now() - startedAt > POLL_TIMEOUT_MS) {
+          if (pollTimer) clearInterval(pollTimer);
+        }
+      }, POLL_INTERVAL_MS);
+    }
+
+    return () => {
+      cancelled = true;
+      if (pollTimer) clearInterval(pollTimer);
+      if (widgetId && window.turnstile) {
+        window.turnstile.remove(widgetId);
+      }
+      onTokenRef.current('');
+    };
+  }, [sitekey]);
+
+  return <div ref={containerRef} className={className} data-testid="turnstile" />;
+}

--- a/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
@@ -1,19 +1,53 @@
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import RegisterPage from "./RegisterPage";
 
 const mockUseRegistrationStatus = vi.fn();
+const mockRegister = vi.fn();
 
 vi.mock("../../hooks/useRegistrationStatus", () => ({
   useRegistrationStatus: () => mockUseRegistrationStatus(),
 }));
 
 vi.mock("../../hooks/useRegister", () => ({
-  default: () => ({ register: vi.fn(), characterAvailable: true }),
+  default: () => ({ register: mockRegister, characterAvailable: true }),
 }));
+
+type TurnstileOptions = { sitekey: string; callback?: (token: string) => void };
+const turnstileWidgets: { options: TurnstileOptions }[] = [];
+
+function installTurnstile() {
+  window.turnstile = {
+    render: (_container: HTMLElement, options: TurnstileOptions) => {
+      turnstileWidgets.push({ options });
+      return `widget-${turnstileWidgets.length}`;
+    },
+    remove: vi.fn(),
+    reset: vi.fn(),
+  };
+}
+
+function openRegistration() {
+  mockUseRegistrationStatus.mockReturnValue({
+    data: {
+      registration_open: true,
+      registration_enabled: true,
+      self_serve_registration: true,
+    },
+    isLoading: false,
+  });
+}
+
+async function fillForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/^email/i), "new@example.com");
+  await user.type(screen.getByLabelText(/^password/i), "sup3rs3cret!");
+  await user.type(screen.getByLabelText(/confirm password/i), "sup3rs3cret!");
+  await user.click(screen.getByRole("checkbox"));
+}
 
 function renderRegisterPage() {
   return render(
@@ -24,6 +58,17 @@ function renderRegisterPage() {
 }
 
 describe("RegisterPage", () => {
+  beforeEach(() => {
+    turnstileWidgets.length = 0;
+    mockRegister.mockReset();
+    mockRegister.mockResolvedValue({ success: true, confirmationRequired: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete window.turnstile;
+  });
+
   it("renders the kill-switch fallback when registration_enabled is false", () => {
     mockUseRegistrationStatus.mockReturnValue({
       data: {
@@ -109,5 +154,82 @@ describe("RegisterPage", () => {
     renderRegisterPage();
 
     expect(screen.getByLabelText(/invite code \(optional\)/i)).not.toBeRequired();
+  });
+
+  it("renders the Turnstile widget when the form mounts after the script has loaded", () => {
+    // Reproduces the SPA bug: the form only mounts once the registration-status
+    // query resolves, long after Cloudflare's implicit DOM scan has run.
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
+    installTurnstile();
+    openRegistration();
+
+    renderRegisterPage();
+
+    expect(turnstileWidgets).toHaveLength(1);
+    expect(turnstileWidgets[0].options.sitekey).toBe("site-key-123");
+  });
+
+  it("blocks submission until the security check produces a token", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
+    installTurnstile();
+    openRegistration();
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+    await fillForm(user);
+    await user.click(screen.getByRole("button", { name: "Create Account" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /complete the security check/i
+    );
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it("submits with the token once the security check completes", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
+    installTurnstile();
+    openRegistration();
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+    await fillForm(user);
+    act(() => turnstileWidgets[0].options.callback?.("tok-abc"));
+
+    await user.click(screen.getByRole("button", { name: "Create Account" }));
+
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    expect(mockRegister.mock.calls[0][5]).toBe("tok-abc");
+  });
+
+  it("does not gate submission on a token when no site key is configured", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
+    openRegistration();
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+    expect(screen.queryByTestId("turnstile")).not.toBeInTheDocument();
+
+    await fillForm(user);
+    await user.click(screen.getByRole("button", { name: "Create Account" }));
+
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+  });
+
+  it("requires the terms checkbox before submitting", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
+    installTurnstile();
+    openRegistration();
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+    await user.type(screen.getByLabelText(/^email/i), "new@example.com");
+    await user.type(screen.getByLabelText(/^password/i), "sup3rs3cret!");
+    await user.type(screen.getByLabelText(/confirm password/i), "sup3rs3cret!");
+    act(() => turnstileWidgets[0].options.callback?.("tok-abc"));
+
+    await user.click(screen.getByRole("button", { name: "Create Account" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/agree to the Terms/i);
+    expect(mockRegister).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
@@ -31,12 +31,13 @@ function installTurnstile() {
   };
 }
 
-function openRegistration() {
+function openRegistration(turnstileSiteKey = "site-key-123") {
   mockUseRegistrationStatus.mockReturnValue({
     data: {
       registration_open: true,
       registration_enabled: true,
       self_serve_registration: true,
+      turnstile_site_key: turnstileSiteKey,
     },
     isLoading: false,
   });
@@ -159,7 +160,6 @@ describe("RegisterPage", () => {
   it("renders the Turnstile widget when the form mounts after the script has loaded", () => {
     // Reproduces the SPA bug: the form only mounts once the registration-status
     // query resolves, long after Cloudflare's implicit DOM scan has run.
-    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
     installTurnstile();
     openRegistration();
 
@@ -170,7 +170,6 @@ describe("RegisterPage", () => {
   });
 
   it("blocks submission until the security check produces a token", async () => {
-    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
     installTurnstile();
     openRegistration();
     const user = userEvent.setup();
@@ -186,7 +185,6 @@ describe("RegisterPage", () => {
   });
 
   it("submits with the token once the security check completes", async () => {
-    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
     installTurnstile();
     openRegistration();
     const user = userEvent.setup();
@@ -203,7 +201,7 @@ describe("RegisterPage", () => {
 
   it("does not gate submission on a token when no site key is configured", async () => {
     vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
-    openRegistration();
+    openRegistration("");
     const user = userEvent.setup();
 
     renderRegisterPage();
@@ -215,8 +213,18 @@ describe("RegisterPage", () => {
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
   });
 
+  it("falls back to the build-time site key when the API returns none", () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "env-key-456");
+    installTurnstile();
+    openRegistration("");
+
+    renderRegisterPage();
+
+    expect(turnstileWidgets).toHaveLength(1);
+    expect(turnstileWidgets[0].options.sitekey).toBe("env-key-456");
+  });
+
   it("requires the terms checkbox before submitting", async () => {
-    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
     installTurnstile();
     openRegistration();
     const user = userEvent.setup();

--- a/frontend/src/pages/RegisterPage/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.tsx
@@ -8,12 +8,21 @@ import useRegister from '../../hooks/useRegister';
 import { useRegistrationStatus } from '../../hooks/useRegistrationStatus';
 import styles from './RegisterPage.module.scss';
 
+// The site key comes from the backend (see /registration_status/) so rotating
+// it or turning Turnstile on doesn't need a frontend rebuild. The build-time
+// env var stays supported as a local override.
+function resolveTurnstileSiteKey(apiSiteKey?: string): string | undefined {
+  return apiSiteKey || (import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined) || undefined;
+}
+
 function RegistrationForm({
   inviteToken,
   selfServe,
+  turnstileSiteKey,
 }: {
   inviteToken?: string;
   selfServe?: boolean;
+  turnstileSiteKey?: string;
 }): React.ReactElement {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -27,7 +36,6 @@ function RegistrationForm({
   const [agreeToTerms, setAgreeToTerms] = useState(false);
   const [formState, setFormState] = useState<'default' | 'submitted'>('default');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
 
   const handleTurnstileToken = useCallback((token: string) => {
     setTurnstileToken(token);
@@ -250,6 +258,7 @@ export default function RegisterPage(): React.ReactElement {
           key={location.key}
           inviteToken={inviteToken}
           selfServe={data?.self_serve_registration}
+          turnstileSiteKey={resolveTurnstileSiteKey(data?.turnstile_site_key)}
         />
       </div>
     </div>

--- a/frontend/src/pages/RegisterPage/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.tsx
@@ -1,19 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import Form from '../../components/Form/Form';
 import Input from '../../components/Input/Input';
+import Turnstile from '../../components/Turnstile/Turnstile';
 import WaitlistForm from '../../components/WaitlistForm/WaitlistForm';
 import useRegister from '../../hooks/useRegister';
 import { useRegistrationStatus } from '../../hooks/useRegistrationStatus';
 import styles from './RegisterPage.module.scss';
-
-declare global {
-  interface Window {
-    __turnstileCallback?: (token: string) => void;
-  }
-}
-
-const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
 
 function RegistrationForm({
   inviteToken,
@@ -34,13 +27,10 @@ function RegistrationForm({
   const [agreeToTerms, setAgreeToTerms] = useState(false);
   const [formState, setFormState] = useState<'default' | 'submitted'>('default');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
 
-  useEffect(() => {
-    // Expose a global callback for the Turnstile widget to call
-    window.__turnstileCallback = (token: string) => setTurnstileToken(token);
-    return () => {
-      delete window.__turnstileCallback;
-    };
+  const handleTurnstileToken = useCallback((token: string) => {
+    setTurnstileToken(token);
   }, []);
 
   const handleRegister = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -54,7 +44,14 @@ function RegistrationForm({
       return;
     }
 
-    if (!turnstileToken) {
+    if (!agreeToTerms) {
+      setError('Please agree to the Terms of Service and Privacy Policy.');
+      return;
+    }
+
+    // Without a site key there is no widget to complete, so don't gate on a
+    // token the user has no way of producing (the backend still verifies).
+    if (turnstileSiteKey && !turnstileToken) {
       setError('Please complete the security check.');
       return;
     }
@@ -164,6 +161,7 @@ function RegistrationForm({
             checked={agreeToTerms}
             onChange={(e) => setAgreeToTerms(e.target.checked)}
             required
+            aria-invalid={!!error && !agreeToTerms}
           />
           <label htmlFor="agree_to_terms">
             I agree to the{' '}
@@ -177,11 +175,9 @@ function RegistrationForm({
             .
           </label>
         </div>
-        <div
-          className="cf-turnstile"
-          data-sitekey={TURNSTILE_SITE_KEY}
-          data-callback="__turnstileCallback"
-        />
+        {turnstileSiteKey && (
+          <Turnstile sitekey={turnstileSiteKey} onToken={handleTurnstileToken} />
+        )}
       </Form>
       {error && (
         <p className={styles.error} role="alert">

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -46,6 +46,8 @@ export interface RegistrationStatus {
   registration_open: boolean;
   registration_enabled: boolean;
   self_serve_registration: boolean;
+  /** Public Cloudflare Turnstile site key; empty when Turnstile is unconfigured. */
+  turnstile_site_key?: string;
 }
 
 /** Game settings returned in fetch_info and /game_settings/ */

--- a/users/tests/test_waitlist.py
+++ b/users/tests/test_waitlist.py
@@ -77,6 +77,18 @@ class RegistrationStatusAPITest(APITestCase):
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertTrue(res.json()["self_serve_registration"])
 
+    def test_turnstile_site_key_reported_when_configured(self):
+        with override_settings(CF_TURNSTILE_SITE_KEY="0x-site-key"):
+            res = self.client.get("/api/v1/registration_status/")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.json()["turnstile_site_key"], "0x-site-key")
+
+    def test_turnstile_site_key_blank_when_unconfigured(self):
+        with override_settings(CF_TURNSTILE_SITE_KEY=None):
+            res = self.client.get("/api/v1/registration_status/")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.json()["turnstile_site_key"], "")
+
 
 class RegistrationKillSwitchTest(APITestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- Self-serve registration on staging always failed with "Please complete the security check" — two independent causes, both fixed:
  1. The Turnstile widget was never rendered. The register form only mounts after the registration-status query resolves, which is after Cloudflare's `api.js` runs its one-shot implicit scan for `.cf-turnstile` elements, so no token was ever produced. Added a `<Turnstile />` component that renders the widget explicitly (`?render=explicit`), polling for the async-loaded script, and clears the token on expiry/error/timeout.
  2. Neither the prod nor staging env groups set `VITE_TURNSTILE_SITE_KEY`, so the bundle had no site key at all. `/registration_status/` (an endpoint the register page already blocks on) now returns `turnstile_site_key` from the backend's `CF_TURNSTILE_SITE_KEY` setting, so enabling/rotating Turnstile is a backend env change with no frontend rebuild. The build-time env var still works as a local override.
- Also fixed: the shared `Form` component validated required checkboxes against `value` instead of `checked`, so a checked "I agree to the Terms" box could still report "This field is required." Added a specific client-side message for the unchecked case.
- `turnstile_token` is now `allow_blank=True` server-side so key-less environments (local dev, tests) aren't blocked; verification still rejects a blank token whenever `CF_TURNSTILE_SECRET_KEY` is configured, and the frontend only skips its own token gate when no site key is present.

## Validation
- Vitest: Turnstile, Form, Input, RegisterPage — 35 tests passing
- `npm run lint` and `tsc --noEmit` clean for touched files
- `npm run build:production` succeeds
- New backend tests for `turnstile_site_key` on `/registration_status/` (not executed in this environment — no Python/Docker available; please run `docker compose run --rm web python manage.py test users.tests.test_waitlist.RegistrationStatusAPITest`)
- Full frontend suite: 358 passing; 12 pre-existing failures in `NavDrawer`/`LibraryPage` unrelated to this change (confirmed failing on base commit too)

## Note on base branch
Per CLAUDE.md, feature PRs normally target `development`. This one targets `staging` directly at the reporter's request, to unblock registration there quickly. A follow-up PR into `development` will be needed so this fix isn't lost on the next `development`→`staging` sync.

Fixes #425


---
_Generated by [Claude Code](https://claude.ai/code/session_0122HFzbokN41qDnDS1LcTJ5)_