### PR TITLE
Fix character teleport on large walker resync (#615 follow-up)

### DIFF
--- a/frontend/src/components/Map/Map.test.tsx
+++ b/frontend/src/components/Map/Map.test.tsx
@@ -665,4 +665,56 @@ describe('PopulationCentreMap path-aware interpolation (#615)', () => {
 
     expect(markerTransform(marker)).toEqual([50, 50]);
   });
+
+  it('glides toward a large resync correction instead of snapping to it instantly (#615 follow-up)', () => {
+    const { container, rerender } = renderMap({ geojson: walkingGeojson });
+    const marker = container.querySelector('g') as SVGGElement;
+
+    // Walk partway along the first (known) segment.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    const [midX] = markerTransform(marker);
+    expect(midX).toBeGreaterThan(0);
+    expect(midX).toBeLessThan(10);
+
+    // A fresh poll reports the character much further along a completely
+    // different route than the client knew about (e.g. it ran past the end
+    // of a capped path preview, or was rerouted) - well beyond
+    // WALKER_RESYNC_DRIFT_THRESHOLD from where the client currently has it.
+    const correctedGeojson = {
+      bbox: [0, 0, 100, 100] as [number, number, number, number],
+      features: [
+        {
+          geometry: { type: 'Point', coordinates: [50, 50] },
+          properties: {
+            feature_type: 'character',
+            id: 1,
+            name: 'Walker',
+            path: [[60, 50]] as [number, number][],
+            effective_speed: 5,
+          },
+        },
+      ],
+    };
+    rerender(
+      <TooltipProvider>
+        <PopulationCentreMap geojson={correctedGeojson} />
+      </TooltipProvider>
+    );
+
+    // Immediately after the correcting poll, the marker should still be
+    // near where the client had it - not instantly teleported to (50, 50).
+    const distanceTo50 = ([x, y]: [number, number]) => Math.hypot(x - 50, y - 50);
+    const justAfter = markerTransform(marker);
+    expect(distanceTo50(justAfter)).toBeGreaterThan(3);
+
+    // But it should be walking straight toward the corrected point rather
+    // than stalled - and eventually arrive there.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    const closer = markerTransform(marker);
+    expect(distanceTo50(closer)).toBeLessThan(distanceTo50(justAfter));
+  });
 });

--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -218,11 +218,11 @@ interface WalkerState {
 }
 
 // If the authoritative polled position lands further than this from where
-// the client has locally walked a character to, snap straight to the poll
-// instead of gliding - a drift this big means a reroute (e.g. a schedule-
-// driven commute reversal) or a missed poll, not just normal interpolation
-// lag, and trying to glide across it would read as the character cutting
-// through walls/buildings to get there.
+// the client has locally walked a character to, treat it as a correction
+// leg (see the resync effect below) rather than ordinary interpolation lag -
+// a drift this big means a reroute (e.g. a schedule-driven commute reversal),
+// a missed poll, or the client running out of its previously-known path
+// before this poll refreshed it.
 const WALKER_RESYNC_DRIFT_THRESHOLD = 3;
 
 // Advances a walker's position along its remaining path by `distance` units,
@@ -601,10 +601,16 @@ export default function PopulationCentreMap({
   const walkerNodeRefs = useRef<Map<string, SVGGElement | null>>(new Map());
 
   // Resyncs each walking character's stored path/speed to the latest poll
-  // whenever the underlying geojson changes. Only snaps the tracked position
-  // itself if it's drifted far from the authoritative one (a reroute or a
-  // missed poll) - otherwise the animation loop keeps walking smoothly from
-  // wherever it currently has the character, picking up the fresh path.
+  // whenever the underlying geojson changes. The tracked position is never
+  // snapped straight to the authoritative one, even when it's drifted far
+  // (a reroute, a missed poll, or the client having walked past the end of
+  // its previously-known, capped-length path before this poll refreshed
+  // it - see JOURNEY_PATH_PREVIEW_LIMIT) - an instant jump there reads as
+  // teleporting. Instead the authoritative point is inserted as the next
+  // waypoint, so the animation loop walks the character there at its normal
+  // speed like any other leg of the route, then continues on with the fresh
+  // path - smooth in every case, just a sharper turn when the drift is
+  // large.
   useEffect(() => {
     const activeIds = new Set<string>();
 
@@ -621,10 +627,10 @@ export default function PopulationCentreMap({
         continue;
       }
 
-      if (distanceBetween(existing.pos, [x, y]) > WALKER_RESYNC_DRIFT_THRESHOLD) {
-        existing.pos = [x, y];
-      }
-      existing.path = path;
+      existing.path =
+        distanceBetween(existing.pos, [x, y]) > WALKER_RESYNC_DRIFT_THRESHOLD
+          ? [[x, y], ...path]
+          : path;
       existing.speed = speed;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #621. After that fix landed on staging, a screen recording showed characters still visibly teleporting on the map (not the original poll/CSS-transition mismatch — a different bug in the new path-aware walker code).

Root cause: in `Map.tsx`'s walker resync effect, whenever a walking character's client-tracked position drifted more than `WALKER_RESYNC_DRIFT_THRESHOLD` (3 units) from the authoritative polled position — e.g. a reroute, a missed poll, or the client working through more of its capped path preview (`JOURNEY_PATH_PREVIEW_LIMIT`) than fits in one 2s poll interval — the code snapped `walker.pos` straight to the new position. That bypassed the per-frame animation loop entirely, so the character instantly jumped instead of gliding.

## Change

Instead of overwriting the tracked position, the corrected point is now prepended as the next waypoint on the walker's path. The existing per-frame animation loop walks the character there at normal speed like any other leg of the route, so corrections read as a (possibly sharp) turn rather than a teleport — no separate "catch-up" logic needed.

## Test plan

- [x] `npx vitest run src/components/Map/Map.test.tsx` — 26/26 passing, including a new test asserting a large resync correction glides toward the authoritative point over subsequent frames instead of snapping to it immediately.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.
- [ ] Manual verification on staging once deployed (backend test suite and full frontend E2E could not be run locally in this sandbox — no `.env`/DB available).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNY7CYzaGPoJWfWVukcumS)_