### PR TITLE
fix: create Player/ActivityTimer for users created via Django admin

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -15,6 +15,7 @@ from .models import (
     Waitlist,
 )
 from .services import waitlist_service
+from .services.registration_services import ensure_player_setup_for_user
 from character.models import PlayerCharacterLink, Character
 from core.models import GameSettings
 from payments.models import UserSubscription
@@ -245,6 +246,11 @@ class CustomUserAdmin(UserAdmin):
             # path as everyone else, keeping the registration cap accurate.
             obj.is_confirmed = True
         super().save_model(request, obj, form, change)
+        if not change:
+            # UserAdmin.save_model() just does obj.save() - it doesn't go
+            # through CustomUserManager.create_user(), so player setup
+            # (Player + ActivityTimer) has to be triggered explicitly here.
+            ensure_player_setup_for_user(obj)
 
     readonly_fields = [
         "created_at",

--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -20,6 +20,7 @@ from progress_rpg.middleware.timezone import UserTimezoneMiddleware
 from users.adapters import CustomAccountAdapter
 from users.achievements import achievement_goals_for_player
 from users.serializers import PlayerSerializer
+from gameplay.models import ActivityTimer
 from users.models import Player, UserLogin
 from progression.models import PlayerActivity
 from users.tasks import (
@@ -96,6 +97,31 @@ class UserCreationTest(TestCase):
 
         self.assertEqual(generated_name, generate_default_player_name(12345))
         self.assertRegex(generated_name, r"^player_\d{8}$")
+
+    def test_create_user_creates_activity_timer(self):
+        """Test that a new user's player gets an ActivityTimer."""
+        user = self.UserModel.objects.create_user(
+            email="testuser5@example.com", password="testpassword123"
+        )
+        self.assertTrue(ActivityTimer.objects.filter(player=user.player).exists())
+
+    def test_admin_created_user_gets_player_and_activity_timer(self):
+        """UserAdmin.save_model() just does obj.save() - it doesn't go
+        through CustomUserManager.create_user() - so CustomUserAdmin must
+        explicitly run player setup for admin-created users."""
+        from users.admin import CustomUserAdmin
+        from django.contrib import admin as django_admin
+
+        user = self.UserModel(email="testuser6@example.com")
+        user.set_password("testpassword123")
+
+        model_admin = CustomUserAdmin(self.UserModel, django_admin.site)
+        model_admin.save_model(request=None, obj=user, form=None, change=False)
+
+        self.assertTrue(Player.objects.filter(user=user).exists())
+        self.assertTrue(
+            ActivityTimer.objects.filter(player__user=user).exists()
+        )
 
 
 class PlayerNameValidationTest(TestCase):


### PR DESCRIPTION
## Summary
- `CustomUserAdmin.save_model()` previously just called `obj.save()` for new users, bypassing `CustomUserManager.create_user()` and the player-setup service, so admin-created users had no `Player`/`ActivityTimer`.
- This caused `Player.activity_timer.RelatedObjectDoesNotExist` in `/api/v1/fetch_info/` for at least one admin-created user in production.
- `save_model()` now explicitly calls `ensure_player_setup_for_user()` for newly-created users, matching the self-serve signup flow.

## Test plan
- [x] Added `test_admin_created_user_gets_player_and_activity_timer` exercising `CustomUserAdmin.save_model()` directly, asserting both `Player` and `ActivityTimer` are created.
- [x] Added `test_create_user_creates_activity_timer` covering the normal `create_user()` path.
- [ ] `python manage.py test users` (could not run locally in this sandbox — no Django/Docker available)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmU4GC5VebhAGYGYowqtwJ)_