### PR TITLE
chore: consolidate spacing/variable systems into one token source

### DIFF
--- a/frontend/src/components/Achievements/Achievements.module.scss
+++ b/frontend/src/components/Achievements/Achievements.module.scss
@@ -1,17 +1,17 @@
 @use '../../styles/utilities/mixins' as m;
 @use '../../styles/utilities/tier-colors' as tc;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 
 .section {
-  padding: v.$padding-lg;
+  padding: sp.$padding-lg;
   border: 1px solid rgba(c.$color-border-primary, 0.2);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.4);
 
   h2 {
-    margin: 0 0 v.$spacing-md 0;
+    margin: 0 0 sp.$spacing-md 0;
     @include t.apply-text-style(t.$text-heading-2);
     color: c.$color-border-primary;
   }
@@ -20,7 +20,7 @@
 .achievementGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
 }
 
 .achievementBadge {
@@ -29,19 +29,19 @@
 
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   min-width: 0;
-  padding: v.$spacing-md;
+  padding: sp.$spacing-md;
   border: 1px solid rgba(c.$color-border-primary, 0.16);
   border-left: 0.35rem solid var(--achievement-color);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: var(--achievement-bg);
 }
 
 .achievementHeader {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   min-width: 0;
 
   h3,
@@ -77,7 +77,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   color: c.$color-text-body;
   @include t.apply-text-style(t.$text-body);
 }

--- a/frontend/src/components/ActivitiesPanel/ActivitiesPanel.module.scss
+++ b/frontend/src/components/ActivitiesPanel/ActivitiesPanel.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 @use 'sass:map';
@@ -16,17 +16,17 @@
 
 .dateTabs {
   display: flex;
-  gap: v.$spacing-sm;
-  margin-bottom: v.$spacing-md;
+  gap: sp.$spacing-sm;
+  margin-bottom: sp.$spacing-md;
   flex-wrap: wrap;
   justify-content: center;
   width: 100%;
 }
 
 .dateButton {
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   border: 1px solid rgba(c.$color-border-primary, 0.4);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: transparent;
   cursor: pointer;
   font-size: 0.9em;
@@ -52,7 +52,7 @@
 .activitiesList {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
   width: 100%;
   max-width: 900px;
   margin: 0 auto;
@@ -60,7 +60,7 @@
   max-height: min(62dvh, calc(100dvh - 25rem));
   overflow-y: auto;
   scrollbar-gutter: stable;
-  padding-right: v.$spacing-sm;
+  padding-right: sp.$spacing-sm;
 
   @include m.respond-to(md, down) {
     max-height: min(56vh, calc(100vh - 19rem));
@@ -96,9 +96,9 @@
 }
 
 .backLink {
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   border: 1px solid c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: transparent;
   color: c.$color-border-primary;
   text-decoration: none;
@@ -106,7 +106,7 @@
   transition: all 0.2s ease;
   @include t.apply-text-style(t.$text-body);
   text-align: center;
-  margin-bottom: v.$spacing-md;
+  margin-bottom: sp.$spacing-md;
 
   &:hover {
     background: rgba(c.$color-border-primary, 0.1);
@@ -121,7 +121,7 @@
 
 .emptyState {
   text-align: center;
-  padding: v.$padding-lg;
+  padding: sp.$padding-lg;
   color: rgba(0, 0, 0, 0.6);
 
   p {

--- a/frontend/src/components/ActivityInput/ActivityInput.module.scss
+++ b/frontend/src/components/ActivityInput/ActivityInput.module.scss
@@ -1,5 +1,4 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/semantic/spacing' as sp;
@@ -17,7 +16,7 @@ $row-control-height: 44px;
 }
 
 .limitWarning {
-  margin: v.$spacing-sm 0 0;
+  margin: sp.$spacing-sm 0 0;
   text-align: left;
   color: c.$color-text-body;
 }
@@ -27,7 +26,7 @@ $row-control-height: 44px;
   z-index: 1;
   display: flex;
   justify-content: center;
-  padding-top: v.$spacing-md;
+  padding-top: sp.$spacing-md;
 }
 
 .supportModeButton {
@@ -42,8 +41,8 @@ $row-control-height: 44px;
   z-index: 2;
 
   border: 1px solid rgba(c.$color-border-primary, 0.15);
-  border-radius: v.$border-radius;
-  padding: v.$padding-base;
+  border-radius: sp.$border-radius;
+  padding: sp.$padding-base;
   background: rgba(c.$color-player, 0.14);
   width: min(100%, 720px);
 }
@@ -79,8 +78,8 @@ $row-control-height: 44px;
   display: flex;
   align-items: center;
   @include m.border(rgba(c.$color-border-primary, 0.3));
-  border-radius: v.$border-radius;
-  padding: v.$padding-base;
+  border-radius: sp.$border-radius;
+  padding: sp.$padding-base;
   line-height: 1;
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -96,11 +95,11 @@ $row-control-height: 44px;
   line-height: 1.2;
   height: 100%;
   min-height: 100%;
-  padding: v.$padding-sm;
+  padding: sp.$padding-sm;
   box-sizing: border-box;
 
   border: none;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: transparent;
   box-shadow: none;
   width: 100%;
@@ -229,11 +228,11 @@ $row-control-height: 44px;
     font-size: 1rem;
     line-height: 1.1;
     min-height: 1.2em;
-    padding: v.$spacing-xs;
+    padding: sp.$spacing-xs;
   }
 
   .timerPill {
-    padding: v.$spacing-sm;
+    padding: sp.$spacing-sm;
     font-size: 1rem;
   }
 
@@ -258,7 +257,7 @@ $row-control-height: 44px;
   }
 
   .timerPill {
-    padding: v.$spacing-xs v.$spacing-sm;
+    padding: sp.$spacing-xs sp.$spacing-sm;
     font-size: 0.95rem;
   }
 }

--- a/frontend/src/components/ActivityTimeline/ActivityTimeline.module.scss
+++ b/frontend/src/components/ActivityTimeline/ActivityTimeline.module.scss
@@ -1,21 +1,21 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 @use 'sass:map';
 
 .activitiesLink {
   display: inline-block;
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   border: 1px solid c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: transparent;
   color: c.$color-border-primary;
   text-decoration: none;
   font-size: 0.9em;
   transition: all 0.2s ease;
   @include t.apply-text-style(t.$text-body);
-  margin-bottom: v.$spacing-md;
+  margin-bottom: sp.$spacing-md;
 
   &:hover {
     background: rgba(c.$color-border-primary, 0.1);
@@ -29,17 +29,17 @@
 }
 
 .heading {
-  margin: v.$spacing-sm 0;
-  margin-bottom: v.$spacing-md;
+  margin: sp.$spacing-sm 0;
+  margin-bottom: sp.$spacing-md;
 }
 
 .container {
   width: min(100%, 720px);
-  margin-top: v.$spacing-md;
+  margin-top: sp.$spacing-md;
 
   border: 1px solid rgba(c.$color-border-default, 0.7);
-  border-radius: v.$border-radius;
-  padding: v.$padding-base;
+  border-radius: sp.$border-radius;
+  padding: sp.$padding-base;
   overflow: hidden;
   background: rgba(c.$color-bg, 0.6);
 
@@ -72,7 +72,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   width: 100%;
   @include c.apply-text-tone(map.get(c.$text-tone, default));
   font-size: 1rem;
@@ -92,7 +92,7 @@
   border: none;
   background: transparent;
   color: c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   width: 1.75rem;
   height: 1.75rem;
   font-size: 1.25rem;
@@ -123,7 +123,7 @@
   border: none;
   background: transparent;
   color: c.$color-warning;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   width: 1.75rem;
   height: 1.75rem;
   font-size: 1.25rem;
@@ -145,8 +145,8 @@
 .header {
   font-style: italic;
   color: rgba(0, 0, 0, 0.6);
-  padding-bottom: v.$spacing-sm;
-  margin-bottom: v.$spacing-sm;
+  padding-bottom: sp.$spacing-sm;
+  margin-bottom: sp.$spacing-sm;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   font-size: 0.9em;
 }

--- a/frontend/src/components/AlertDialog/AlertDialog.module.scss
+++ b/frontend/src/components/AlertDialog/AlertDialog.module.scss
@@ -1,4 +1,5 @@
 @use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 
 .overlay {
@@ -17,11 +18,11 @@
 
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
   background: c.$color-bg;
-  border-radius: v.$border-radius;
-  box-shadow: 0 v.$spacing-sm v.$spacing-md rgba(0, 0, 0, 0.2);
-  padding: v.$spacing-lg;
+  border-radius: sp.$border-radius;
+  box-shadow: 0 sp.$spacing-sm sp.$spacing-md rgba(0, 0, 0, 0.2);
+  padding: sp.$spacing-lg;
   width: 90%;
   max-width: min(95vw, 440px);
 
@@ -47,8 +48,8 @@
 .actions {
   display: flex;
   justify-content: flex-end;
-  gap: v.$spacing-sm;
-  margin-top: v.$spacing-sm;
+  gap: sp.$spacing-sm;
+  margin-top: sp.$spacing-sm;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/components/BackToTopButton/BackToTopButton.module.scss
+++ b/frontend/src/components/BackToTopButton/BackToTopButton.module.scss
@@ -1,11 +1,11 @@
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/semantic/typography' as t;
 
 .backToTop {
   position: fixed;
-  right: v.$spacing-lg;
-  bottom: v.$spacing-lg;
+  right: sp.$spacing-lg;
+  bottom: sp.$spacing-lg;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -21,7 +21,7 @@
   overflow: hidden;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: v.$button-radius;
+  border-radius: sp.$button-radius;
   @include t.apply-text-style(t.$text-button);
   @include c.apply-button-variant(primary);
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.18);

--- a/frontend/src/components/Button/Button.module.scss
+++ b/frontend/src/components/Button/Button.module.scss
@@ -1,4 +1,4 @@
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/utilities/mixins' as m;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
@@ -8,9 +8,9 @@
   justify-content: center;
   align-items: center;
 
-  padding: v.$button-padding;
-  gap: v.$spacing-gap;
-  border-radius: v.$button-radius;
+  padding: sp.$button-padding;
+  gap: sp.$spacing-gap;
+  border-radius: sp.$button-radius;
   border: 1px solid transparent;
 
   cursor: pointer;

--- a/frontend/src/components/Button/ButtonFrame.module.scss
+++ b/frontend/src/components/Button/ButtonFrame.module.scss
@@ -1,13 +1,13 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 
 .buttonFrame {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   justify-content: stretch;
-  gap: v.$spacing-gap;
-  margin-top: v.$spacing-md;
+  gap: sp.$spacing-gap;
+  margin-top: sp.$spacing-md;
   width: 100%;
   flex-grow: 0;
 

--- a/frontend/src/components/CharacterCurrentActivity/CharacterCurrentActivity.module.scss
+++ b/frontend/src/components/CharacterCurrentActivity/CharacterCurrentActivity.module.scss
@@ -1,6 +1,6 @@
 /* components/CharacterActivityCurrent/CharacterActivityCurrent.module.scss */
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 @use 'sass:map';
@@ -9,11 +9,11 @@
   width: min(100%, 720px);
 
 
-  padding: v.$padding-base;
+  padding: sp.$padding-base;
   font-size: 0.95rem;
 
   border: 1px solid rgba(c.$color-character, 0.15);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-character, 0.08);
   @include t.apply-text-style(t.$text-body);
 }
@@ -31,10 +31,10 @@
 }
 
 .bonus {
-  margin-top: v.$spacing-xs;
+  margin-top: sp.$spacing-xs;
 }
 
 .bonusActive {
-  margin-top: v.$spacing-xs;
+  margin-top: sp.$spacing-xs;
   color: c.$color-text-heading;
 }

--- a/frontend/src/components/ComingSoonPanel/ComingSoonPanel.module.scss
+++ b/frontend/src/components/ComingSoonPanel/ComingSoonPanel.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/list-pages' as lp;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 
 .page {
   width: min(100%, 720px);
@@ -10,7 +10,7 @@
 
 .header {
   text-align: center;
-  margin-bottom: v.$spacing-lg;
+  margin-bottom: sp.$spacing-lg;
 }
 
 .emptyState {

--- a/frontend/src/components/CurrentActivity/CurrentActivity.module.scss
+++ b/frontend/src/components/CurrentActivity/CurrentActivity.module.scss
@@ -1,23 +1,23 @@
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/utilities/mixins' as m;
 
 .wrapper {
   width: min(100%, 720px);
   border: 1px solid rgba(c.$color-border-default, 0.7);
-  border-radius: v.$border-radius;
-  padding: v.$padding-base;
+  border-radius: sp.$border-radius;
+  padding: sp.$padding-base;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   background: rgba(c.$color-bg, 0.5);
   position: relative;
   box-sizing: border-box;
 }
 
 .heading {
-  margin: v.$spacing-sm 0;
-  margin-bottom: v.$spacing-md;
+  margin: sp.$spacing-sm 0;
+  margin-bottom: sp.$spacing-md;
 }
 
 .wrapper > * {
@@ -63,7 +63,7 @@
   content: "";
   position: absolute;
   inset: -2px;
-  border-radius: calc(#{v.$border-radius} + 1px);
+  border-radius: calc(#{sp.$border-radius} + 1px);
   padding: 1px;
   background: linear-gradient(
     to bottom,

--- a/frontend/src/components/EntitySearchInput/EntitySearchInput.module.scss
+++ b/frontend/src/components/EntitySearchInput/EntitySearchInput.module.scss
@@ -1,5 +1,6 @@
 @use '../../styles/utilities/mixins' as m;
 @use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 
@@ -12,9 +13,9 @@
 .input {
   width: 100%;
   min-width: 0;
-  padding: v.$padding-base;
+  padding: sp.$padding-base;
   box-sizing: border-box;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   @include t.apply-text-style(t.$text-body);
   @include m.border-interactive(
     rgba(c.$color-border-primary, 0.4),
@@ -33,15 +34,15 @@
 
 .dropdown {
   position: absolute;
-  top: calc(100% + #{v.$spacing-xs});
+  top: calc(100% + #{sp.$spacing-xs});
   left: 0;
   right: 0;
   z-index: v.$z-index-tooltip;
   margin: 0;
-  padding: v.$spacing-xs 0;
+  padding: sp.$spacing-xs 0;
   list-style: none;
   border: 1px solid rgba(c.$color-border-primary, 0.2);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.98);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
 }
@@ -57,7 +58,7 @@
   left: auto;
   right: auto;
   z-index: v.$z-index-dropdown;
-  margin-top: v.$spacing-xs;
+  margin-top: sp.$spacing-xs;
   border-color: rgba(c.$color-border-primary, 0.12);
   background: rgba(c.$color-bg, 0.6);
   box-shadow: none;
@@ -76,7 +77,7 @@
   width: 100%;
   border: 0;
   background: transparent;
-  padding: v.$spacing-sm v.$spacing-md;
+  padding: sp.$spacing-sm sp.$spacing-md;
   text-align: left;
   color: c.$color-text-body;
   cursor: pointer;
@@ -92,7 +93,7 @@
 }
 
 .groupLabel {
-  padding: v.$spacing-xs v.$spacing-md;
+  padding: sp.$spacing-xs sp.$spacing-md;
   font-size: 0.8em;
   color: rgba(c.$color-text-body, 0.5);
   text-transform: uppercase;
@@ -106,8 +107,8 @@
 }
 
 .emptyMessage {
-  margin: v.$spacing-xs 0 0;
-  padding: v.$spacing-sm v.$padding-base;
+  margin: sp.$spacing-xs 0 0;
+  padding: sp.$spacing-sm sp.$padding-base;
   color: rgba(c.$color-text-body, 0.6);
   box-sizing: border-box;
   min-height: var(--entity-search-persistent-min-height, auto);

--- a/frontend/src/components/FeatureToggle.module.scss
+++ b/frontend/src/components/FeatureToggle.module.scss
@@ -1,4 +1,4 @@
-@use '../styles/base/variables' as v;
+@use '../styles/semantic/spacing' as sp;
 @use '../styles/semantic/colors' as c;
 
 .fallbackPage {
@@ -6,24 +6,24 @@
   width: 100%;
   display: grid;
   place-items: center;
-  padding: v.$spacing-lg;
+  padding: sp.$spacing-lg;
 }
 
 .fallbackCard {
   width: min(100%, 28rem);
-  padding: v.$spacing-lg;
+  padding: sp.$spacing-lg;
   border: 1px solid rgba(c.$color-border-primary, 0.25);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.92);
   box-shadow: 0 8px 24px rgba(c.$color-border-primary, 0.12);
   text-align: center;
 
   p {
-    margin: 0 0 v.$spacing-sm;
+    margin: 0 0 sp.$spacing-sm;
   }
 
   p:last-of-type {
-    margin-bottom: v.$spacing-md;
+    margin-bottom: sp.$spacing-md;
   }
 }
 

--- a/frontend/src/components/FeedbackWidget/FeedbackWidget.module.scss
+++ b/frontend/src/components/FeedbackWidget/FeedbackWidget.module.scss
@@ -21,7 +21,7 @@
   max-width: 320px;
   background-color: c.$color-bg;
   @include m.border(c.$color-border-primary);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   @include m.box-shadow(md);
   padding: map.get(sp.$gap, md);
   z-index: v.$z-index-dropdown;
@@ -40,8 +40,8 @@
     gap: 0.5rem;
 
     .modalButton {
-      padding: v.$padding-base;
-      border-radius: v.$border-radius;
+      padding: sp.$padding-base;
+      border-radius: sp.$border-radius;
       text-align: center;
       text-decoration: none;
       font-weight: 500;

--- a/frontend/src/components/Form/Card/Card.module.scss
+++ b/frontend/src/components/Form/Card/Card.module.scss
@@ -1,4 +1,3 @@
-@use '../../../styles/base/variables' as v;
 @use '../../../styles/semantic/spacing' as sp;
 @use '../../../styles/semantic/colors' as c;
 @use '../../../styles/utilities/mixins' as m;

--- a/frontend/src/components/Form/Form.module.scss
+++ b/frontend/src/components/Form/Form.module.scss
@@ -1,4 +1,4 @@
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/utilities/mixins' as m;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
@@ -7,18 +7,18 @@
 .formFrame {
   max-width: 80vw;
   margin: 0 auto;
-  padding: v.$spacing-lg;
-  border-radius: v.$border-radius;
+  padding: sp.$spacing-lg;
+  border-radius: sp.$border-radius;
   background-color: c.$color-bg;
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.08);
 
   @include m.respond-to(sm) {
-    padding: v.$spacing-xl;
+    padding: sp.$spacing-xl;
   }
 }
 
 .formTitle {
-  margin-bottom: v.$spacing-lg;
+  margin-bottom: sp.$spacing-lg;
   text-align: center;
   @include t.apply-text-style(t.$text-heading-2);
 }
@@ -26,12 +26,12 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   min-width: 17rem;
 }
 
 .actions {
   display: flex;
   justify-content: center;
-  margin-top: v.$spacing-md;
+  margin-top: sp.$spacing-md;
 }

--- a/frontend/src/components/Input/Input.module.scss
+++ b/frontend/src/components/Input/Input.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 @use 'sass:map';
@@ -7,7 +7,7 @@
 .inputGroup {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   width: 100%;
   max-width: 30rem;
 
@@ -22,11 +22,11 @@
 
 .required {
   //color: red;
-  margin-left: v.$spacing-xs;
+  margin-left: sp.$spacing-xs;
 }
 
 .inputField {
-  padding: v.$padding-base;
+  padding: sp.$padding-base;
   box-sizing: border-box;
   max-width: 30rem;
   @include m.border-interactive(
@@ -34,7 +34,7 @@
     c.$color-border-primary,
     c.$color-border-accent
   );
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   transition: border 0.2s, background 0.2s;
   @include t.apply-text-style(t.$text-body);
 
@@ -42,7 +42,7 @@
     outline: none;
     border-color: c.$color-border-primary;
     background-color: c.$color-bg;
-    border-radius: v.$border-radius;
+    border-radius: sp.$border-radius;
   }
 
   @include m.focus-outline(c.$color-border-accent);
@@ -94,7 +94,7 @@
   border: none;
   cursor: pointer;
   color: c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   transition: color 0.2s;
 
   &:hover {

--- a/frontend/src/components/List/List.module.scss
+++ b/frontend/src/components/List/List.module.scss
@@ -1,11 +1,11 @@
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/utilities/mixins' as m;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 
 .listSection {
-  //padding: v.$spacing-xs 0;
-  gap: v.$spacing-gap;
+  //padding: sp.$spacing-xs 0;
+  gap: sp.$spacing-gap;
   align-self: stretch;
   display: flex;
 }
@@ -16,10 +16,10 @@
   align-items: flex-start;
   padding: 0;
   margin: 0;
-  //gap: v.$spacing-xs;
+  //gap: sp.$spacing-xs;
   width: 100%;
   list-style: none;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   overflow: hidden;
 }
 
@@ -28,11 +28,11 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   width: 100%;
-  padding: v.$padding-base;
+  padding: sp.$padding-base;
   //border: 1px solid rgba(c.$color-border-primary, 0.2);
-  //border-radius: v.$border-radius;
+  //border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.4);
   transition: background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   position: relative;

--- a/frontend/src/components/Modal/Modal.module.scss
+++ b/frontend/src/components/Modal/Modal.module.scss
@@ -1,5 +1,6 @@
 // components/Modal/Modal.module.scss
 @use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 @use '../../layout/two-columns' as tc;
 @use 'sass:map';
@@ -29,12 +30,12 @@
   height: auto;
   max-height: 90vh;
   min-height: 0;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   overflow: hidden;
-  box-shadow: 0 v.$spacing-sm v.$spacing-md rgba(0,0,0,0.2);
+  box-shadow: 0 sp.$spacing-sm sp.$spacing-md rgba(0,0,0,0.2);
 
-  gap: v.$spacing-gap;
-  padding: v.$padding-base;
+  gap: sp.$spacing-gap;
+  padding: sp.$padding-base;
 }
 
 .modal:focus,
@@ -52,8 +53,8 @@
   overflow-y: auto;
   overflow-x: hidden;
   min-height: 0;
-  padding-top: v.$spacing-md;
-  padding-bottom: v.$spacing-md;
+  padding-top: sp.$spacing-md;
+  padding-bottom: sp.$spacing-md;
   @include tc.two-column-layout;
 
   justify-content: flex-start;
@@ -66,9 +67,9 @@
 .modalFooter {
   display: flex;
   align-items: center;
-  padding: v.$spacing-sm v.$padding-base;
+  padding: sp.$spacing-sm sp.$padding-base;
   border-top: 1px solid rgba(c.$color-border-primary, 0.4);
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
 }
 
 .modalHeader {
@@ -77,7 +78,7 @@
   justify-content: center;
   align-items: center;
   min-height: 3.5rem;
-  padding: v.$spacing-sm 4.5rem;
+  padding: sp.$spacing-sm 4.5rem;
   border-bottom: 1px solid rgba(c.$color-border-primary, 0.4);
 }
 

--- a/frontend/src/components/OnlineCountBadge/OnlineCountBadge.module.scss
+++ b/frontend/src/components/OnlineCountBadge/OnlineCountBadge.module.scss
@@ -12,7 +12,7 @@
   z-index: v.$z-index-dropdown;
   background: c.$color-bg;
   border: 1px solid c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   padding: map.get(sp.$gap, xs) map.get(sp.$gap, sm);
   @include t.apply-text-style(t.$text-body);
 

--- a/frontend/src/components/PlayerItemList/PlayerItemList.module.scss
+++ b/frontend/src/components/PlayerItemList/PlayerItemList.module.scss
@@ -1,4 +1,4 @@
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/semantic/typography' as t;
 
@@ -17,7 +17,7 @@
   overflow-y: auto;
   flex: 1;
   min-height: 0;
-  padding-right: v.$spacing-sm;
+  padding-right: sp.$spacing-sm;
   scrollbar-gutter: stable;
 
   &::-webkit-scrollbar {
@@ -41,14 +41,14 @@
 .controls {
   display: flex;
   flex-wrap: wrap;
-  gap: v.$spacing-sm;
-  margin-bottom: v.$spacing-sm;
+  gap: sp.$spacing-sm;
+  margin-bottom: sp.$spacing-sm;
 }
 
 .controlGroup {
   display: flex;
   align-items: center;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
   flex-wrap: wrap;
 }
 
@@ -58,9 +58,9 @@
 }
 
 .sortSelect {
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   border: 1px solid rgba(c.$color-border-primary, 0.35);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: transparent;
   font-size: 0.875em;
   font-family: inherit;
@@ -74,16 +74,16 @@
 }
 
 .list {
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   overflow: visible;
 }
 
 .item {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   border: 1px solid rgba(c.$color-border-primary, 0.2);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.4);
   transition:
     background 0.2s ease,
@@ -118,13 +118,13 @@
   flex: 1;
   min-width: 0;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .rowActions {
   display: flex;
   align-items: center;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
   flex-shrink: 0;
   opacity: 0;
   pointer-events: none;
@@ -141,7 +141,7 @@
   border: none;
   background: transparent;
   color: c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   width: 1.75rem;
   height: 1.75rem;
   font-size: 1rem;
@@ -188,7 +188,7 @@
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
 }
 
 .itemDetailsButton {
@@ -214,15 +214,15 @@
 .editTitleRow {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .editInput {
   flex: 1;
   min-width: 0;
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   border: 2px solid rgba(c.$color-status-success, 0.45);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   font-size: 1em;
   font-family: inherit;
   transition: border-color 0.2s ease;
@@ -235,7 +235,7 @@
 
 .editConfirmContent {
   display: grid;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
   width: 100%;
 
   p {
@@ -247,13 +247,13 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   flex-wrap: wrap;
 }
 
 .deleteConfirmContent {
   display: grid;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
 
   p {
     margin: 0;
@@ -264,13 +264,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .editConfirmMeta {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
   margin: 0;
   color: rgba(0, 0, 0, 0.65);
   @include t.apply-text-style(t.$text-caption);

--- a/frontend/src/components/PopulationCentreResidents/PopulationCentreResidents.module.scss
+++ b/frontend/src/components/PopulationCentreResidents/PopulationCentreResidents.module.scss
@@ -1,12 +1,12 @@
 @use 'sass:map';
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/semantic/typography' as t;
 
 .section {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   width: 100%;
   align-items: center;
 }
@@ -23,7 +23,7 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   max-width: 640px;
   margin: 0 auto;
   max-height: 360px;
@@ -33,9 +33,9 @@
 .item {
   display: flex;
   flex-direction: row;
-  padding: v.$padding-base;
+  padding: sp.$padding-base;
   border: 1px solid rgba(c.$color-border-primary, 0.25);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.7);
 }
 
@@ -48,7 +48,7 @@
   @include t.apply-text-style(t.$text-body);
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   width: 100%;
   min-width: 0;
 }

--- a/frontend/src/components/ProgressBar/ProgressBar.module.scss
+++ b/frontend/src/components/ProgressBar/ProgressBar.module.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/tokens/typography' as tt;
@@ -8,9 +8,9 @@
 .progressBarWrapper {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   width: 100%;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   position: relative;
 }
 
@@ -32,12 +32,12 @@
 
 .progressTrack {
   width: 100%;
-  height: v.$spacing-lg;
+  height: sp.$spacing-lg;
   background-color: c.$color-bg;
   overflow: hidden;
   position: relative;
 
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   border: 1px solid rgba(c.$color-border-primary, 0.8);;
 }
 
@@ -47,11 +47,11 @@
   justify-content: center;
   height: 100%;
   transition: width 0.3s ease;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  border-top-right-radius: v.$border-radius;
-  border-bottom-right-radius: v.$border-radius;
+  border-top-right-radius: sp.$border-radius;
+  border-bottom-right-radius: sp.$border-radius;
   white-space: nowrap;
   //padding: 0 0.5rem;
 }

--- a/frontend/src/components/SupportFlow/SupportFlowModal.module.scss
+++ b/frontend/src/components/SupportFlow/SupportFlowModal.module.scss
@@ -1,12 +1,12 @@
 // SupportFlow/SupportFlowModal.module.scss
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/utilities/mixins' as m;
 
 .activityInputScreen {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
   width: 100%;
 }
 
@@ -16,9 +16,9 @@
 
 .activityTextArea {
   width: 100%;
-  padding: v.$spacing-sm;
+  padding: sp.$spacing-sm;
   border: 1px solid c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: c.$color-bg;
   color: c.$color-text-body;
   font-size: 1rem;
@@ -29,7 +29,7 @@
 .durationRow {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   flex-wrap: wrap;
 }
 
@@ -41,24 +41,24 @@
 
 .durationInput {
   width: 5rem;
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   border: 1px solid c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: c.$color-bg;
   color: c.$color-text-body;
   font-size: 1rem;
 }
 
 .detailIntro {
-  margin-bottom: v.$spacing-sm;
+  margin-bottom: sp.$spacing-sm;
 }
 
 .videoWrapper {
   width: 100%;
   aspect-ratio: 16 / 9;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   overflow: hidden;
-  margin-bottom: v.$spacing-md;
+  margin-bottom: sp.$spacing-md;
   background: rgba(c.$color-border-primary, 0.12);
 }
 
@@ -71,26 +71,26 @@
 .hint {
   font-size: 0.875rem;
   color: c.$color-text-muted;
-  margin-bottom: v.$spacing-sm;
+  margin-bottom: sp.$spacing-sm;
 }
 
 .stepsList {
-  padding-left: v.$spacing-lg;
-  margin-bottom: v.$spacing-md;
+  padding-left: sp.$spacing-lg;
+  margin-bottom: sp.$spacing-md;
 
   li {
-    margin-bottom: v.$spacing-xs;
+    margin-bottom: sp.$spacing-xs;
   }
 }
 
 .tabBar {
   display: flex;
   border-bottom: 1px solid rgba(c.$color-border-primary, 0.25);
-  margin-bottom: v.$spacing-sm;
+  margin-bottom: sp.$spacing-sm;
 }
 
 .tab {
-  padding: v.$spacing-xs v.$spacing-md;
+  padding: sp.$spacing-xs sp.$spacing-md;
   border: none;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
@@ -115,7 +115,7 @@
 .taskPickList {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
   max-height: 220px;
   overflow-y: auto;
 
@@ -136,10 +136,10 @@
 .taskPickRow {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
-  padding: v.$spacing-xs v.$spacing-sm;
+  gap: sp.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   border: 1px solid rgba(c.$color-border-primary, 0.15);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.4);
   width: 100%;
   box-sizing: border-box;
@@ -156,7 +156,7 @@
 
 .taskPickEmpty {
   text-align: center;
-  padding: v.$spacing-md;
+  padding: sp.$spacing-md;
   color: c.$color-text-muted;
   font-size: 0.9rem;
   margin: 0;
@@ -165,23 +165,23 @@
 .priorityThreeContainer {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   width: 100%;
 }
 
 .priorityRow {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   width: 100%;
 }
 
 .priorityInput {
   flex: 1 1 auto;
   min-width: 0;
-  padding: v.$spacing-sm;
+  padding: sp.$spacing-sm;
   border: 1px solid c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: c.$color-bg;
   color: c.$color-text-body;
   font-size: 1rem;
@@ -191,7 +191,7 @@
 .supportOptionList {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
   width: 100%;
 }
 
@@ -199,8 +199,8 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: v.$spacing-md;
-  padding-bottom: v.$spacing-sm;
+  gap: sp.$spacing-md;
+  padding-bottom: sp.$spacing-sm;
   border-bottom: 1px solid rgba(c.$color-border-primary, 0.25);
   width: 100%;
 
@@ -223,12 +223,12 @@
 
 .rewardBreakdown {
   display: grid;
-  gap: v.$spacing-sm;
-  margin-bottom: v.$spacing-md;
+  gap: sp.$spacing-sm;
+  margin-bottom: sp.$spacing-md;
   width: 100%;
-  padding: v.$spacing-md;
+  padding: sp.$spacing-md;
   border: 2px solid rgba(c.$color-border-primary, 0.4);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.9);
   box-shadow: 0 8px 24px rgba(c.$color-border-primary, 0.14);
 }
@@ -242,10 +242,10 @@
 .rewardBreakdownRow {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
   align-items: center;
-  padding: v.$spacing-xs v.$spacing-sm;
-  border-radius: v.$border-radius;
+  padding: sp.$spacing-xs sp.$spacing-sm;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.65);
 }
 
@@ -270,15 +270,15 @@
 
 .taskCompletionPanel {
   width: 100%;
-  margin-bottom: v.$spacing-md;
-  padding: v.$spacing-xs v.$spacing-md;
+  margin-bottom: sp.$spacing-md;
+  padding: sp.$spacing-xs sp.$spacing-md;
   border: 1px solid rgba(c.$color-border-primary, 0.5);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.45);
 }
 
 .taskCompletionTitle {
-  margin: 0 0 v.$spacing-xs;
+  margin: 0 0 sp.$spacing-xs;
   font-weight: 600;
   font-size: 0.95rem;
 }
@@ -287,7 +287,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
 }
 
 .taskCompletionTime {
@@ -299,7 +299,7 @@
 .taskCompletionCheck {
   display: flex;
   align-items: center;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
   font-size: 0.9rem;
   color: c.$color-text-muted;
   cursor: pointer;
@@ -314,7 +314,7 @@
 }
 
 .taskCompletionXp {
-  margin: v.$spacing-xs 0 0;
+  margin: sp.$spacing-xs 0 0;
   font-size: 0.9rem;
   font-weight: 600;
   color: c.$color-text-body;
@@ -323,14 +323,14 @@
 .upgradePanel {
   width: 100%;
   margin-bottom: 0;
-  padding: v.$spacing-sm v.$spacing-md;
+  padding: sp.$spacing-sm sp.$spacing-md;
   border: 1px solid rgba(c.$color-border-primary, 0.5);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.45);
 
   p {
     margin-top: 0;
-    margin-bottom: v.$spacing-sm;
+    margin-bottom: sp.$spacing-sm;
     color: c.$color-text-muted;
   }
 
@@ -342,9 +342,9 @@
 .supportPanel {
   width: 100%;
   margin-bottom: 0;
-  padding: v.$spacing-sm v.$spacing-md;
+  padding: sp.$spacing-sm sp.$spacing-md;
   border: none;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.7);
 
   p {
@@ -355,7 +355,7 @@
 .supportPanelActions {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .supportCountdownButton {
@@ -403,5 +403,5 @@
 .actionRow {
   width: 100%;
   display: grid;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
 }

--- a/frontend/src/components/TasksPanel/TasksPanel.module.scss
+++ b/frontend/src/components/TasksPanel/TasksPanel.module.scss
@@ -1,6 +1,6 @@
 @use '../../styles/utilities/mixins' as m;
 @use '../../styles/utilities/list-pages' as lp;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 
 .page {
@@ -96,7 +96,7 @@
 .taskTimestamps {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .timestampLabel {
@@ -111,7 +111,7 @@
 .filterToggle {
   align-self: flex-start;
   font-size: 0.875em;
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   min-width: 9rem;
 }
 
@@ -119,7 +119,7 @@
   border: none;
   background: transparent;
   color: c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   width: 1.75rem;
   height: 1.75rem;
   font-size: 1.25rem;

--- a/frontend/src/components/Toast/Toast.module.scss
+++ b/frontend/src/components/Toast/Toast.module.scss
@@ -1,4 +1,5 @@
 @use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/utilities/mixins' as m;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
@@ -14,7 +15,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   width: min(96vw, 720px);
   /* Required by Radix to be a list */
   list-style: none;
@@ -30,7 +31,7 @@
 
   /* Base look */
   background: rgba(c.$color-bg, 1);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   padding: 0;
   overflow: hidden;
 
@@ -86,7 +87,7 @@
 @keyframes fadeInUp {
   from {
     opacity: 0;
-    transform: translateY(-(v.$spacing-sm));
+    transform: translateY(-(sp.$spacing-sm));
   }
   to {
     opacity: 1;
@@ -101,6 +102,6 @@
   }
   to {
     opacity: 0;
-    transform: translateY(-(v.$spacing-sm));
+    transform: translateY(-(sp.$spacing-sm));
   }
 }

--- a/frontend/src/components/Tooltip/Tooltip.module.scss
+++ b/frontend/src/components/Tooltip/Tooltip.module.scss
@@ -1,4 +1,5 @@
 @use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 
 .content {
@@ -11,12 +12,12 @@
   // Letting pointer events pass through avoids the tooltip ever intercepting
   // the hover in the first place.
   pointer-events: none;
-  max-width: min(20rem, calc(100vw - (2 * #{v.$spacing-md})));
+  max-width: min(20rem, calc(100vw - (2 * #{sp.$spacing-md})));
   border: 1px solid rgba(c.$color-border-primary, 0.22);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg-invert, 0.96);
   color: c.$color-text-invert;
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
   font-size: 0.875rem;
   line-height: 1.4;

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss
@@ -1,5 +1,4 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/semantic/spacing' as sp;
@@ -11,8 +10,8 @@ $row-control-height: 44px;
   position: relative;
   width: min(100%, 720px);
   border: 1px solid rgba(c.$color-border-primary, 0.15);
-  border-radius: v.$border-radius;
-  padding: v.$padding-base;
+  border-radius: sp.$border-radius;
+  padding: sp.$padding-base;
   background: rgba(c.$color-player, 0.14);
 }
 
@@ -65,8 +64,8 @@ $row-control-height: 44px;
   text-align: left;
   border: 2px solid transparent;
   background: transparent;
-  border-radius: v.$border-radius;
-  padding: v.$padding-sm;
+  border-radius: sp.$border-radius;
+  padding: sp.$padding-sm;
   font-size: 1.05rem;
   cursor: pointer;
   color: c.$color-text-body;
@@ -103,13 +102,13 @@ $row-control-height: 44px;
   justify-content: center;
   height: $row-control-height;
   @include m.border(rgba(c.$color-border-primary, 0.3));
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   // $padding-base is itself a 2-value shorthand ($padding-vertical
   // $padding-horizontal) — `0 $padding-base` silently expanded to a 3-value
   // padding (0 top, $padding-vertical left/right, $padding-horizontal
   // bottom), which is what was pushing the digits off-center. Use the
   // horizontal-only variable instead so this stays a clean 2-value shorthand.
-  padding: 0 v.$padding-horizontal;
+  padding: 0 sp.$padding-horizontal;
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 1.1rem;
@@ -123,7 +122,7 @@ $row-control-height: 44px;
 }
 
 .limitWarning {
-  margin: v.$spacing-sm 0 0;
+  margin: sp.$spacing-sm 0 0;
   text-align: left;
   color: c.$color-text-body;
 }
@@ -131,7 +130,7 @@ $row-control-height: 44px;
 .supportButtonRow {
   display: flex;
   justify-content: center;
-  padding-top: v.$spacing-md;
+  padding-top: sp.$spacing-md;
 }
 
 .supportModeButton {

--- a/frontend/src/layout/Footer/Footer.module.scss
+++ b/frontend/src/layout/Footer/Footer.module.scss
@@ -1,4 +1,4 @@
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 
@@ -7,15 +7,15 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: v.$padding-base;
-  gap: v.$spacing-lg;
-  margin-top: v.$spacing-md;
+  padding: sp.$padding-base;
+  gap: sp.$spacing-lg;
+  margin-top: sp.$spacing-md;
   width: 100%;
   background: c.$color-bg;
   @include t.apply-text-style(t.$text-body);
 
   a {
-    margin: 0 v.$spacing-sm;
+    margin: 0 sp.$spacing-sm;
     @include t.apply-text-style(t.$text-body);
 
     &:hover {
@@ -28,5 +28,5 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }

--- a/frontend/src/layout/Infobar/AchievementBadges.module.scss
+++ b/frontend/src/layout/Infobar/AchievementBadges.module.scss
@@ -1,12 +1,12 @@
 @use '../../styles/utilities/tier-colors' as tc;
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 
 .badgeRow {
   display: flex;
   align-items: center;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
   flex-shrink: 0;
 }
 

--- a/frontend/src/layout/Infobar/Infobar.module.scss
+++ b/frontend/src/layout/Infobar/Infobar.module.scss
@@ -1,4 +1,4 @@
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/utilities/mixins' as m;
 
@@ -9,7 +9,7 @@
   gap: 0;
   width: 100%;
   max-width: 420px;
-  margin: v.$spacing-md auto 0;
+  margin: sp.$spacing-md auto 0;
 
   @include m.respond-to(sm, down) {
     max-width: 100%;
@@ -20,14 +20,14 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: v.$spacing-xs;
-  padding: v.$spacing-xs v.$spacing-md;
+  gap: sp.$spacing-xs;
+  padding: sp.$spacing-xs sp.$spacing-md;
   border: 1px solid rgba(c.$color-border-primary, 0.15);
 
   @include m.respond-to(sm) {
     flex-direction: row;
     align-items: center;
-    gap: v.$spacing-sm;
+    gap: sp.$spacing-sm;
   }
 
   .value {
@@ -76,7 +76,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
   flex-shrink: 0;
   margin-left: auto;
 }
@@ -84,7 +84,7 @@
 .player {
   background: rgba(c.$color-player, 0.14);
   color: c.$color-text-heading;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   flex: 1;
   flex-direction: row;
   align-items: center;

--- a/frontend/src/layout/NavDrawer/NavDrawer.module.scss
+++ b/frontend/src/layout/NavDrawer/NavDrawer.module.scss
@@ -1,4 +1,5 @@
 @use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/utilities/mixins' as m;
 @use '../../styles/semantic/typography' as t;
@@ -26,7 +27,7 @@
 }
 
 .nav-drawer-header {
-    padding: v.$spacing-md;
+    padding: sp.$spacing-md;
     display: flex;
     justify-content: flex-end;
     align-items: center;
@@ -36,7 +37,7 @@
     width: 40px;
     height: 40px;
     border: 1px solid rgba(c.$color-border-primary, 0.3);
-    border-radius: v.$border-radius;
+    border-radius: sp.$border-radius;
     background: transparent;
     color: c.$color-border-primary;
     font-size: 1.5em;
@@ -61,11 +62,11 @@
 
 .nav-drawer-links {
     list-style: none;
-    padding: v.$spacing-md;
+    padding: sp.$spacing-md;
     margin: 0;
     display: flex;
     flex-direction: column;
-    gap: v.$spacing-sm;
+    gap: sp.$spacing-sm;
 }
 
 .nav-drawer-links li {
@@ -76,10 +77,10 @@
 .nav-drawer-links a {
     text-decoration: none;
     width: 100%;
-    padding: v.$padding-base;
+    padding: sp.$padding-base;
     display: flex;
     align-items: center;
-    gap: v.$spacing-xs;
+    gap: sp.$spacing-xs;
     @include t.apply-text-style(t.$text-body);
 
     span[aria-hidden] {

--- a/frontend/src/layout/Navbar/Navbar.module.scss
+++ b/frontend/src/layout/Navbar/Navbar.module.scss
@@ -16,7 +16,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  padding: v.$padding-base;
+  padding: sp.$padding-base;
   width: 100%;
   max-width: 100%;
   background: c.$color-bg;
@@ -28,8 +28,8 @@
   flex-direction: row;
   align-items: center;
   align-self: stretch;
-  gap: v.$spacing-md;
-  margin: 0 v.$spacing-sm;
+  gap: sp.$spacing-md;
+  margin: 0 sp.$spacing-sm;
   @include t.apply-text-style(t.$text-heading-2);
 }
 
@@ -63,7 +63,7 @@
     // Tighter than Button's own default padding ($button-padding) - with
     // several nav buttons sharing one row, the default spacing left too
     // little room for a label to fit on one line.
-    padding: v.$spacing-xs v.$spacing-sm;
+    padding: sp.$spacing-xs sp.$spacing-sm;
 }
 
 .unreadBadge {
@@ -103,9 +103,9 @@
   overflow: auto;
   background: c.$color-bg;
   border: 1px solid rgba(c.$color-border-primary, 0.25);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
-  padding: v.$spacing-sm;
+  padding: sp.$spacing-sm;
   z-index: v.$z-index-dropdown;
 }
 
@@ -113,8 +113,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: v.$spacing-sm;
-  margin-bottom: v.$spacing-sm;
+  gap: sp.$spacing-sm;
+  margin-bottom: sp.$spacing-sm;
 }
 
 .announcementsList {
@@ -123,25 +123,25 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .announcementItem {
   border: 1px solid rgba(c.$color-border-primary, 0.2);
-  border-radius: v.$border-radius;
-  padding: v.$spacing-sm;
+  border-radius: sp.$border-radius;
+  padding: sp.$spacing-sm;
 }
 
 .announcementTitleRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   font-weight: 600;
 }
 
 .announcementSummary {
-  margin: v.$spacing-xs 0;
+  margin: sp.$spacing-xs 0;
   font-size: 0.9rem;
   opacity: 0.9;
 }
@@ -159,7 +159,7 @@
   &:focus-visible {
     outline: 2px solid rgba(c.$color-border-primary, 0.5);
     outline-offset: 2px;
-    border-radius: v.$border-radius;
+    border-radius: sp.$border-radius;
   }
 }
 
@@ -170,11 +170,11 @@
 .announcementMetaRight {
   display: inline-flex;
   align-items: center;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
 }
 
 .announcementBody {
-  margin: v.$spacing-xs 0 0;
+  margin: sp.$spacing-xs 0 0;
   font-size: 0.9rem;
   white-space: pre-wrap;
   line-height: 1.35;
@@ -219,7 +219,7 @@
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   border: 1px solid rgba(c.$color-border-primary, 0.35);
   background: transparent;
   cursor: pointer;
@@ -243,7 +243,7 @@
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   border: 1px solid rgba(c.$color-border-primary, 0.35);
   color: inherit;
   text-decoration: none;
@@ -270,9 +270,9 @@
   min-width: 160px;
   background: c.$color-bg;
   border: 1px solid rgba(c.$color-border-primary, 0.2);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
-  padding: v.$spacing-xs 0;
+  padding: sp.$spacing-xs 0;
   z-index: v.$z-index-dropdown;
   outline: none;
 }
@@ -280,7 +280,7 @@
 .accountDropdownItem {
   display: block;
   text-decoration: none;
-  padding: v.$spacing-sm v.$spacing-md;
+  padding: sp.$spacing-sm sp.$spacing-md;
   @include t.apply-text-style(t.$text-body);
   @include c.apply-text-tone(map.get(c.$text-tone, default));
   width: 100%;
@@ -294,7 +294,7 @@
     width: 100%;
     display: flex;
     align-items: center;
-    gap: v.$spacing-xs;
+    gap: sp.$spacing-xs;
     text-decoration: none;
     color: inherit;
   }
@@ -307,10 +307,10 @@
 }
 
 .mobileAnnouncementsPanel {
-  margin: 0 v.$spacing-sm v.$spacing-sm;
-  padding: v.$spacing-sm;
+  margin: 0 sp.$spacing-sm sp.$spacing-sm;
+  padding: sp.$spacing-sm;
   border: 1px solid rgba(c.$color-border-primary, 0.2);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.95);
 }
 
@@ -318,8 +318,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: v.$spacing-sm;
-  margin-bottom: v.$spacing-sm;
+  gap: sp.$spacing-sm;
+  margin-bottom: sp.$spacing-sm;
 }
 
 //.account {
@@ -331,7 +331,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  padding: v.$spacing-md;
+  padding: sp.$spacing-md;
   width: 100%;
   max-width: 100%;
 
@@ -363,7 +363,7 @@
 
   .leftLinks,
   .rightLinks {
-    gap: v.$spacing-xs;
+    gap: sp.$spacing-xs;
   }
 
   .navLink.navLink {
@@ -379,7 +379,7 @@
 @include m.respond-to(lg) {
   .leftLinks,
   .rightLinks {
-    gap: v.$spacing-md;
+    gap: sp.$spacing-md;
   }
 
   .navLink.navLink {

--- a/frontend/src/layout/_two-columns.scss
+++ b/frontend/src/layout/_two-columns.scss
@@ -1,12 +1,12 @@
 @use '../styles/utilities/mixins' as m;
-@use '../styles/base/variables' as v;
+@use '../styles/semantic/spacing' as sp;
 @use '../styles/semantic/colors' as c;
 
 @mixin two-column-layout {
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   width: 100%;
   max-width: 100vw;
   flex-direction: column;
@@ -22,11 +22,11 @@
   justify-content: flex-start;
   flex-direction: column;
   align-items: flex-start;
-  gap: v.$spacing-gap;
-  padding: v.$padding-base;
+  gap: sp.$spacing-gap;
+  padding: sp.$padding-base;
   background: c.$color-bg;
   border: 1px solid rgba(c.$color-border-primary, 0.8);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   align-self: stretch;
   max-width: 100%;
 
@@ -42,5 +42,5 @@
 @mixin bodyRow {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
 }

--- a/frontend/src/pages/Account/Account.module.scss
+++ b/frontend/src/pages/Account/Account.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 
@@ -10,20 +10,20 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-lg;
+  gap: sp.$spacing-lg;
   width: 100%;
   max-width: 800px;
   margin: 0 auto;
 }
 
 .section {
-  padding: v.$padding-lg;
+  padding: sp.$padding-lg;
   border: 1px solid rgba(c.$color-border-primary, 0.2);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.4);
 
   h2 {
-    margin: 0 0 v.$spacing-md 0;
+    margin: 0 0 sp.$spacing-md 0;
     @include t.apply-text-style(t.$text-heading-2);
     color: c.$color-border-primary;
   }
@@ -32,16 +32,16 @@
 .infoGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
 }
 
 .infoItem {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
-  padding: v.$spacing-sm;
+  gap: sp.$spacing-xs;
+  padding: sp.$spacing-sm;
   background: rgba(c.$color-border-primary, 0.05);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   transition: background 0.2s ease;
 
   &:hover {
@@ -90,7 +90,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   flex-wrap: wrap;
 }
 
@@ -101,7 +101,7 @@
 .nameEditor {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .rulesList {
@@ -129,14 +129,14 @@
 }
 
 .description {
-  margin-bottom: v.$spacing-md;
+  margin-bottom: sp.$spacing-md;
   color: rgba(0, 0, 0, 0.7);
   @include t.apply-text-style(t.$text-body);
 }
 
 .billingRow {
   display: grid;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
   align-items: center;
 
   @include m.respond-to(md) {
@@ -151,13 +151,13 @@
 }
 
 .billingAction .description {
-  margin-bottom: v.$spacing-sm;
+  margin-bottom: sp.$spacing-sm;
 }
 
 .input {
-  padding: v.$spacing-sm;
+  padding: sp.$spacing-sm;
   border: 2px solid rgba(c.$color-border-primary, 0.3);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   font-size: 1em;
   font-family: inherit;
   transition: border-color 0.2s ease;
@@ -172,10 +172,10 @@
 .deleteConfirmation {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-md;
-  padding: v.$padding-base;
+  gap: sp.$spacing-md;
+  padding: sp.$padding-base;
   border: 2px solid #d32f2f;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(211, 47, 47, 0.05);
 }
 
@@ -188,25 +188,25 @@
 
 .buttonGroup {
   display: flex;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   flex-wrap: wrap;
 }
 
 .bioSection {
-  margin-bottom: v.$spacing-md;
-  padding-bottom: v.$spacing-md;
+  margin-bottom: sp.$spacing-md;
+  padding-bottom: sp.$spacing-md;
   border-bottom: 1px solid rgba(c.$color-border-primary, 0.1);
 
   .label {
     display: block;
-    margin-bottom: v.$spacing-xs;
+    margin-bottom: sp.$spacing-xs;
   }
 
   .bio {
     margin: 0;
-    padding: v.$spacing-sm;
+    padding: sp.$spacing-sm;
     background: rgba(c.$color-border-primary, 0.05);
-    border-radius: v.$border-radius;
+    border-radius: sp.$border-radius;
     color: rgba(0, 0, 0, 0.8);
     line-height: 1.6;
     @include t.apply-text-style(t.$text-body);

--- a/frontend/src/pages/EditAccount/EditAccount.module.scss
+++ b/frontend/src/pages/EditAccount/EditAccount.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 
@@ -11,8 +11,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: v.$spacing-lg;
-  gap: v.$spacing-sm;
+  margin-bottom: sp.$spacing-lg;
+  gap: sp.$spacing-sm;
 
   h1 {
     margin: 0;
@@ -22,9 +22,9 @@
 }
 
 .backLink {
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   border: 1px solid c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: transparent;
   color: c.$color-border-primary;
   text-decoration: none;
@@ -46,20 +46,20 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xl;
+  gap: sp.$spacing-xl;
   width: 100%;
   max-width: 700px;
   margin: 0 auto;
 }
 
 .section {
-  padding: v.$padding-lg;
+  padding: sp.$padding-lg;
   border: 1px solid rgba(c.$color-border-primary, 0.2);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.4);
 
   h2 {
-    margin: 0 0 v.$spacing-md 0;
+    margin: 0 0 sp.$spacing-md 0;
     @include t.apply-text-style(t.$text-heading-2);
   }
 }
@@ -71,19 +71,19 @@
 }
 
 .description {
-  margin-bottom: v.$spacing-md;
+  margin-bottom: sp.$spacing-md;
   color: rgba(0, 0, 0, 0.7);
   @include t.apply-text-style(t.$text-body);
 }
 
 .currentInfo {
   display: flex;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   align-items: baseline;
-  margin-bottom: v.$spacing-md;
-  padding: v.$spacing-sm;
+  margin-bottom: sp.$spacing-md;
+  padding: sp.$spacing-sm;
   background: rgba(c.$color-border-primary, 0.05);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
 
   .currentLabel {
     margin: 0;
@@ -103,13 +103,13 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
 }
 
 .formGroup {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
 
   label {
     font-weight: 500;
@@ -118,9 +118,9 @@
 }
 
 .input {
-  padding: v.$spacing-sm;
+  padding: sp.$spacing-sm;
   border: 2px solid rgba(c.$color-border-primary, 0.3);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   font-size: 1em;
   font-family: inherit;
   transition: border-color 0.2s ease;
@@ -133,11 +133,11 @@
 }
 
 .primaryButton {
-  padding: v.$spacing-sm v.$spacing-md;
+  padding: sp.$spacing-sm sp.$spacing-md;
   border: 1px solid #5a4cff;
   background: #5a4cff;
   color: white;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   cursor: pointer;
   font-size: 1em;
   transition: all 0.2s ease;
@@ -159,11 +159,11 @@
 }
 
 .secondaryButton {
-  padding: v.$spacing-sm v.$spacing-md;
+  padding: sp.$spacing-sm sp.$spacing-md;
   border: 1px solid c.$color-border-primary;
   background: transparent;
   color: c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   cursor: pointer;
   font-size: 1em;
   transition: all 0.2s ease;
@@ -186,11 +186,11 @@
 }
 
 .dangerButton {
-  padding: v.$spacing-sm v.$spacing-md;
+  padding: sp.$spacing-sm sp.$spacing-md;
   border: 1px solid #d32f2f;
   background: transparent;
   color: #d32f2f;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   cursor: pointer;
   font-size: 1em;
   transition: all 0.2s ease;
@@ -229,10 +229,10 @@
 .deleteConfirmation {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-md;
-  padding: v.$padding-base;
+  gap: sp.$spacing-md;
+  padding: sp.$padding-base;
   border: 2px solid #d32f2f;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(211, 47, 47, 0.05);
 }
 
@@ -245,6 +245,6 @@
 
 .buttonGroup {
   display: flex;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   flex-wrap: wrap;
 }

--- a/frontend/src/pages/Game2/ActivityTimelinePage.module.scss
+++ b/frontend/src/pages/Game2/ActivityTimelinePage.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 
@@ -7,14 +7,14 @@
   @include m.page-layout();
 
   @include m.respond-to(sm, down) {
-    padding-inline: v.$spacing-sm;
+    padding-inline: sp.$spacing-sm;
   }
 }
 
 .activitiesLink {
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   border: 1px solid c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: transparent;
   color: c.$color-border-primary;
   text-decoration: none;
@@ -38,8 +38,8 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-gap;
-  margin-top: v.$spacing-gap;
+  gap: sp.$spacing-gap;
+  margin-top: sp.$spacing-gap;
   width: 100%;
   align-items: center;
 }

--- a/frontend/src/pages/Home/Home.module.scss
+++ b/frontend/src/pages/Home/Home.module.scss
@@ -1,6 +1,6 @@
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/utilities/mixins' as m;
 @use '../../styles/tokens/colors' as tc;
 @use 'sass:map';
@@ -17,17 +17,17 @@
 .skipLink {
   position: absolute;
   top: -3rem;
-  left: v.$spacing-md;
+  left: sp.$spacing-md;
   z-index: 20;
-  padding: v.$spacing-sm v.$spacing-md;
-  border-radius: v.$border-radius;
+  padding: sp.$spacing-sm sp.$spacing-md;
+  border-radius: sp.$border-radius;
   background: tc.$color-light;
   color: map.get(tc.$primary-scale, 700);
   box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.18);
   text-decoration: none;
 
   &:focus {
-    top: v.$spacing-md;
+    top: sp.$spacing-md;
   }
 }
 
@@ -36,7 +36,7 @@
 .sectionHeading {
   @include t.apply-text-style(t.$text-heading-2);
   text-align: center;
-  margin-bottom: v.$spacing-lg;
+  margin-bottom: sp.$spacing-lg;
   scroll-margin-top: 6rem;
 }
 
@@ -50,7 +50,7 @@
     map.get(tc.$primary-scale, 300) 100%
   );
   color: tc.$color-light;
-  padding: v.$spacing-3xl v.$spacing-md;
+  padding: sp.$spacing-3xl sp.$spacing-md;
   display: flex;
   justify-content: center;
 }
@@ -62,7 +62,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  gap: v.$spacing-lg;
+  gap: sp.$spacing-lg;
 }
 
 .heroHeading {
@@ -98,14 +98,14 @@
   width: 100%;
   max-width: 40rem;
   display: grid;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .heroHighlightItem {
   background: rgba(tc.$color-light, 0.14);
   border-left: 0.25rem solid rgba(tc.$color-light, 0.72);
-  border-radius: v.$border-radius;
-  padding: v.$spacing-sm v.$spacing-md;
+  border-radius: sp.$border-radius;
+  padding: sp.$spacing-sm sp.$spacing-md;
   text-align: left;
   @include t.apply-text-style(t.$text-body);
 }
@@ -114,7 +114,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   width: 100%;
   max-width: 40rem;
 
@@ -123,8 +123,8 @@
     align-items: center;
     justify-content: center;
     min-height: 2.5rem;
-    padding: 0 v.$spacing-md;
-    border-radius: v.$button-radius;
+    padding: 0 sp.$spacing-md;
+    border-radius: sp.$button-radius;
     border: 1px solid rgba(c.$color-border-primary, 0.35);
     @include t.apply-text-style(t.$text-button);
     @include c.apply-button-variant(secondary);
@@ -151,15 +151,15 @@
 .heroSignupBox {
   background: map.get(tc.$secondary-scale, 100);
   border: 1px solid map.get(tc.$secondary-scale, 300);
-  border-radius: v.$border-radius;
-  padding: v.$spacing-xl v.$spacing-lg;
+  border-radius: sp.$border-radius;
+  padding: sp.$spacing-xl sp.$spacing-lg;
   max-width: 560px;
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
   box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.16);
 }
 
@@ -183,7 +183,7 @@
 // ─── Features ────────────────────────────────────────────────────────────────
 
 .features {
-  padding: v.$spacing-2xl v.$spacing-md;
+  padding: sp.$spacing-2xl sp.$spacing-md;
   background: c.$color-bg;
   display: flex;
   flex-direction: column;
@@ -196,7 +196,7 @@
   padding: 0;
   display: grid;
   grid-template-columns: 1fr;
-  gap: v.$spacing-lg;
+  gap: sp.$spacing-lg;
   width: 100%;
   max-width: 960px;
 
@@ -207,11 +207,11 @@
 
 .featureCard {
   background: map.get(tc.$secondary-scale, 100);
-  border-radius: v.$border-radius;
-  padding: v.$spacing-lg;
+  border-radius: sp.$border-radius;
+  padding: sp.$spacing-lg;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .featureIcon {
@@ -232,7 +232,7 @@
 // ─── How it works ─────────────────────────────────────────────────────────────
 
 .howItWorks {
-  padding: v.$spacing-2xl v.$spacing-md;
+  padding: sp.$spacing-2xl sp.$spacing-md;
   background: map.get(tc.$secondary-scale, 100);
   display: flex;
   flex-direction: column;
@@ -245,7 +245,7 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-lg;
+  gap: sp.$spacing-lg;
   width: 100%;
   max-width: 640px;
 }
@@ -253,12 +253,12 @@
 .step {
   display: flex;
   align-items: flex-start;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
 
   strong {
     @include t.apply-text-style(t.$text-heading-3);
     display: block;
-    margin-bottom: v.$spacing-xs;
+    margin-bottom: sp.$spacing-xs;
   }
 
   p {
@@ -285,7 +285,7 @@
 // ─── Story / mission ───────────────────────────────────────────────────────────
 
 .storySection {
-  padding: v.$spacing-2xl v.$spacing-md;
+  padding: sp.$spacing-2xl sp.$spacing-md;
   background: c.$color-bg;
   display: flex;
   justify-content: center;
@@ -296,7 +296,7 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
   text-align: center;
 }
 
@@ -329,13 +329,13 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .signupFieldGroup {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
   width: 100%;
 }
 
@@ -353,7 +353,7 @@
 
 .signupFields {
   display: flex;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   width: 100%;
   flex-wrap: wrap;
   justify-content: center;
@@ -361,9 +361,9 @@
 
 .signupInput {
   flex: 1 1 220px;
-  padding: v.$padding-base;
+  padding: sp.$padding-base;
   border: 1px solid map.get(tc.$primary-scale, 300);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   @include t.apply-text-style(t.$text-body);
   background: tc.$color-light;
 
@@ -389,9 +389,9 @@
 }
 
 .signupSuccess {
-  padding: v.$spacing-md;
+  padding: sp.$spacing-md;
   background: map.get(tc.$secondary-scale, 200);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   border: 1px solid map.get(tc.$secondary-scale, 400);
 
   p {

--- a/frontend/src/pages/LegalPage/LegalPage.module.scss
+++ b/frontend/src/pages/LegalPage/LegalPage.module.scss
@@ -1,4 +1,4 @@
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/utilities/mixins' as m;
@@ -7,29 +7,29 @@
   @include m.page-layout();
   display: flex;
   justify-content: center;
-  padding-top: v.$spacing-2xl;
-  padding-bottom: v.$spacing-2xl;
+  padding-top: sp.$spacing-2xl;
+  padding-bottom: sp.$spacing-2xl;
 }
 
 .card {
   width: min(100%, 52rem);
   background: c.$color-bg;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.08);
-  padding: v.$spacing-xl;
+  padding: sp.$spacing-xl;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-lg;
+  gap: sp.$spacing-lg;
 
   @include m.respond-to(sm) {
-    padding: v.$spacing-2xl;
+    padding: sp.$spacing-2xl;
   }
 }
 
 .header {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .title {
@@ -58,15 +58,15 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xl;
+  gap: sp.$spacing-xl;
 }
 
 .toc {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
-  padding: v.$spacing-lg;
-  border-radius: v.$border-radius;
+  gap: sp.$spacing-sm;
+  padding: sp.$spacing-lg;
+  border-radius: sp.$border-radius;
   background: c.$color-bg;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
 }
@@ -82,7 +82,7 @@
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
 }
 
 .tocList a {
@@ -92,7 +92,7 @@
 .section {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .sectionTitle {

--- a/frontend/src/pages/LibraryPage/LibraryPage.module.scss
+++ b/frontend/src/pages/LibraryPage/LibraryPage.module.scss
@@ -1,4 +1,4 @@
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 @use '../../styles/semantic/typography' as t;
 
@@ -8,12 +8,12 @@
   align-items: center;
   width: 100%;
   margin: 0 auto;
-  padding: v.$padding-base;
+  padding: sp.$padding-base;
 }
 
 .header {
   text-align: center;
-  margin-bottom: v.$spacing-lg;
+  margin-bottom: sp.$spacing-lg;
 
   h1 {
     @include t.apply-text-style(t.$text-heading-1);
@@ -29,13 +29,13 @@
 .tabBar {
   display: flex;
   justify-content: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   border-bottom: 1px solid rgba(c.$color-border-primary, 0.25);
-  margin-bottom: v.$spacing-md;
+  margin-bottom: sp.$spacing-md;
 }
 
 .tab {
-  padding: v.$spacing-sm v.$spacing-md;
+  padding: sp.$spacing-sm sp.$spacing-md;
   border: none;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;

--- a/frontend/src/pages/LoginPage/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage/LoginPage.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 @use 'sass:map';
@@ -11,7 +11,7 @@
   justify-content: flex-start;
   align-items: center;
   min-height: 100vh;
-  padding-top: v.$spacing-2xl;
+  padding-top: sp.$spacing-2xl;
 }
 
 .formFrame {
@@ -19,14 +19,14 @@
 }
 
 .form {
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   width: 100%;
 }
 
 .rememberMeField {
   flex-direction: row;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .rememberMeInput {
@@ -36,7 +36,7 @@
 
 .error {
   @include c.apply-text-tone(map.get(c.$text-tone, error));
-  margin-bottom: v.$spacing-sm;
+  margin-bottom: sp.$spacing-sm;
   text-align: center;
   @include t.apply-text-style(t.$text-body);
 }

--- a/frontend/src/pages/MaintenancePage/MaintenancePage.module.scss
+++ b/frontend/src/pages/MaintenancePage/MaintenancePage.module.scss
@@ -1,2 +1,1 @@
-@use '../../styles/base/variables' as v;
 @use '../../styles/semantic/typography' as t;

--- a/frontend/src/pages/MapPage/MapPage.module.scss
+++ b/frontend/src/pages/MapPage/MapPage.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 
@@ -12,7 +12,7 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   width: 100%;
   align-items: center;
 }

--- a/frontend/src/pages/NotFoundPage/NotFoundPage.module.scss
+++ b/frontend/src/pages/NotFoundPage/NotFoundPage.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 
@@ -9,7 +9,7 @@
   justify-content: center;
   align-items: center;
   text-align: center;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
 }
 
 .code {
@@ -24,10 +24,10 @@
 }
 
 .actions {
-  margin-top: v.$spacing-sm;
+  margin-top: sp.$spacing-sm;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   align-items: center;
 }
 

--- a/frontend/src/pages/PasswordResetPage.module.scss
+++ b/frontend/src/pages/PasswordResetPage.module.scss
@@ -1,5 +1,5 @@
 @use '../styles/utilities/mixins' as m;
-@use '../styles/base/variables' as v;
+@use '../styles/semantic/spacing' as sp;
 @use '../styles/semantic/typography' as t;
 @use '../styles/semantic/colors' as c;
 @use 'sass:map';
@@ -14,18 +14,18 @@
 }
 
 .form {
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
 }
 
 .panel {
   width: min(100%, 36rem);
-  padding: v.$spacing-lg;
-  border-radius: v.$border-radius;
+  padding: sp.$spacing-lg;
+  border-radius: sp.$border-radius;
   @include m.border(c.$color-border-default);
   background: c.$color-bg;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-md;
+  gap: sp.$spacing-md;
 }
 
 .title {

--- a/frontend/src/pages/PlayerPage/PlayerPage.module.scss
+++ b/frontend/src/pages/PlayerPage/PlayerPage.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 
 .page {
   @include m.page-layout();
@@ -8,6 +8,6 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   width: 100%;
 }

--- a/frontend/src/pages/RegisterPage/RegisterPage.module.scss
+++ b/frontend/src/pages/RegisterPage/RegisterPage.module.scss
@@ -1,5 +1,5 @@
 @use '../../styles/utilities/mixins' as m;
-@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/typography' as t;
 @use '../../styles/semantic/colors' as c;
 
@@ -10,25 +10,25 @@
   justify-content: flex-start;
   align-items: center;
   min-height: 100vh;
-  padding-top: v.$spacing-2xl;
+  padding-top: sp.$spacing-2xl;
 }
 
 .formFrame {
   width: min(100%, 32rem);
   max-width: 80vw;
   margin: 0 auto;
-  padding: v.$spacing-lg;
-  border-radius: v.$border-radius;
+  padding: sp.$spacing-lg;
+  border-radius: sp.$border-radius;
   background-color: c.$color-bg;
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.08);
 
   @include m.respond-to(sm) {
-    padding: v.$spacing-xl;
+    padding: sp.$spacing-xl;
   }
 }
 
 .title {
-  margin-bottom: v.$spacing-lg;
+  margin-bottom: sp.$spacing-lg;
   text-align: center;
   @include t.apply-text-style(t.$text-heading-2);
 }
@@ -36,7 +36,7 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-gap;
+  gap: sp.$spacing-gap;
   width: 100%;
   @include t.apply-text-style(t.$text-body);
 
@@ -53,7 +53,7 @@
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   @include t.apply-text-style(t.$text-body);
 
   a:hover {

--- a/frontend/src/pages/SuccessPage.module.scss
+++ b/frontend/src/pages/SuccessPage.module.scss
@@ -1,5 +1,5 @@
 @use '../styles/semantic/colors' as c;
-@use '../styles/base/variables' as v;
+@use '../styles/semantic/spacing' as sp;
 @use '../styles/utilities/mixins' as m;
 @use '../styles/tokens/colors' as tc;
 @use 'sass:map';
@@ -18,7 +18,7 @@
     map.get(tc.$primary-scale, 300) 100%
   );
   color: tc.$color-light;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   padding: 2.5rem 2rem;
   @include m.fade-in(0.4s);
 }
@@ -69,7 +69,7 @@
 .perkCard {
   background: c.$color-bg;
   border: 1px solid rgba(c.$color-border-primary, 0.2);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   padding: 1.1rem 1.25rem;
   display: flex;
   gap: 1rem;
@@ -116,7 +116,7 @@
   margin-top: 1.5rem;
   padding: 1rem 1.25rem;
   border: 1px solid rgba(c.$color-status-danger, 0.3);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: c.$color-error-bg;
   color: c.$color-text-error;
 }

--- a/frontend/src/styles/base/_variables.scss
+++ b/frontend/src/styles/base/_variables.scss
@@ -1,4 +1,9 @@
-
+// Layout & UI constants that aren't part of the tokens/ design-token
+// scale (spacing/color/typography — see semantic/_spacing.scss for that
+// pattern). Breakpoints drive respond-to(), z-index establishes the
+// stacking order across components, and durations/easing drive
+// transitions. They stay here, rather than in tokens/ or semantic/,
+// because nothing composes them the way the spacing scale is composed.
 
 $breakpoints: (
   sm: 576px,
@@ -8,25 +13,6 @@ $breakpoints: (
   xxl: 1440px
 );
 
-
-// Spacing
-$spacing-xs: 0.25rem;
-$spacing-sm: 0.5rem; // 8px
-$spacing-md: 1rem; // 16px
-$spacing-lg: 2rem;
-$spacing-xl: 4rem;
-$spacing-2xl: 6rem;
-$spacing-3xl: 8rem;
-
-$spacing-gap: $spacing-sm;
-
-$padding-vertical: $spacing-sm;
-$padding-horizontal: $spacing-md;
-
-$padding-sm: $spacing-xs $spacing-sm;
-$padding-base: $padding-vertical $padding-horizontal;
-$padding-lg: $spacing-md $spacing-lg;
-
 $z-index-base: 1;
 $z-index-dropdown: 10;
 $z-index-header: 50;
@@ -35,14 +21,7 @@ $z-index-toast: 200;
 $z-index-tooltip: 300;
 $z-index-overlay: 999;
 
-$border-radius: $spacing-sm;
-$button-padding: $spacing-xs $spacing-md;
-$button-radius: $spacing-md;
-$content-padding: $spacing-lg;
-
-
 // Animations
-
 $duration-fast: 150ms;
 $duration-base: 250ms;
 $duration-slow: 400ms;

--- a/frontend/src/styles/semantic/_spacing.scss
+++ b/frontend/src/styles/semantic/_spacing.scss
@@ -1,7 +1,44 @@
 @use '../tokens/spacing' as s;
 @use 'sass:map';
 
-// === Spacing ===
+// Composes the single spacing scale (tokens/_spacing.scss) into the
+// semantically-named values consumed across the app — following the same
+// tokens/ -> semantic/ pattern as colors and typography. This is now the
+// only home for spacing-derived values; base/_variables.scss holds only
+// breakpoints, z-index, and animation durations (none of which compose
+// from the spacing scale).
+//
+// $margin-*, $section-padding, $container-gap, and this file's previous,
+// separate $spacing-gap/$border-radius were dropped during consolidation:
+// they were defined but never referenced anywhere, and in $border-radius's
+// case duplicated a different value than the one actually in use app-wide.
+
+// === Flat scalars ===
+$spacing-xs: map.get(s.$spacing, xs);
+$spacing-sm: map.get(s.$spacing, sm); // 8px
+$spacing-md: map.get(s.$spacing, md); // 16px
+$spacing-lg: map.get(s.$spacing, lg);
+$spacing-xl: map.get(s.$spacing, xl);
+$spacing-2xl: map.get(s.$spacing, 2xl);
+$spacing-3xl: map.get(s.$spacing, 3xl);
+
+$spacing-gap: $spacing-sm;
+
+// === Padding shorthands ===
+$padding-vertical: $spacing-sm;
+$padding-horizontal: $spacing-md;
+
+$padding-sm: $spacing-xs $spacing-sm;
+$padding-base: $padding-vertical $padding-horizontal;
+$padding-lg: $spacing-md $spacing-lg;
+
+// === Component shortcuts ===
+$border-radius: $spacing-sm;
+$button-padding: $spacing-xs $spacing-md;
+$button-radius: $spacing-md;
+$content-padding: $spacing-lg;
+
+// === Gap / radius / shadow collections ===
 $gap: (
   xs: map.get(s.$spacing, xs),
   sm: map.get(s.$spacing, sm),
@@ -9,29 +46,14 @@ $gap: (
   lg: map.get(s.$spacing, lg),
 );
 
-$spacing-gap: map.get($gap, sm);
-
-// === Padding ===
 $padding-vertical-sm: map.get(s.$spacing, sm);
-$padding-vertical-md: map.get(s.$spacing, md);
 $padding-horizontal-sm: map.get(s.$spacing, md);
-$padding-horizontal-md: map.get(s.$spacing, lg);
 
 $spacing-padding: (
   base: $padding-vertical-sm $padding-horizontal-sm,
-  lg: $padding-vertical-md $padding-horizontal-md,
 );
 
-// === Margins ===
-$margin-xs: map.get(s.$spacing, xs);
-$margin-sm: map.get(s.$spacing, sm);
-$margin-md: map.get(s.$spacing, md);
-$margin-lg: map.get(s.$spacing, lg);
-
-// === Utility shortcuts ===
-$section-padding: map.get($spacing-padding, lg);
 $card-padding: map.get($spacing-padding, base);
-$container-gap: $spacing-gap;
 
 $radius: (
   sm: map.get(s.$spacing, xs),
@@ -44,5 +66,3 @@ $shadow: (
   md: 0 4px 8px rgba(0, 0, 0, 0.1),
   lg: 0 8px 16px rgba(0, 0, 0, 0.1)
 );
-
-$border-radius: map.get($radius, lg);

--- a/frontend/src/styles/tokens/_spacing.scss
+++ b/frontend/src/styles/tokens/_spacing.scss
@@ -1,12 +1,20 @@
 // tokens/_spacing.scss
+//
+// Single source of truth for the spacing scale. base/_variables.scss
+// derives its flat scalars ($spacing-xs etc.) from this map instead of
+// hardcoding values, and semantic/_spacing.scss composes it into
+// higher-level tokens (gap, padding, radius). Do not redefine the scale
+// anywhere else.
 
 $spacing: (
   xs: 0.25rem,
   sm: 0.5rem,
   md: 1rem,
-  md-lg: 1.5rem,
   lg: 2rem,
   xl: 4rem,
   2xl: 6rem,
   3xl: 8rem
 );
+// `md-lg: 1.5rem` previously existed here but had no consumer anywhere in
+// the codebase (checked both flat-scalar and map.get() access patterns) —
+// dropped rather than kept as a phantom step in the scale.

--- a/frontend/src/styles/utilities/_list-pages.scss
+++ b/frontend/src/styles/utilities/_list-pages.scss
@@ -1,25 +1,25 @@
-@use '../base/variables' as v;
+@use '../semantic/spacing' as sp;
 @use '../semantic/typography' as t;
 @use '../semantic/colors' as c;
 
 @mixin list-page-header {
   text-align: center;
-  margin-bottom: v.$spacing-lg;
+  margin-bottom: sp.$spacing-lg;
 
   h1 {
     @include t.apply-text-style(t.$text-heading-1);
-    margin-bottom: v.$spacing-md;
+    margin-bottom: sp.$spacing-md;
   }
 }
 
 @mixin list-page-add-form {
   display: flex;
-  gap: v.$spacing-sm;
+  gap: sp.$spacing-sm;
   align-items: flex-start;
   width: 100%;
   max-width: 900px;
-  margin: 0 auto v.$spacing-md;
-  padding-right: v.$spacing-sm;
+  margin: 0 auto sp.$spacing-md;
+  padding-right: sp.$spacing-sm;
 }
 
 @mixin list-page-add-input {
@@ -47,10 +47,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: v.$spacing-md;
-  padding: v.$padding-base;
+  gap: sp.$spacing-md;
+  padding: sp.$padding-base;
   border: 1px solid rgba(c.$color-border-primary, 0.2);
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   background: rgba(c.$color-bg, 0.4);
   transition: background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
   position: relative;
@@ -68,7 +68,7 @@
 @mixin list-page-details {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
   flex: 1;
 
   .name {
@@ -84,9 +84,9 @@
 }
 
 @mixin list-page-edit-input {
-  padding: v.$spacing-xs v.$spacing-sm;
+  padding: sp.$spacing-xs sp.$spacing-sm;
   border: 2px solid c.$color-border-primary;
-  border-radius: v.$border-radius;
+  border-radius: sp.$border-radius;
   font-size: 1em;
   font-family: inherit;
   transition: border-color 0.2s ease;
@@ -99,14 +99,14 @@
 
 @mixin list-page-actions {
   display: flex;
-  gap: v.$spacing-xs;
+  gap: sp.$spacing-xs;
   flex-wrap: wrap;
   justify-content: flex-end;
 }
 
 @mixin list-page-action-button-base {
-  padding: v.$spacing-xs v.$spacing-sm;
-  border-radius: v.$border-radius;
+  padding: sp.$spacing-xs sp.$spacing-sm;
+  border-radius: sp.$border-radius;
   cursor: pointer;
   font-size: 0.85em;
   transition: all 0.2s ease;
@@ -115,7 +115,7 @@
 
 @mixin list-page-empty-state {
   text-align: center;
-  padding: v.$padding-lg;
+  padding: sp.$padding-lg;
   color: rgba(0, 0, 0, 0.6);
 
   p {

--- a/frontend/src/styles/utilities/_mixins.scss
+++ b/frontend/src/styles/utilities/_mixins.scss
@@ -151,7 +151,7 @@
   align-items: center;
   width: 100%;
   margin: 0 auto;
-  padding: v.$padding-base;
+  padding: sp.$padding-base;
 
   > * {
     width: 100%;


### PR DESCRIPTION
## Summary

Closes #590. Stacked on #627 (issue #589) since this touches the same `base/_variables.scss`/`utilities/_mixins.scss` files that PR cleans up — this PR's diff is the incremental change on top of that one. Marked as draft until #627 merges; base will be retargeted to `development` at that point.

## The duplication (and what else the audit found)

Spacing was defined in three places, not two — `tokens/_spacing.scss` (map), `base/_variables.scss` (hardcoded flat scalars), and `semantic/_spacing.scss` (a second, independently-hardcoded set of derived collections built from the map). Auditing actual consumers turned up more ambiguity than the issue described:

- `semantic/_spacing.scss` had its own `$border-radius` (`1rem`) that silently disagreed with `base/_variables.scss`'s `$border-radius` (`0.5rem`, used ~93 times app-wide) — but the semantic one had zero consumers, so it was just a landmine.
- `$margin-xs/sm/md/lg`, `$section-padding`, `$container-gap`, and `semantic/_spacing.scss`'s own `$spacing-gap` were defined but never referenced anywhere (checked every flat-scalar and `map.get()` access pattern across the whole frontend).
- `tokens/_spacing.scss`'s `md-lg: 1.5rem` key had no consumer either.

## Design decision

The codebase already has an established `tokens/` (raw scale) → `semantic/` (composed, semantically-named values) pattern for colors and typography — neither of those has any presence in `base/_variables.scss`. Spacing now follows the same pattern instead of introducing a third shape:

- **`tokens/_spacing.scss`** — the single canonical map. Dropped the unused `md-lg` key with a comment explaining why.
- **`semantic/_spacing.scss`** — now the only home for every spacing-derived value: the flat scalars (`$spacing-xs`…`$spacing-3xl`), `$spacing-gap`, the `$padding-*` shorthands, `$border-radius`, `$button-padding`/`$button-radius`, `$content-padding`, plus the pre-existing `$gap`/`$radius`/`$shadow`/`$card-padding` collections. Dropped the dead exports listed above.
- **`base/_variables.scss`** — stripped to just `$breakpoints`, the z-index scale, and animation durations/easing: the constants that don't compose from the spacing scale, so they don't fit the tokens/semantic split. Documented why they live there in a header comment.

## Migration

Migrated all 51 dependent modules (scripted, mechanical rename — same variable names throughout, only the import target changed) to pull spacing values from `semantic/_spacing.scss`. The 9 modules that also need z-index or animation-duration values keep a second `@use` for `base/_variables.scss`. Two modules (`MaintenancePage`, `Form/Card`) had a dead, unused `base/_variables.scss` import that was removed outright.

## Test plan

- [x] `npm run build:production` succeeds
- [x] **Zero visual change**, verified the way the issue asked: built the full CSS output before and after, normalized to one declaration per line, sorted, and diffed — **byte-identical**, not eyeballed
- [x] `npm run lint` — no new errors (pre-existing unrelated errors in `ActivityRewardScreen.tsx` and `vite.ds.config.js` untouched by this change)
- [x] `npm run test` (vitest) — same 12 pre-existing failures as baseline (unrelated `LibraryPage` assertion + missing headless-shell browser binary in this sandbox), no new failures
- [ ] `npx playwright test` — could not run in this sandbox (no Docker daemon available to bring up the backend/DB Playwright's global-setup requires). Needs to run in CI before merge.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MogQdUUUXTYfgMhwq1ufwL

---
_Generated by [Claude Code](https://claude.ai/code/session_01MogQdUUUXTYfgMhwq1ufwL)_