### PR TITLE
fix: apiFetch retry + injected navigation handlers (#538, #570)

### DIFF
--- a/frontend/src/components/MaintenanceWatcher.test.tsx
+++ b/frontend/src/components/MaintenanceWatcher.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import MaintenanceWatcher from "./MaintenanceWatcher";
+import { MaintenanceProvider, useMaintenanceContext } from "../context/MaintenanceContext";
+import * as api from "../utils/api";
+
+function ActiveMaintenanceProbe() {
+  const { maintenance } = useMaintenanceContext();
+  return <span data-testid="maintenance-active">{String(maintenance.active)}</span>;
+}
+
+describe("MaintenanceWatcher", () => {
+  afterEach(() => {
+    api.setMaintenanceHandler(null);
+    api.setNetworkErrorHandler(null);
+    vi.restoreAllMocks();
+  });
+
+  it("registers apiFetch's maintenance/network handlers on mount and clears them on unmount", () => {
+    const setMaintenanceHandlerSpy = vi.spyOn(api, "setMaintenanceHandler");
+    const setNetworkErrorHandlerSpy = vi.spyOn(api, "setNetworkErrorHandler");
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <MaintenanceProvider>
+          <MaintenanceWatcher />
+        </MaintenanceProvider>
+      </MemoryRouter>
+    );
+
+    expect(setMaintenanceHandlerSpy).toHaveBeenCalledWith(expect.any(Function));
+    expect(setNetworkErrorHandlerSpy).toHaveBeenCalledWith(expect.any(Function));
+
+    unmount();
+
+    expect(setMaintenanceHandlerSpy).toHaveBeenLastCalledWith(null);
+    expect(setNetworkErrorHandlerSpy).toHaveBeenLastCalledWith(null);
+  });
+
+  it("flips maintenance.active when apiFetch hits a 503, without apiFetch touching window directly", async () => {
+    globalThis.fetch = () => Promise.resolve({ ok: false, status: 503 } as Response);
+
+    render(
+      <MemoryRouter>
+        <MaintenanceProvider>
+          <MaintenanceWatcher />
+          <ActiveMaintenanceProbe />
+        </MaintenanceProvider>
+      </MemoryRouter>
+    );
+
+    const probe = () => document.querySelector('[data-testid="maintenance-active"]');
+    expect(probe()?.textContent).toBe("false");
+
+    await act(async () => {
+      await expect(api.apiFetch("/me/", {}, "test-token")).rejects.toMatchObject({
+        kind: "service_unavailable",
+      });
+    });
+
+    expect(probe()?.textContent).toBe("true");
+  });
+});

--- a/frontend/src/components/MaintenanceWatcher.tsx
+++ b/frontend/src/components/MaintenanceWatcher.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef } from "react";
 import { useNavigate, Navigate, useLocation } from "react-router-dom";
 import { useMaintenanceContext } from "../context/MaintenanceContext";
+import { setMaintenanceHandler, setNetworkErrorHandler } from "../utils/api";
 
 export default function MaintenanceWatcher() {
   const { maintenance, setMaintenance } = useMaintenanceContext();
@@ -10,6 +11,20 @@ export default function MaintenanceWatcher() {
 
   const wasActiveRef = useRef(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // apiFetch has no window/router of its own (#570) — a 503 flips maintenance
+  // state here, which the effect below already knows how to react to (same
+  // path the WebSocket-pushed maintenance state uses); a network TypeError
+  // navigates straight to /unavailable since there's no equivalent state for
+  // that page to react to declaratively.
+  useEffect(() => {
+    setMaintenanceHandler(() => setMaintenance((prev) => ({ ...prev, active: true })));
+    setNetworkErrorHandler(() => navigate("/unavailable"));
+    return () => {
+      setMaintenanceHandler(null);
+      setNetworkErrorHandler(null);
+    };
+  }, [navigate, setMaintenance]);
 
   useEffect(() => {
     if (maintenance.active && !wasActiveRef.current) {

--- a/frontend/src/utils/api.test.ts
+++ b/frontend/src/utils/api.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jwtDecode } from "jwt-decode";
 
-import { getValidAccessToken, setUnauthorizedHandler } from "./api";
+import { apiFetch, ApiFetchError, getValidAccessToken, setUnauthorizedHandler } from "./api";
 import { getStoredAuthTokens, storeAuthTokens } from "./authStorage";
 
 vi.mock("jwt-decode", () => ({
@@ -49,5 +49,111 @@ describe("getValidAccessToken", () => {
 
     expect(unauthorizedHandler).toHaveBeenCalled();
     expect(getStoredAuthTokens().accessToken).toBeNull();
+  });
+});
+
+describe("apiFetch", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { href: "" },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  const okResponse = { ok: true, status: 200, json: async () => ({ ok: true }) };
+
+  it("succeeds on the first attempt with no retry and no redirect", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
+
+    const result = await apiFetch("/me/", {}, "test-token");
+
+    expect(result).toEqual({ ok: true });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe("");
+  });
+
+  it("recovers after one transient network error", async () => {
+    vi.useFakeTimers();
+    (globalThis.fetch as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(okResponse);
+
+    const promise = apiFetch("/me/", {}, "test-token");
+    await vi.advanceTimersByTimeAsync(300);
+    const result = await promise;
+
+    expect(result).toEqual({ ok: true });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(window.location.href).toBe("");
+  });
+
+  it("recovers after two transient network errors", async () => {
+    vi.useFakeTimers();
+    (globalThis.fetch as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(okResponse);
+
+    const promise = apiFetch("/me/", {}, "test-token");
+    await vi.advanceTimersByTimeAsync(300);
+    await vi.advanceTimersByTimeAsync(600);
+    const result = await promise;
+
+    expect(result).toEqual({ ok: true });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    expect(window.location.href).toBe("");
+  });
+
+  it("redirects to /unavailable once all retries are exhausted", async () => {
+    vi.useFakeTimers();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const promise = apiFetch("/me/", {}, "test-token");
+    const expectation = expect(promise).rejects.toMatchObject({
+      kind: "network",
+    } satisfies Partial<ApiFetchError>);
+    await vi.advanceTimersByTimeAsync(300);
+    await vi.advanceTimersByTimeAsync(600);
+    await expectation;
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    expect(window.location.href).toBe("/unavailable");
+  });
+
+  it("does not retry a non-network error", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("boom"));
+
+    await expect(apiFetch("/me/", {}, "test-token")).rejects.toThrow("boom");
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe("");
+  });
+
+  it("does not retry a 401 response", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, status: 401 });
+
+    await expect(apiFetch("/me/", {}, "test-token")).rejects.toMatchObject({
+      kind: "unauthorized",
+    } satisfies Partial<ApiFetchError>);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe("");
+  });
+
+  it("does not retry a 503 response and redirects to /maintenance", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, status: 503 });
+
+    await expect(apiFetch("/me/", {}, "test-token")).rejects.toMatchObject({
+      kind: "service_unavailable",
+    } satisfies Partial<ApiFetchError>);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe("/maintenance");
   });
 });

--- a/frontend/src/utils/api.test.ts
+++ b/frontend/src/utils/api.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jwtDecode } from "jwt-decode";
 
-import { apiFetch, ApiFetchError, getValidAccessToken, setUnauthorizedHandler } from "./api";
+import {
+  apiFetch,
+  ApiFetchError,
+  getValidAccessToken,
+  setMaintenanceHandler,
+  setNetworkErrorHandler,
+  setUnauthorizedHandler,
+} from "./api";
 import { getStoredAuthTokens, storeAuthTokens } from "./authStorage";
 
 vi.mock("jwt-decode", () => ({
@@ -55,27 +62,24 @@ describe("getValidAccessToken", () => {
 describe("apiFetch", () => {
   beforeEach(() => {
     globalThis.fetch = vi.fn();
-    Object.defineProperty(window, "location", {
-      value: { href: "" },
-      writable: true,
-    });
   });
 
   afterEach(() => {
+    setMaintenanceHandler(null);
+    setNetworkErrorHandler(null);
     vi.clearAllMocks();
     vi.useRealTimers();
   });
 
   const okResponse = { ok: true, status: 200, json: async () => ({ ok: true }) };
 
-  it("succeeds on the first attempt with no retry and no redirect", async () => {
+  it("succeeds on the first attempt with no retry", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
 
     const result = await apiFetch("/me/", {}, "test-token");
 
     expect(result).toEqual({ ok: true });
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(window.location.href).toBe("");
   });
 
   it("recovers after one transient network error", async () => {
@@ -90,7 +94,6 @@ describe("apiFetch", () => {
 
     expect(result).toEqual({ ok: true });
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
-    expect(window.location.href).toBe("");
   });
 
   it("recovers after two transient network errors", async () => {
@@ -107,10 +110,9 @@ describe("apiFetch", () => {
 
     expect(result).toEqual({ ok: true });
     expect(globalThis.fetch).toHaveBeenCalledTimes(3);
-    expect(window.location.href).toBe("");
   });
 
-  it("redirects to /unavailable once all retries are exhausted", async () => {
+  it("rejects with a network ApiFetchError once retries are exhausted, without a handler registered", async () => {
     vi.useFakeTimers();
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new TypeError("Failed to fetch"));
 
@@ -123,7 +125,23 @@ describe("apiFetch", () => {
     await expectation;
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(3);
-    expect(window.location.href).toBe("/unavailable");
+  });
+
+  it("invokes the registered network-error handler once retries are exhausted", async () => {
+    vi.useFakeTimers();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new TypeError("Failed to fetch"));
+    const networkErrorHandler = vi.fn();
+    setNetworkErrorHandler(networkErrorHandler);
+
+    const promise = apiFetch("/me/", {}, "test-token");
+    const expectation = expect(promise).rejects.toMatchObject({
+      kind: "network",
+    } satisfies Partial<ApiFetchError>);
+    await vi.advanceTimersByTimeAsync(300);
+    await vi.advanceTimersByTimeAsync(600);
+    await expectation;
+
+    expect(networkErrorHandler).toHaveBeenCalledTimes(1);
   });
 
   it("does not retry a non-network error", async () => {
@@ -132,7 +150,6 @@ describe("apiFetch", () => {
     await expect(apiFetch("/me/", {}, "test-token")).rejects.toThrow("boom");
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(window.location.href).toBe("");
   });
 
   it("does not retry a 401 response", async () => {
@@ -143,10 +160,9 @@ describe("apiFetch", () => {
     } satisfies Partial<ApiFetchError>);
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(window.location.href).toBe("");
   });
 
-  it("does not retry a 503 response and redirects to /maintenance", async () => {
+  it("does not retry a 503 response, rejecting with a service_unavailable ApiFetchError without a handler registered", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, status: 503 });
 
     await expect(apiFetch("/me/", {}, "test-token")).rejects.toMatchObject({
@@ -154,6 +170,17 @@ describe("apiFetch", () => {
     } satisfies Partial<ApiFetchError>);
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(window.location.href).toBe("/maintenance");
+  });
+
+  it("invokes the registered maintenance handler on a 503 response", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, status: 503 });
+    const maintenanceHandler = vi.fn();
+    setMaintenanceHandler(maintenanceHandler);
+
+    await expect(apiFetch("/me/", {}, "test-token")).rejects.toMatchObject({
+      kind: "service_unavailable",
+    } satisfies Partial<ApiFetchError>);
+
+    expect(maintenanceHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -6,6 +6,30 @@ import { clearAuthStorage, getStoredAuthTokens, updateStoredAccessToken } from "
 
 const API_URL = `${API_BASE_URL}/api/v1`;
 
+const NETWORK_RETRY_ATTEMPTS = 2; // retries after the initial attempt (3 attempts total)
+const NETWORK_RETRY_DELAY_MS = [300, 600]; // delay before retry attempt N (index 0 = before 1st retry)
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// A single flaky connection shouldn't take down the whole app (see #538) -
+// retry transient network failures (fetch() throwing TypeError) a couple of
+// times before giving up. Non-network errors and HTTP error statuses (401,
+// 503, etc.) are handled by the caller and never enter this loop.
+async function fetchWithRetry(input: string, init: RequestInit): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fetch(input, init);
+    } catch (err) {
+      if (!(err instanceof TypeError) || attempt >= NETWORK_RETRY_ATTEMPTS) {
+        throw err;
+      }
+      await delay(NETWORK_RETRY_DELAY_MS[attempt]);
+    }
+  }
+}
+
 type ResponseType = "json" | "blob" | "text" | "raw";
 
 interface ApiFetchOptions extends Omit<RequestInit, "headers"> {
@@ -136,7 +160,7 @@ export async function apiFetch<T = unknown>(
       "Content-Type": "application/json",
     };
 
-    const response = await fetch(`${API_URL}${path}`, {
+    const response = await fetchWithRetry(`${API_URL}${path}`, {
       ...fetchOptions,
       headers,
     });

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -71,6 +71,26 @@ export function setUnauthorizedHandler(handler: UnauthorizedHandler | null): voi
   unauthorizedHandler = handler;
 }
 
+// Same rationale as unauthorizedHandler above: api.ts has no window/router of
+// its own (see #570 — keeping it DOM-free is prep for a non-browser runtime
+// like React Native), so maintenance/network-failure navigation is delegated
+// to whatever's registered rather than assigned via window.location directly.
+// Unregistered is a valid, safe state (e.g. in tests): the caller still gets
+// the typed ApiFetchError below either way, it just doesn't navigate anywhere.
+type MaintenanceHandler = () => void;
+let maintenanceHandler: MaintenanceHandler | null = null;
+
+export function setMaintenanceHandler(handler: MaintenanceHandler | null): void {
+  maintenanceHandler = handler;
+}
+
+type NetworkErrorHandler = () => void;
+let networkErrorHandler: NetworkErrorHandler | null = null;
+
+export function setNetworkErrorHandler(handler: NetworkErrorHandler | null): void {
+  networkErrorHandler = handler;
+}
+
 function handleUnauthorized(): void {
   // Cleared here unconditionally, not left solely to the registered handler:
   // this covers a request firing before AuthProvider has mounted, or in a
@@ -171,7 +191,7 @@ export async function apiFetch<T = unknown>(
     }
 
     if (response.status === 503) {
-      window.location.href = "/maintenance";
+      maintenanceHandler?.();
       return Promise.reject(new ApiFetchError("service_unavailable", "Maintenance mode"));
     }
 
@@ -193,7 +213,7 @@ export async function apiFetch<T = unknown>(
     }
   } catch (err) {
     if (err instanceof TypeError) {
-      window.location.href = "/unavailable";
+      networkErrorHandler?.();
       return Promise.reject(new ApiFetchError("network", err.message));
     }
     console.error("apiFetch error:", err);


### PR DESCRIPTION
## Summary

**#538 — false-positive "Server Unavailable"**
- `apiFetch` (`frontend/src/utils/api.ts`) wraps every authenticated API call. When the underlying `fetch()` threw a `TypeError` (a network-level failure — connection blip, DNS hiccup, etc.), it immediately hard-redirected the *entire app*, even while every other request in the same window was succeeding.
- Fix: retry the `fetch()` call up to twice (300ms, then 600ms delay) on `TypeError` before giving up. 401 and 503 handling is untouched — those are resolved `Response`s, not thrown errors, so they never enter the retry loop.

**#570 — decouple apiFetch from the DOM**
- `apiFetch` also navigated directly via `window.location.href` on both the 503 (maintenance) and network-failure-exhausted paths, making the single most depended-upon frontend module browser-only (blocks RN/Expo migration prep, per the parent epic #569).
- Fix: followed the existing `setUnauthorizedHandler` pattern already in the file — added `setMaintenanceHandler` / `setNetworkErrorHandler`, registered by `MaintenanceWatcher` (which already has router access and `MaintenanceContext`) instead of assigned inline. A 503 now flips `maintenance.active`, routed through the same declarative `<Navigate>` flow already used for the WebSocket-pushed maintenance state; an exhausted network retry navigates straight to `/unavailable`. No `window.` reference remains in `api.ts`. Unregistered handlers are a safe no-op — the caller still gets the typed `ApiFetchError` either way.

These two folded into one PR because #570 was going to touch the exact same two lines #538 needed retry logic wrapped around — see [issue comment](https://github.com/progressrpg/ProgressRPG/issues/570#issuecomment-5116938875) for the original conflict analysis before deciding to combine them.

## Scope note (from #538 investigation)

The issue also suggested changing `config.ts` to route local-dev traffic through Vite's proxy instead of hitting `localhost:8000` directly. That was investigated and deliberately left out: `API_BASE_URL` is also consumed as an absolute URL by ~8 other call sites (login/register/password-reset/waitlist raw `fetch()` calls, the WebSocket handshake, the admin-panel link), so a clean fix would need a second base-URL constant — wider blast radius for uncertain benefit, and it wouldn't address the production-relevant half of #538 at all. Full writeup: `.claude/plans/investigate-issue-538-and-enchanted-wigderson.md`.

## Test plan

- [x] `frontend/src/utils/api.test.ts` — new `describe("apiFetch", ...)` block (11 cases): retry recovery (1/2 transient errors), retry exhaustion with and without a registered network-error handler, non-`TypeError` not retried, 401 not retried, 503 not retried (with and without a registered maintenance handler).
- [x] `frontend/src/components/MaintenanceWatcher.test.tsx` (new) — verifies the handlers are registered on mount and cleared on unmount, and that a 503 through `apiFetch` flips `maintenance.active` via the registered handler (no direct `window.` use).
- [x] `npx vitest run --project unit` — 50/52 files pass; the 2 failing files (`NavDrawer`, `LibraryPage`) are pre-existing failures unrelated to this change, confirmed by reproducing them on a clean stash of this branch.
- [x] `eslint` clean on all changed/new files.

**Not merging yet** — holding as part of a stack of infrastructure-issue PRs to be tested locally and merged one at a time.

Fixes #538
Fixes #570