### PR TITLE
fix(tooltip): unify click/tap-to-toggle across desktop and mobile

### DIFF
--- a/frontend/src/components/Map/Map.test.tsx
+++ b/frontend/src/components/Map/Map.test.tsx
@@ -7,7 +7,7 @@ import { TooltipProvider } from '../Tooltip/Tooltip';
 
 function renderMap(props: ComponentProps<typeof PopulationCentreMap>) {
   return render(
-    <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+    <TooltipProvider>
       <PopulationCentreMap {...props} />
     </TooltipProvider>
   );
@@ -332,13 +332,13 @@ describe('PopulationCentreMap', () => {
     };
     const user = userEvent.setup();
     render(
-      <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <TooltipProvider>
         <PopulationCentreMap geojson={geojsonWithBuilding} />
       </TooltipProvider>
     );
 
     const building = document.querySelector('polygon[fill="#ddd"]') as SVGPolygonElement;
-    await user.hover(building);
+    await user.click(building);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('House');
@@ -368,13 +368,13 @@ describe('PopulationCentreMap', () => {
     };
     const user = userEvent.setup();
     render(
-      <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <TooltipProvider>
         <PopulationCentreMap geojson={geojsonWithBuilding} />
       </TooltipProvider>
     );
 
     const building = document.querySelector('polygon[fill="#ddd"]') as SVGPolygonElement;
-    await user.hover(building);
+    await user.click(building);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('Workers: 2');
@@ -401,13 +401,13 @@ describe('PopulationCentreMap', () => {
     };
     const user = userEvent.setup();
     render(
-      <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <TooltipProvider>
         <PopulationCentreMap geojson={geojsonWithHouse} />
       </TooltipProvider>
     );
 
     const house = document.querySelector('polygon[fill="#ddd"]') as SVGPolygonElement;
-    await user.hover(house);
+    await user.click(house);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('Residents: 3');
@@ -433,12 +433,12 @@ describe('PopulationCentreMap', () => {
     };
     const user = userEvent.setup();
     render(
-      <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <TooltipProvider>
         <PopulationCentreMap geojson={geojsonWithCharacter} />
       </TooltipProvider>
     );
 
-    await user.hover(document.querySelector('g') as SVGGElement);
+    await user.click(document.querySelector('g') as SVGGElement);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('Alice');
@@ -466,13 +466,13 @@ describe('PopulationCentreMap', () => {
     };
     const user = userEvent.setup();
     render(
-      <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <TooltipProvider>
         <PopulationCentreMap geojson={geojsonWithReadyField} />
       </TooltipProvider>
     );
 
     const field = document.querySelector('polygon[fill="#E4C158"]') as SVGPolygonElement;
-    await user.hover(field);
+    await user.click(field);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('Ready to harvest');

--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -564,10 +564,7 @@ export default function PopulationCentreMap({
   }, []);
 
   return (
-    // Local provider: map tooltips should appear immediately on hover
-    // (markers are small and easy to overshoot), independent of the app's
-    // default hover delay used elsewhere.
-    <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+    <TooltipProvider>
     <div className={styles.mapWrapper}>
       <svg
         ref={svgRef}

--- a/frontend/src/components/Tooltip/Tooltip.module.scss
+++ b/frontend/src/components/Tooltip/Tooltip.module.scss
@@ -1,6 +1,16 @@
 @use '../../styles/base/variables' as v;
 @use '../../styles/semantic/colors' as c;
 
+.trigger {
+  // Click/tap opens the tooltip now (see #568), so a long-press on a
+  // trigger must never fall through to the browser's native
+  // text-selection/callout gesture - only our own tap handling should run.
+  touch-action: manipulation;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 .content {
   z-index: v.$z-index-tooltip;
   // Read-only content, never something to click/hover on its own - but on

--- a/frontend/src/components/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.stories.tsx
@@ -5,10 +5,12 @@ import Button from '../Button/Button';
 
 /**
  * `Tooltip` wraps a single focusable trigger element and shows supplementary
- * content on hover/focus via Radix. It must be nested under a
+ * content on click/tap or focus via Radix — hover never opens it, on either
+ * desktop or mobile (see #568). Clicking/tapping the trigger again, clicking
+ * anywhere else, or pressing Escape closes it. It must be nested under a
  * `TooltipProvider` (mounted once near the app root). Use tooltips only for
  * supplementary context — essential information must remain available
- * without hovering or focusing.
+ * without clicking or focusing.
  */
 const meta: Meta<typeof Tooltip> = {
   title: 'Shared/Tooltip',
@@ -22,7 +24,7 @@ const meta: Meta<typeof Tooltip> = {
     ),
   ],
   args: {
-    content: 'Additional context shown on hover or focus',
+    content: 'Additional context shown on click/tap or focus',
     placement: 'top',
   },
 };
@@ -33,16 +35,16 @@ type Story = StoryObj<typeof Tooltip>;
 export const Default: Story = {
   render: (args) => (
     <Tooltip {...args}>
-      <Button>Hover or focus me</Button>
+      <Button>Click or focus me</Button>
     </Tooltip>
   ),
   play: async ({ canvas, userEvent, canvasElement }) => {
-    const trigger = canvas.getByRole('button', { name: 'Hover or focus me' });
+    const trigger = canvas.getByRole('button', { name: 'Click or focus me' });
     await userEvent.tab();
     await expect(trigger).toHaveFocus();
     // Tooltip content renders via a Radix Portal into document.body.
     const tooltip = await within(canvasElement.ownerDocument.body).findByRole('tooltip');
-    await expect(tooltip).toHaveTextContent('Additional context shown on hover or focus');
+    await expect(tooltip).toHaveTextContent('Additional context shown on click/tap or focus');
   },
 };
 

--- a/frontend/src/components/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.test.tsx
@@ -7,22 +7,49 @@ function renderTooltip() {
   render(
     <TooltipProvider delayDuration={0} skipDelayDuration={0}>
       <Tooltip content="Helpful context">
-        <button type="button">Hover me</button>
+        <button type="button">Trigger</button>
       </Tooltip>
+      <button type="button">Elsewhere</button>
     </TooltipProvider>
   );
 }
 
 describe('Tooltip', () => {
-  it('shows on hover and hides when the pointer leaves', async () => {
+  it('does not open on hover', async () => {
     const user = userEvent.setup();
 
     renderTooltip();
 
-    await user.hover(screen.getByRole('button', { name: 'Hover me' }));
+    await user.hover(screen.getByRole('button', { name: 'Trigger' }));
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('opens on click and closes when the trigger is clicked again', async () => {
+    const user = userEvent.setup();
+
+    renderTooltip();
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+    await user.click(trigger);
     expect(await screen.findByRole('tooltip')).toHaveTextContent('Helpful context');
 
-    await user.unhover(screen.getByRole('button', { name: 'Hover me' }));
+    await user.click(trigger);
+    await waitFor(() => {
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes when clicking outside the trigger, including unrelated elements', async () => {
+    const user = userEvent.setup();
+
+    renderTooltip();
+
+    await user.click(screen.getByRole('button', { name: 'Trigger' }));
+    expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Elsewhere' }));
 
     await waitFor(() => {
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
@@ -36,7 +63,7 @@ describe('Tooltip', () => {
 
     await user.tab();
 
-    const trigger = screen.getByRole('button', { name: 'Hover me' });
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
     const tooltip = await screen.findByRole('tooltip');
 
     expect(trigger).toHaveFocus();

--- a/frontend/src/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.tsx
@@ -44,6 +44,10 @@ export function TooltipProvider({
  * Use tooltips only for supplementary context. The trigger must remain a
  * focusable interactive element, and any essential information should stay
  * available without requiring hover or focus.
+ *
+ * Click/tap-to-toggle on both desktop and mobile (see #568): hover never
+ * opens the tooltip, and clicking/tapping the trigger again - or anywhere
+ * else - closes it.
  */
 export default function Tooltip({
   children,
@@ -55,27 +59,69 @@ export default function Tooltip({
   disabled = false,
 }: TooltipProps): React.ReactElement {
   const [open, setOpen] = React.useState(false);
+  // Tracks whether the trigger's current focus came from our own
+  // pointerdown handler below, so that handler and handleFocus don't both
+  // try to decide the open state for the same interaction.
+  const pointerDownRef = React.useRef(false);
 
   if (disabled || content === null || content === undefined || content === false) {
     return <>{children}</>;
   }
 
-  // Radix's hover logic explicitly ignores touch pointers, and a tap's own
-  // pointerdown/click still reach the trigger's built-in "close" handlers -
-  // so on mobile the tooltip flashes open and is immediately closed by the
-  // same tap that opened it. Toggling our own controlled state on touch
-  // pointerdown (and preventDefault-ing, which per the Pointer Events spec
-  // suppresses the compatibility click that would otherwise re-close it)
-  // makes a tap behave like a real toggle instead.
+  // Radix's Trigger opens on hover and unconditionally closes on click,
+  // which fights a click/tap-to-toggle model on both counts. We take the
+  // trigger's open/close decisions over entirely: hover is inert (handled
+  // below), and pointerdown is the sole place we ever *open* it - never
+  // close, because a pointerdown on an already-open trigger is also seen by
+  // the open tooltip's own dismissable layer as an "outside" press (the
+  // trigger isn't part of the portaled content), which closes it for us.
+  // Deciding to close here too would race that, since our own pointerdown
+  // handler runs in the bubble phase, after the layer's capture-phase
+  // dismissal has already fired.
   const handlePointerDown = (event: React.PointerEvent) => {
-    if (event.pointerType !== 'touch') return;
     event.preventDefault();
-    setOpen((prev) => !prev);
+    pointerDownRef.current = true;
+    document.addEventListener(
+      'pointerup',
+      () => {
+        pointerDownRef.current = false;
+      },
+      { once: true }
+    );
+    if (!open) setOpen(true);
+  };
+
+  // preventDefault() on pointerdown doesn't stop the resulting click event
+  // for mouse pointers (only for touch, where it suppresses the
+  // compatibility click outright) - so on desktop, Radix's own "click
+  // always closes" trigger handler would still fire right after the
+  // pointerdown above opens it. Taking the click event over too stops that.
+  const handleClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+  };
+
+  // Suppress Radix's hover-driven open/close entirely - hover is cursor
+  // affordance only now, never a way to open or close the tooltip.
+  const suppressHover = (event: React.PointerEvent) => {
+    event.preventDefault();
+  };
+
+  const handleFocus = (event: React.FocusEvent) => {
+    event.preventDefault();
+    if (!pointerDownRef.current) setOpen(true);
   };
 
   return (
     <TooltipPrimitive.Root open={open} onOpenChange={setOpen}>
-      <TooltipPrimitive.Trigger asChild onPointerDown={handlePointerDown}>
+      <TooltipPrimitive.Trigger
+        asChild
+        className={styles.trigger}
+        onPointerDown={handlePointerDown}
+        onClick={handleClick}
+        onPointerMove={suppressHover}
+        onPointerLeave={suppressHover}
+        onFocus={handleFocus}
+      >
         {children}
       </TooltipPrimitive.Trigger>
       <TooltipPrimitive.Portal>


### PR DESCRIPTION
## Summary
- Replaces hover-to-open (desktop) / tap-to-open (mobile) with a single click/tap-to-toggle model in `Tooltip`, superseding the mobile-only fix in #566
- Trigger now takes over open/close entirely: hover never opens or closes the tooltip (cursor affordance only), and a single pointerdown handler drives both mouse and touch — opening when closed, and relying on the open tooltip's own dismissable layer to close it when the trigger or anywhere else is pressed again
- Adds `touch-action`/`-webkit-touch-callout`/`user-select` CSS on the trigger so long-press no longer triggers the native text-selection/context-menu gesture on mobile
- Updates `Map`'s `TooltipProvider` usage and tests, which relied on hover-open (now click-based)

Closes #568

## Test plan
- [x] `npx vitest run src/components/Tooltip/Tooltip.test.tsx src/components/Map/Map.test.tsx src/layout/Infobar/AchievementBadges.test.tsx` — all pass
- [x] `npx eslint src/components/Tooltip src/components/Map` — clean
- [x] `npx tsc --noEmit` — no new errors
- [ ] Manual verification on a real mobile device or accurate touch emulation (not done in this session — recommend verifying tap-to-toggle and no long-press text-selection before merging to `main`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPDRE7nvrcveGNsU6PJUhU)_