### PR TITLE
fix(register): send self-serve-off users to the waitlist, not a dead-end invite code

### DIFF
--- a/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
@@ -112,12 +112,12 @@ describe("RegisterPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the registration form when registration is enabled and cap not reached", () => {
+  it("renders the registration form when registration is enabled, self-serve is on, and cap not reached", () => {
     mockUseRegistrationStatus.mockReturnValue({
       data: {
         registration_open: true,
         registration_enabled: true,
-        self_serve_registration: false,
+        self_serve_registration: true,
       },
       isLoading: false,
     });
@@ -127,7 +127,7 @@ describe("RegisterPage", () => {
     expect(screen.getByRole("button", { name: "Create Account" })).toBeInTheDocument();
   });
 
-  it("requires an invite code when self-serve registration is off", () => {
+  it("renders the waitlist form (not the register form) when self-serve registration is off", () => {
     mockUseRegistrationStatus.mockReturnValue({
       data: {
         registration_open: true,
@@ -139,7 +139,32 @@ describe("RegisterPage", () => {
 
     renderRegisterPage();
 
-    expect(screen.getByLabelText(/invite code/i)).toBeRequired();
+    expect(
+      screen.getByRole("heading", { name: "Registration is by invite only" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create Account" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Join Waitlist" })).toBeInTheDocument();
+  });
+
+  it("still renders the registration form for an invited user even when self-serve registration is off", () => {
+    mockUseRegistrationStatus.mockReturnValue({
+      data: {
+        registration_open: true,
+        registration_enabled: true,
+        self_serve_registration: false,
+      },
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/waitlist/redeem/some-invite-token"]}>
+        <Routes>
+          <Route path="/waitlist/redeem/:token" element={<RegisterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("button", { name: "Create Account" })).toBeInTheDocument();
   });
 
   it("makes the invite code optional when self-serve registration is on", () => {

--- a/frontend/src/pages/RegisterPage/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.tsx
@@ -230,17 +230,21 @@ export default function RegisterPage(): React.ReactElement {
   }
 
   // Invited users always get the registration form, even if the cap has
-  // since been reached again — their invite is proof of a slot at invite time.
-  if (!inviteToken && data && !data.registration_open) {
+  // since been reached again, or self-serve is off — their invite is proof
+  // of a slot at invite time.
+  if (!inviteToken && data && (!data.registration_open || !data.self_serve_registration)) {
+    const title = !data.registration_open
+      ? 'Registration is temporarily full'
+      : 'Registration is by invite only';
+    const body = !data.registration_open
+      ? "We've reached our current capacity for new players. Join the waitlist and we'll be in touch."
+      : "We're inviting new players from the waitlist. Join the waitlist and we'll be in touch.";
     return (
       <div className={styles.page}>
         <div className={styles.formFrame}>
-          <h1 className={styles.title}>Registration is temporarily full</h1>
+          <h1 className={styles.title}>{title}</h1>
           <div className={styles.content}>
-            <p>
-              We&apos;ve reached our current capacity for new players. Join the waitlist and
-              we&apos;ll be in touch.
-            </p>
+            <p>{body}</p>
             <WaitlistForm />
             <p className={styles.footer}>
               Already have an account? <a href="/login">Log in here</a>.


### PR DESCRIPTION
## Summary
- `RegisterPage` now shows the real in-app `WaitlistForm` whenever the registration cap is full **or** `self_serve_registration` is off, instead of only when the cap is full.
- Previously, with self-serve off but the cap not yet reached, users landed on the plain registration form with a required invite-code field and no way to join the waitlist.
- Invite-token holders (`/waitlist/redeem/:token`) are unaffected — they always get the registration form directly.
- Distinct copy for the two waitlist-trigger cases ("Registration is temporarily full" vs. "Registration is by invite only").

## Test plan
- [x] `npx vitest run src/pages/RegisterPage/RegisterPage.test.tsx` — 12/12 passing, including new coverage for the self-serve-off waitlist path and invited-user bypass.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122HFzbokN41qDnDS1LcTJ5)_