### PR TITLE
Recompute walker position from a fresh checkpoint each frame (#615 follow-up)

### DIFF
--- a/frontend/src/components/Map/Map.test.tsx
+++ b/frontend/src/components/Map/Map.test.tsx
@@ -666,7 +666,7 @@ describe('PopulationCentreMap path-aware interpolation (#615)', () => {
     expect(markerTransform(marker)).toEqual([50, 50]);
   });
 
-  it('glides toward a large resync correction instead of snapping to it instantly (#615 follow-up)', () => {
+  it('adopts a fresh poll as the new authoritative checkpoint rather than extrapolating from the previous one (#615 follow-up)', () => {
     const { container, rerender } = renderMap({ geojson: walkingGeojson });
     const marker = container.querySelector('g') as SVGGElement;
 
@@ -678,10 +678,9 @@ describe('PopulationCentreMap path-aware interpolation (#615)', () => {
     expect(midX).toBeGreaterThan(0);
     expect(midX).toBeLessThan(10);
 
-    // A fresh poll reports the character much further along a completely
-    // different route than the client knew about (e.g. it ran past the end
-    // of a capped path preview, or was rerouted) - well beyond
-    // WALKER_RESYNC_DRIFT_THRESHOLD from where the client currently has it.
+    // A fresh poll reports the character on a completely different route
+    // than the client knew about (e.g. a reroute, or the client having run
+    // past the end of a capped path preview between polls).
     const correctedGeojson = {
       bbox: [0, 0, 100, 100] as [number, number, number, number],
       features: [
@@ -703,18 +702,55 @@ describe('PopulationCentreMap path-aware interpolation (#615)', () => {
       </TooltipProvider>
     );
 
-    // Immediately after the correcting poll, the marker should still be
-    // near where the client had it - not instantly teleported to (50, 50).
-    const distanceTo50 = ([x, y]: [number, number]) => Math.hypot(x - 50, y - 50);
+    // The poll is trusted outright as the character's new position, not
+    // treated as a target to glide toward from wherever the client's own
+    // (possibly wrong) extrapolation had drifted to - the whole point of
+    // recomputing from a fresh checkpoint every poll is that error never
+    // gets a chance to compound across polls in the first place.
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
     const justAfter = markerTransform(marker);
-    expect(distanceTo50(justAfter)).toBeGreaterThan(3);
+    expect(Math.hypot(justAfter[0] - 50, justAfter[1] - 50)).toBeLessThan(0.5);
 
-    // But it should be walking straight toward the corrected point rather
-    // than stalled - and eventually arrive there.
+    // And it continues walking normally from there along the fresh path.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    const later = markerTransform(marker);
+    expect(later[0]).toBeGreaterThan(justAfter[0]);
+    expect(later[1]).toBeCloseTo(50, 5);
+  });
+
+  it('recomputes position fresh each frame instead of accumulating step-to-step error (#615 follow-up)', () => {
+    // Two renders of the same walking character: one where time is advanced
+    // in a single 1000ms jump, one where the same 1000ms passes across many
+    // small frames. If position were stepped incrementally frame-by-frame
+    // (the earlier implementation), many small steps could drift from one
+    // big step over time; recomputing from the checkpoint every frame keeps
+    // them identical regardless of how the elapsed time was divided up.
+    const { container: singleStepContainer } = renderMap({ geojson: walkingGeojson });
     act(() => {
       vi.advanceTimersByTime(1000);
     });
-    const closer = markerTransform(marker);
-    expect(distanceTo50(closer)).toBeLessThan(distanceTo50(justAfter));
+    const singleStepPos = markerTransform(
+      singleStepContainer.querySelector('g') as SVGGElement
+    );
+
+    const { container: manyStepsContainer } = renderMap({ geojson: walkingGeojson });
+    act(() => {
+      for (let i = 0; i < 50; i++) {
+        vi.advanceTimersByTime(20);
+      }
+    });
+    const manyStepsPos = markerTransform(
+      manyStepsContainer.querySelector('g') as SVGGElement
+    );
+
+    // A small tolerance accounts for fake-timer rAF scheduling granularity,
+    // not accumulated simulation error - the two should land in the same
+    // place regardless of how the elapsed time was chunked into frames.
+    expect(manyStepsPos[0]).toBeCloseTo(singleStepPos[0], 1);
+    expect(manyStepsPos[1]).toBeCloseTo(singleStepPos[1], 1);
   });
 });

--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -211,44 +211,56 @@ interface PositionedCharacter {
   isWalking?: boolean;
 }
 
+// A walker's position is never stepped incrementally frame-to-frame (that
+// approach let small per-poll speed mismatches between client and server
+// silently accumulate over the whole journey, surfacing as a character
+// lagging further and further behind, then snapping/rushing to catch up).
+// Instead each poll records a fresh checkpoint - the authoritative position
+// the server reported, the remaining path from there, and the client
+// timestamp it was received - and every frame recomputes position from
+// scratch as a pure function of that checkpoint and elapsed real time.
+// Whatever drift builds up within a single poll interval (small, since it's
+// only ever one interval's worth) is wiped out by the next poll's fresh
+// checkpoint rather than compounding across the journey.
 interface WalkerState {
-  pos: [number, number];
+  checkpointPos: [number, number];
   path: [number, number][];
   speed: number;
+  receivedAt: number;
 }
 
-// If the authoritative polled position lands further than this from where
-// the client has locally walked a character to, treat it as a correction
-// leg (see the resync effect below) rather than ordinary interpolation lag -
-// a drift this big means a reroute (e.g. a schedule-driven commute reversal),
-// a missed poll, or the client running out of its previously-known path
-// before this poll refreshed it.
-const WALKER_RESYNC_DRIFT_THRESHOLD = 3;
-
-// Advances a walker's position along its remaining path by `distance` units,
-// consuming as many waypoints as it reaches in one call rather than stopping
-// at the first one short of the full distance - the same carry-over-leftover-
-// budget approach as the backend's step_toward (locations/services/
-// movement.py), so a character crossing several short segments in one frame
-// doesn't visibly slow down at each waypoint.
-function advanceWalker(walker: WalkerState, distance: number): void {
+// Walks `distance` units from `start` along `path`, consuming as many
+// waypoints as it reaches rather than stopping at the first one short of the
+// full distance - the same carry-over-leftover-budget approach as the
+// backend's step_toward (locations/services/movement.py), so a character
+// crossing several short segments doesn't visibly slow down at each one.
+// Holds at the final point rather than extrapolating past it if `distance`
+// exceeds the path's total length (e.g. the client's clock has run ahead of
+// the server's capped path preview - the next poll will supply more path).
+function positionAlongPath(
+  start: [number, number],
+  path: [number, number][],
+  distance: number
+): [number, number] {
+  let pos = start;
   let remaining = distance;
-  while (remaining > 0 && walker.path.length > 0) {
-    const [nx, ny] = walker.path[0];
-    const dx = nx - walker.pos[0];
-    const dy = ny - walker.pos[1];
+
+  for (const [nx, ny] of path) {
+    const dx = nx - pos[0];
+    const dy = ny - pos[1];
     const segmentDistance = Math.hypot(dx, dy);
 
     if (segmentDistance <= remaining) {
-      walker.pos = [nx, ny];
-      walker.path = walker.path.slice(1);
+      pos = [nx, ny];
       remaining -= segmentDistance;
     } else {
       const factor = segmentDistance === 0 ? 0 : remaining / segmentDistance;
-      walker.pos = [walker.pos[0] + dx * factor, walker.pos[1] + dy * factor];
-      remaining = 0;
+      pos = [pos[0] + dx * factor, pos[1] + dy * factor];
+      break;
     }
   }
+
+  return pos;
 }
 
 function buildingFootprintRings(features: GeoJSONFeature[]): Ring[] {
@@ -600,19 +612,15 @@ export default function PopulationCentreMap({
   const walkersRef = useRef<Map<string, WalkerState>>(new Map());
   const walkerNodeRefs = useRef<Map<string, SVGGElement | null>>(new Map());
 
-  // Resyncs each walking character's stored path/speed to the latest poll
-  // whenever the underlying geojson changes. The tracked position is never
-  // snapped straight to the authoritative one, even when it's drifted far
-  // (a reroute, a missed poll, or the client having walked past the end of
-  // its previously-known, capped-length path before this poll refreshed
-  // it - see JOURNEY_PATH_PREVIEW_LIMIT) - an instant jump there reads as
-  // teleporting. Instead the authoritative point is inserted as the next
-  // waypoint, so the animation loop walks the character there at its normal
-  // speed like any other leg of the route, then continues on with the fresh
-  // path - smooth in every case, just a sharper turn when the drift is
-  // large.
+  // Resets each walking character's checkpoint to the latest poll whenever
+  // the underlying geojson changes: the authoritative position, its
+  // remaining path, its speed, and the moment this checkpoint was taken.
+  // Unconditional - there's no drift to weigh here, since the animation loop
+  // below never accumulates state across polls; it only ever measures time
+  // elapsed since this checkpoint.
   useEffect(() => {
     const activeIds = new Set<string>();
+    const receivedAt = performance.now();
 
     for (const feature of walkingFeatures) {
       const id = String(feature.properties?.id);
@@ -621,17 +629,7 @@ export default function PopulationCentreMap({
       const path = feature.properties?.path ?? [];
       const speed = Number(feature.properties?.effective_speed) || 0;
 
-      const existing = walkersRef.current.get(id);
-      if (!existing) {
-        walkersRef.current.set(id, { pos: [x, y], path, speed });
-        continue;
-      }
-
-      existing.path =
-        distanceBetween(existing.pos, [x, y]) > WALKER_RESYNC_DRIFT_THRESHOLD
-          ? [[x, y], ...path]
-          : path;
-      existing.speed = speed;
+      walkersRef.current.set(id, { checkpointPos: [x, y], path, speed, receivedAt });
     }
 
     // Characters no longer walking (arrived, or gone from the map) fall back
@@ -644,29 +642,30 @@ export default function PopulationCentreMap({
   }, [walkingFeatures]);
 
   // Drives smooth per-frame movement for walking characters between polls.
-  // Writes positions straight to the DOM node (bypassing React state) so a
-  // full re-render isn't needed every frame; positionedCharacters below also
-  // reads the same walker ref for its initial/poll-driven render, so both
-  // stay consistent with whatever the loop has most recently written.
+  // Each frame recomputes position from scratch - the checkpoint plus how
+  // much time has passed since it was taken - rather than stepping forward
+  // from wherever the previous frame left off, so nothing compounds across
+  // frames or across polls (see the WalkerState comment above). Writes
+  // positions straight to the DOM node (bypassing React state) so a full
+  // re-render isn't needed every frame; positionedCharacters below also
+  // reads the same checkpoint for its initial/poll-driven render.
   useEffect(() => {
     let frameId: number;
-    let lastTimestamp: number | null = null;
 
-    const step = (timestamp: number) => {
-      if (lastTimestamp !== null) {
-        const deltaSeconds = (timestamp - lastTimestamp) / 1000;
-        walkersRef.current.forEach((walker, id) => {
-          advanceWalker(walker, walker.speed * deltaSeconds);
-          const node = walkerNodeRefs.current.get(id);
-          if (node) {
-            node.setAttribute(
-              "transform",
-              `translate(${walker.pos[0]}, ${walker.pos[1]})`
-            );
-          }
-        });
-      }
-      lastTimestamp = timestamp;
+    const step = () => {
+      const now = performance.now();
+      walkersRef.current.forEach((walker, id) => {
+        const elapsedSeconds = (now - walker.receivedAt) / 1000;
+        const pos = positionAlongPath(
+          walker.checkpointPos,
+          walker.path,
+          walker.speed * elapsedSeconds
+        );
+        const node = walkerNodeRefs.current.get(id);
+        if (node) {
+          node.setAttribute("transform", `translate(${pos[0]}, ${pos[1]})`);
+        }
+      });
       frameId = requestAnimationFrame(step);
     };
 
@@ -679,7 +678,7 @@ export default function PopulationCentreMap({
     const walkingPositioned: PositionedCharacter[] = walkingFeatures.map((feature) => {
       const id = String(feature.properties?.id);
       const [x, y] = feature.geometry.coordinates as [number, number];
-      const pos = walkersRef.current.get(id)?.pos ?? [x, y];
+      const pos = walkersRef.current.get(id)?.checkpointPos ?? [x, y];
       return { feature, cx: pos[0], cy: pos[1], isWalking: true };
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #622. After that fix landed on staging, movement was reported as still off: characters moved noticeably slower than expected, then appeared to speed up right as they arrived at their destination.

Root cause: the frontend walker ran its own incremental simulation (`advanceWalker` mutating a tracked position every animation frame, independent of the backend's own tick-based movement). Any small mismatch between the two speeds went uncorrected as long as it stayed under the resync drift threshold, so it quietly compounded over the whole journey - the character fell further and further behind. When the journey completed, the character switched from the walker path to idle placement, whose position change is driven by a fixed 2-second CSS transition - so whatever gap had built up over the journey got compressed into that fixed window, reading as a sudden burst of speed right at arrival.

## Change

- Replaced the incremental per-frame simulation with `positionAlongPath`, a pure function computing position from a **checkpoint** (authoritative position + remaining path + speed + the client timestamp it was received) and elapsed real time since that checkpoint - recomputed fresh every animation frame rather than stepped forward from the previous frame's mutated state.
- Every poll now unconditionally resets the checkpoint to the latest authoritative data. Since nothing is carried over between checkpoints, any drift is bounded to a single ~2s poll interval instead of compounding across the whole journey, and arrival needs no special-cased catch-up - it's just where the same formula naturally lands.
- Removed the now-unnecessary drift-threshold/corrective-waypoint logic from the previous fix (#622), since there's no longer any stale state to correct against.

## Test plan

- [x] `npx vitest run src/components/Map/Map.test.tsx` — 27/27 passing, including two new tests: a fresh poll is adopted as the new checkpoint immediately rather than glided toward from stale state, and position is identical whether elapsed time is measured in one big jump or many small animation frames (guards against reintroducing incremental drift).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.
- [ ] Manual verification on staging once deployed (backend test suite and full frontend E2E could not be run locally in this sandbox — no `.env`/DB available).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNY7CYzaGPoJWfWVukcumS)_