### PR TITLE
Fix out-of-order map poll responses overwriting newer data (#624)

### DIFF
--- a/frontend/src/pages/MapPage/MapPage.test.tsx
+++ b/frontend/src/pages/MapPage/MapPage.test.tsx
@@ -1,0 +1,80 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MapPage from './MapPage';
+
+const mockApiFetch = vi.fn();
+
+vi.mock('../../utils/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+vi.mock('../../components/Map/Map', () => ({
+  default: ({ geojson }: { geojson: { meta?: { population_centre_name?: string } } | null }) => (
+    <div data-testid="map-stub">{geojson?.meta?.population_centre_name}</div>
+  ),
+}));
+
+describe('MapPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockApiFetch.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    vi.useRealTimers();
+  });
+
+  it('ignores an out-of-order poll response that resolves after a newer one (#624)', async () => {
+    const mapCalls: { resolve: (value: unknown) => void }[] = [];
+
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url === '/population-centres/') {
+        return Promise.resolve([{ id: 1 }]);
+      }
+      // Each poll to the map endpoint gets its own promise that this test
+      // resolves manually, in whatever order it chooses - simulating
+      // ordinary network jitter where responses needn't arrive in the
+      // order the requests were sent.
+      return new Promise((resolve) => {
+        mapCalls.push({ resolve });
+      });
+    });
+
+    render(<MapPage />);
+
+    // Flush the population-centre lookup (mount effect) so pcId is set and
+    // the first map poll fires.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mapCalls).toHaveLength(1);
+
+    // Advance to the next scheduled poll - a second, newer request goes out
+    // while the first is still pending.
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+    expect(mapCalls).toHaveLength(2);
+
+    // The newer (second) request resolves first...
+    await act(async () => {
+      mapCalls[1].resolve({ meta: { population_centre_name: 'Newer village' } });
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('map-stub').textContent).toBe('Newer village');
+
+    // ...then the older (first) request finally resolves late. It must not
+    // overwrite the newer data that already rendered.
+    await act(async () => {
+      mapCalls[0].resolve({ meta: { population_centre_name: 'Stale village' } });
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('map-stub').textContent).toBe('Newer village');
+  });
+});

--- a/frontend/src/pages/MapPage/MapPage.tsx
+++ b/frontend/src/pages/MapPage/MapPage.tsx
@@ -47,11 +47,24 @@ export default function MapPage(): React.ReactElement {
     if (pcId == null) return;
 
     let cancelled = false;
+    // Successive polls can resolve out of order (ordinary network jitter -
+    // no two requests here are guaranteed to complete in the order they
+    // were sent). `cancelled` alone doesn't guard against that: it only
+    // gets set once the whole effect tears down, not between one poll and
+    // the next, so a slow response from an earlier poll could still land
+    // after - and overwrite - a faster, newer one. That regresses every
+    // walking character's position by a couple of seconds all at once
+    // (Map.tsx resets each one's animation checkpoint on every geojson
+    // change), reading as a synchronized jump backward. Tagging each
+    // request with a sequence number and only applying the latest-issued
+    // one's response closes that gap.
+    let latestRequestId = 0;
 
     const fetchData = async () => {
+      const requestId = ++latestRequestId;
       try {
         const data = await apiFetch(`/population-centres/${pcId}/map/`);
-        if (!cancelled) setGeojson(data);
+        if (!cancelled && requestId === latestRequestId) setGeojson(data);
       } catch (err) {
         console.error("Error fetching map:", err);
       }


### PR DESCRIPTION
## Summary

Closes #624. After #623 landed on staging, all moving characters on the village map started jumping back and forth in sync, roughly every couple of seconds, sometimes twice in a row.

Root cause: `MapPage`'s poll loop (`frontend/src/pages/MapPage/MapPage.tsx`) had no protection against two in-flight requests to the map endpoint resolving out of order - ordinary network jitter, no different from any other pair of concurrent requests. The existing `cancelled` flag only guards against applying a response after the whole effect tears down; it does nothing to stop an older poll's response landing (and applying) *after* a newer one's.

This race has always existed, but was invisible before #623: idle characters glide via a CSS transition, so a stale response briefly regressing the position just blended into that drift. #623 replaced the walking-character animation with an unconditional per-poll checkpoint reset (see #615/#621/#622/#623) with no smoothing, so the same race now shows up as an instant, synchronized jump backward across every walking character at once - immediately followed by the next real poll jumping forward again, which reads as "back and forth."

## Change

Tags each poll request with a sequence number and only applies the latest-issued one's response to state, discarding anything older that happens to resolve late.

## Test plan

- [x] `npx vitest run src/pages/MapPage/MapPage.test.tsx src/components/Map/Map.test.tsx` — 28/28 passing, including a new `MapPage.test.tsx` covering the exact race: an older poll resolving after a newer one must not overwrite it.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.
- [ ] Manual verification on staging once deployed (backend test suite and full frontend E2E could not be run locally in this sandbox — no `.env`/DB available).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNY7CYzaGPoJWfWVukcumS)_