### PR TITLE
Rename page-scoped feature flags to feature-scoped; admin dropdown excludes taken keys

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "f=$(jq -r '.tool_input.file_path'); case \"$f\" in *.py) cd /home/gaidheal/repos/progressrpg && .venv/bin/pre-commit run black --files \"$f\" ;; esac",
+            "command": "f=$(jq -r '.tool_input.file_path'); case \"$f\" in *.py) cd \"${CLAUDE_PROJECT_DIR:-.}\" && if [ -x .venv/bin/pre-commit ]; then .venv/bin/pre-commit run black --files \"$f\"; elif command -v pre-commit >/dev/null 2>&1; then pre-commit run black --files \"$f\"; fi ;; esac",
             "statusMessage": "Formatting Python..."
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,3 +163,5 @@ React SPA served separately (port 5173 in dev, built via Vite for prod).
 - `development` → `staging` via periodic PR (base `staging`, head `development`); deploys to staging via `render-staging.yaml` (services `web-staging`/`celery-staging`/`celery-beat-staging`, env group "Staging env")
 - `staging` → `main` via periodic PR (base `main`, head `staging`); `main` is the repo's default branch and deploys to production via `render.yaml` (services `web`/`celery`/`celery-beat`, env group "Prod env")
 - Repo: `progressrpg/ProgressRPG` (org `progressrpg`), region `frankfurt` for all Render services
+
+**Current exception (temporary):** for now, PR feature branches directly into `staging` instead of `development`, so changes can be tested on staging without waiting on a `development` → `staging` sync PR first. Revert to basing on `development` once told to.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,8 +164,4 @@ React SPA served separately (port 5173 in dev, built via Vite for prod).
 - `staging` → `main` via periodic PR (base `main`, head `staging`); `main` is the repo's default branch and deploys to production via `render.yaml` (services `web`/`celery`/`celery-beat`, env group "Prod env")
 - Repo: `progressrpg/ProgressRPG` (org `progressrpg`), region `frankfurt` for all Render services
 
-**Exception:** base a feature-branch PR on `staging` instead of `development` when either:
-- local dev tooling isn't available in the working environment (e.g. no Docker/Postgres/Redis access, so the change can't be run or tested locally), or
-- the change only manifests in a live/staging-like environment (e.g. deploy config, webhook integrations, anything that can't be meaningfully verified against `development` alone).
-
-Otherwise, base feature-branch PRs on `development` as usual.
+**Exception:** base a feature-branch PR on `staging` instead of `development` when the user says to — typically because their local dev tools are blocked (e.g. by Freedom) or the change can only be verified in a live/staging-like environment. Acknowledge the stated reason and use `staging` for that PR. This is a user call, not something to infer from the working environment (e.g. a Claude Code cloud/remote session lacking Docker is not by itself a reason to target `staging`). Otherwise, base feature-branch PRs on `development` as usual.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,4 +164,8 @@ React SPA served separately (port 5173 in dev, built via Vite for prod).
 - `staging` → `main` via periodic PR (base `main`, head `staging`); `main` is the repo's default branch and deploys to production via `render.yaml` (services `web`/`celery`/`celery-beat`, env group "Prod env")
 - Repo: `progressrpg/ProgressRPG` (org `progressrpg`), region `frankfurt` for all Render services
 
-**Current exception (temporary):** for now, PR feature branches directly into `staging` instead of `development`, so changes can be tested on staging without waiting on a `development` → `staging` sync PR first. Revert to basing on `development` once told to.
+**Exception:** base a feature-branch PR on `staging` instead of `development` when either:
+- local dev tooling isn't available in the working environment (e.g. no Docker/Postgres/Redis access, so the change can't be run or tested locally), or
+- the change only manifests in a live/staging-like environment (e.g. deploy config, webhook integrations, anything that can't be meaningfully verified against `development` alone).
+
+Otherwise, base feature-branch PRs on `development` as usual.

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -258,6 +258,7 @@ class RegistrationStatusResponseSerializer(serializers.Serializer):
     registration_open = serializers.BooleanField()
     registration_enabled = serializers.BooleanField()
     self_serve_registration = serializers.BooleanField()
+    waitlist_signup_provider = serializers.ChoiceField(choices=["mailchimp", "internal"])
     turnstile_site_key = serializers.CharField(allow_blank=True)
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -258,6 +258,7 @@ class RegistrationStatusResponseSerializer(serializers.Serializer):
     registration_open = serializers.BooleanField()
     registration_enabled = serializers.BooleanField()
     self_serve_registration = serializers.BooleanField()
+    turnstile_site_key = serializers.CharField(allow_blank=True)
 
 
 class WaitlistJoinRequestSerializer(serializers.Serializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -314,7 +314,12 @@ class CustomRegisterSerializer(RegisterSerializer):
         write_only=True, required=False, allow_blank=True
     )
     agree_to_terms = serializers.BooleanField(write_only=True, required=True)
-    turnstile_token = serializers.CharField(write_only=True, required=True)
+    # Blank is allowed so deployments without a Turnstile site key (local dev,
+    # tests) can still register; verification below rejects a blank token
+    # whenever a secret *is* configured.
+    turnstile_token = serializers.CharField(
+        write_only=True, required=True, allow_blank=True
+    )
     email = serializers.EmailField(required=True)
     timezone = serializers.CharField(write_only=True, required=False)
 

--- a/api/views.py
+++ b/api/views.py
@@ -85,6 +85,7 @@ from progression.serializers import PlayerActivitySerializer
 
 from users.models import Player, TutorialStep, Waitlist
 from users.serializers import PlayerSerializer, TutorialStepSerializer
+from users.services import waitlist_service
 from users.services.registration_services import verified_user_count
 from users.utils import send_email_to_users
 
@@ -177,6 +178,7 @@ class RegistrationStatusAPIView(APIView):
                 "registration_open": registration_open,
                 "registration_enabled": game_settings.registration_enabled,
                 "self_serve_registration": game_settings.self_serve_registration,
+                "waitlist_signup_provider": game_settings.waitlist_signup_provider,
                 # The site key is public, and serving it here keeps it out of
                 # the frontend build: rotating the key or enabling Turnstile
                 # needs only a backend env change, no rebuild.
@@ -201,9 +203,11 @@ class WaitlistJoinAPIView(APIView):
         ).exists()
         if not already_waiting:
             try:
-                Waitlist.objects.create(email=email, status=Waitlist.Status.WAITING)
+                entry = Waitlist.objects.create(email=email, status=Waitlist.Status.WAITING)
             except IntegrityError:
                 pass  # race with a concurrent signup — treat as already-waiting
+            else:
+                waitlist_service.send_signup_confirmation_email(entry)
 
         return Response(
             {"detail": "You're on the waitlist."}, status=status.HTTP_200_OK

--- a/api/views.py
+++ b/api/views.py
@@ -177,6 +177,10 @@ class RegistrationStatusAPIView(APIView):
                 "registration_open": registration_open,
                 "registration_enabled": game_settings.registration_enabled,
                 "self_serve_registration": game_settings.self_serve_registration,
+                # The site key is public, and serving it here keeps it out of
+                # the frontend build: rotating the key or enabling Turnstile
+                # needs only a backend env change, no rebuild.
+                "turnstile_site_key": settings.CF_TURNSTILE_SITE_KEY or "",
             }
         )
 

--- a/core/admin.py
+++ b/core/admin.py
@@ -22,6 +22,7 @@ class GameSettingsAdmin(admin.ModelAdmin):
         "registration_cap",
         "registration_enabled",
         "self_serve_registration",
+        "waitlist_signup_provider",
     )
     fieldsets = (
         ("Timer", {"fields": ("free_timer_limit_seconds",)}),
@@ -54,6 +55,7 @@ class GameSettingsAdmin(admin.ModelAdmin):
                     "registration_cap",
                     "registration_enabled",
                     "self_serve_registration",
+                    "waitlist_signup_provider",
                 )
             },
         ),

--- a/core/migrations/0012_gamesettings_waitlist_signup_provider.py
+++ b/core/migrations/0012_gamesettings_waitlist_signup_provider.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0011_merge_20260709_2330"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="gamesettings",
+            name="waitlist_signup_provider",
+            field=models.CharField(
+                choices=[("mailchimp", "Mailchimp"), ("internal", "Internal")],
+                default="mailchimp",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -97,6 +97,16 @@ class GameSettings(models.Model):
     self_serve_registration = models.BooleanField(default=False)
     waitlist_nudges_enabled_from = models.DateTimeField(null=True, blank=True)
 
+    class WaitlistSignupProvider(models.TextChoices):
+        MAILCHIMP = "mailchimp", "Mailchimp"
+        INTERNAL = "internal", "Internal"
+
+    waitlist_signup_provider = models.CharField(
+        max_length=20,
+        choices=WaitlistSignupProvider.choices,
+        default=WaitlistSignupProvider.MAILCHIMP,
+    )
+
     class Meta:
         verbose_name = "Game settings"
         verbose_name_plural = "Game settings"

--- a/economy/management/commands/economy_forecast.py
+++ b/economy/management/commands/economy_forecast.py
@@ -368,9 +368,14 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"  First bread produced on simulated day {first_bread_day}."
             )
-        self.stdout.write(
-            f"  Minimum bread baked in a single day: {format_quantity('bread', min_bread)}"
-        )
+        if min_bread is None:
+            self.stdout.write(
+                "  Minimum bread baked in a single day: n/a (no days simulated)"
+            )
+        else:
+            self.stdout.write(
+                f"  Minimum bread baked in a single day: {format_quantity('bread', min_bread)}"
+            )
         self.stdout.write(
             f"  Worst hunger value reached by any character: {worst_hunger:.1f}"
         )

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,7 +24,9 @@
     />
     <link rel="canonical" href="https://progressrpg.com/" />
     <title>Progress RPG | ADHD-Friendly Body Doubling Productivity Game</title>
-    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+    <!-- Explicit rendering: the widget is mounted by the React <Turnstile />
+         component, which can appear long after this script has loaded. -->
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/Form/Form.test.tsx
+++ b/frontend/src/components/Form/Form.test.tsx
@@ -57,6 +57,52 @@ describe("Form", () => {
     expect(screen.queryByText("This field is required")).not.toBeInTheDocument();
   });
 
+  it("validates required checkboxes against their checked state", async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <Form
+        title="Terms form"
+        onSubmit={(event) => event.preventDefault()}
+        fields={[
+          {
+            name: "agree_to_terms",
+            label: "I agree",
+            type: "checkbox",
+            checked: false,
+            onChange: vi.fn(),
+            required: true,
+          },
+        ]}
+      />
+    );
+
+    await user.click(screen.getByRole("checkbox"));
+    await user.tab();
+
+    expect(screen.getByText("This field is required")).toBeInTheDocument();
+
+    rerender(
+      <Form
+        title="Terms form"
+        onSubmit={(event) => event.preventDefault()}
+        fields={[
+          {
+            name: "agree_to_terms",
+            label: "I agree",
+            type: "checkbox",
+            checked: true,
+            onChange: vi.fn(),
+            required: true,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("checkbox")).toBeChecked();
+    expect(screen.queryByText("This field is required")).not.toBeInTheDocument();
+  });
+
   it("disables the submit button while submitting", () => {
     render(
       <Form

--- a/frontend/src/components/Form/Form.tsx
+++ b/frontend/src/components/Form/Form.tsx
@@ -10,6 +10,7 @@ interface FormField {
   label?: string;
   type?: string;
   value?: string;
+  checked?: boolean;
   onChange?: (value: string | boolean) => void;
   placeholder?: string;
   helpText?: string;
@@ -58,6 +59,11 @@ export default function Form({
 
     if (!touched[field.name]) return '';
 
+    // Checkboxes carry their state in `checked`, not `value`.
+    if (field.type === 'checkbox') {
+      return field.required && !field.checked ? 'This field is required' : '';
+    }
+
     if (field.required && !field.value) {
       return 'This field is required';
     }
@@ -93,6 +99,7 @@ export default function Form({
                 label={field.label || field.name}
                 type={field.type}
                 value={field.value}
+                checked={field.checked}
                 onChange={field.onChange}
                 placeholder={field.placeholder}
                 helpText={field.helpText}

--- a/frontend/src/components/Map/Map.test.tsx
+++ b/frontend/src/components/Map/Map.test.tsx
@@ -7,7 +7,7 @@ import { TooltipProvider } from '../Tooltip/Tooltip';
 
 function renderMap(props: ComponentProps<typeof PopulationCentreMap>) {
   return render(
-    <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+    <TooltipProvider>
       <PopulationCentreMap {...props} />
     </TooltipProvider>
   );
@@ -332,13 +332,13 @@ describe('PopulationCentreMap', () => {
     };
     const user = userEvent.setup();
     render(
-      <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <TooltipProvider>
         <PopulationCentreMap geojson={geojsonWithBuilding} />
       </TooltipProvider>
     );
 
     const building = document.querySelector('polygon[fill="#ddd"]') as SVGPolygonElement;
-    await user.hover(building);
+    await user.click(building);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('House');
@@ -368,13 +368,13 @@ describe('PopulationCentreMap', () => {
     };
     const user = userEvent.setup();
     render(
-      <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <TooltipProvider>
         <PopulationCentreMap geojson={geojsonWithBuilding} />
       </TooltipProvider>
     );
 
     const building = document.querySelector('polygon[fill="#ddd"]') as SVGPolygonElement;
-    await user.hover(building);
+    await user.click(building);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('Workers: 2');
@@ -401,13 +401,13 @@ describe('PopulationCentreMap', () => {
     };
     const user = userEvent.setup();
     render(
-      <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <TooltipProvider>
         <PopulationCentreMap geojson={geojsonWithHouse} />
       </TooltipProvider>
     );
 
     const house = document.querySelector('polygon[fill="#ddd"]') as SVGPolygonElement;
-    await user.hover(house);
+    await user.click(house);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('Residents: 3');
@@ -433,12 +433,12 @@ describe('PopulationCentreMap', () => {
     };
     const user = userEvent.setup();
     render(
-      <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <TooltipProvider>
         <PopulationCentreMap geojson={geojsonWithCharacter} />
       </TooltipProvider>
     );
 
-    await user.hover(document.querySelector('g') as SVGGElement);
+    await user.click(document.querySelector('g') as SVGGElement);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('Alice');
@@ -466,13 +466,13 @@ describe('PopulationCentreMap', () => {
     };
     const user = userEvent.setup();
     render(
-      <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <TooltipProvider>
         <PopulationCentreMap geojson={geojsonWithReadyField} />
       </TooltipProvider>
     );
 
     const field = document.querySelector('polygon[fill="#E4C158"]') as SVGPolygonElement;
-    await user.hover(field);
+    await user.click(field);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('Ready to harvest');

--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -564,10 +564,7 @@ export default function PopulationCentreMap({
   }, []);
 
   return (
-    // Local provider: map tooltips should appear immediately on hover
-    // (markers are small and easy to overshoot), independent of the app's
-    // default hover delay used elsewhere.
-    <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+    <TooltipProvider>
     <div className={styles.mapWrapper}>
       <svg
         ref={svgRef}

--- a/frontend/src/components/Tooltip/Tooltip.module.scss
+++ b/frontend/src/components/Tooltip/Tooltip.module.scss
@@ -2,6 +2,16 @@
 @use '../../styles/semantic/spacing' as sp;
 @use '../../styles/semantic/colors' as c;
 
+.trigger {
+  // Click/tap opens the tooltip now (see #568), so a long-press on a
+  // trigger must never fall through to the browser's native
+  // text-selection/callout gesture - only our own tap handling should run.
+  touch-action: manipulation;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 .content {
   z-index: v.$z-index-tooltip;
   // Read-only content, never something to click/hover on its own - but on

--- a/frontend/src/components/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.stories.tsx
@@ -5,10 +5,12 @@ import Button from '../Button/Button';
 
 /**
  * `Tooltip` wraps a single focusable trigger element and shows supplementary
- * content on hover/focus via Radix. It must be nested under a
+ * content on click/tap or focus via Radix — hover never opens it, on either
+ * desktop or mobile (see #568). Clicking/tapping the trigger again, clicking
+ * anywhere else, or pressing Escape closes it. It must be nested under a
  * `TooltipProvider` (mounted once near the app root). Use tooltips only for
  * supplementary context — essential information must remain available
- * without hovering or focusing.
+ * without clicking or focusing.
  */
 const meta: Meta<typeof Tooltip> = {
   title: 'Shared/Tooltip',
@@ -22,7 +24,7 @@ const meta: Meta<typeof Tooltip> = {
     ),
   ],
   args: {
-    content: 'Additional context shown on hover or focus',
+    content: 'Additional context shown on click/tap or focus',
     placement: 'top',
   },
 };
@@ -33,16 +35,16 @@ type Story = StoryObj<typeof Tooltip>;
 export const Default: Story = {
   render: (args) => (
     <Tooltip {...args}>
-      <Button>Hover or focus me</Button>
+      <Button>Click or focus me</Button>
     </Tooltip>
   ),
   play: async ({ canvas, userEvent, canvasElement }) => {
-    const trigger = canvas.getByRole('button', { name: 'Hover or focus me' });
+    const trigger = canvas.getByRole('button', { name: 'Click or focus me' });
     await userEvent.tab();
     await expect(trigger).toHaveFocus();
     // Tooltip content renders via a Radix Portal into document.body.
     const tooltip = await within(canvasElement.ownerDocument.body).findByRole('tooltip');
-    await expect(tooltip).toHaveTextContent('Additional context shown on hover or focus');
+    await expect(tooltip).toHaveTextContent('Additional context shown on click/tap or focus');
   },
 };
 

--- a/frontend/src/components/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.test.tsx
@@ -7,22 +7,49 @@ function renderTooltip() {
   render(
     <TooltipProvider delayDuration={0} skipDelayDuration={0}>
       <Tooltip content="Helpful context">
-        <button type="button">Hover me</button>
+        <button type="button">Trigger</button>
       </Tooltip>
+      <button type="button">Elsewhere</button>
     </TooltipProvider>
   );
 }
 
 describe('Tooltip', () => {
-  it('shows on hover and hides when the pointer leaves', async () => {
+  it('does not open on hover', async () => {
     const user = userEvent.setup();
 
     renderTooltip();
 
-    await user.hover(screen.getByRole('button', { name: 'Hover me' }));
+    await user.hover(screen.getByRole('button', { name: 'Trigger' }));
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('opens on click and closes when the trigger is clicked again', async () => {
+    const user = userEvent.setup();
+
+    renderTooltip();
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+    await user.click(trigger);
     expect(await screen.findByRole('tooltip')).toHaveTextContent('Helpful context');
 
-    await user.unhover(screen.getByRole('button', { name: 'Hover me' }));
+    await user.click(trigger);
+    await waitFor(() => {
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes when clicking outside the trigger, including unrelated elements', async () => {
+    const user = userEvent.setup();
+
+    renderTooltip();
+
+    await user.click(screen.getByRole('button', { name: 'Trigger' }));
+    expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Elsewhere' }));
 
     await waitFor(() => {
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
@@ -36,7 +63,7 @@ describe('Tooltip', () => {
 
     await user.tab();
 
-    const trigger = screen.getByRole('button', { name: 'Hover me' });
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
     const tooltip = await screen.findByRole('tooltip');
 
     expect(trigger).toHaveFocus();

--- a/frontend/src/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.tsx
@@ -44,6 +44,10 @@ export function TooltipProvider({
  * Use tooltips only for supplementary context. The trigger must remain a
  * focusable interactive element, and any essential information should stay
  * available without requiring hover or focus.
+ *
+ * Click/tap-to-toggle on both desktop and mobile (see #568): hover never
+ * opens the tooltip, and clicking/tapping the trigger again - or anywhere
+ * else - closes it.
  */
 export default function Tooltip({
   children,
@@ -55,27 +59,69 @@ export default function Tooltip({
   disabled = false,
 }: TooltipProps): React.ReactElement {
   const [open, setOpen] = React.useState(false);
+  // Tracks whether the trigger's current focus came from our own
+  // pointerdown handler below, so that handler and handleFocus don't both
+  // try to decide the open state for the same interaction.
+  const pointerDownRef = React.useRef(false);
 
   if (disabled || content === null || content === undefined || content === false) {
     return <>{children}</>;
   }
 
-  // Radix's hover logic explicitly ignores touch pointers, and a tap's own
-  // pointerdown/click still reach the trigger's built-in "close" handlers -
-  // so on mobile the tooltip flashes open and is immediately closed by the
-  // same tap that opened it. Toggling our own controlled state on touch
-  // pointerdown (and preventDefault-ing, which per the Pointer Events spec
-  // suppresses the compatibility click that would otherwise re-close it)
-  // makes a tap behave like a real toggle instead.
+  // Radix's Trigger opens on hover and unconditionally closes on click,
+  // which fights a click/tap-to-toggle model on both counts. We take the
+  // trigger's open/close decisions over entirely: hover is inert (handled
+  // below), and pointerdown is the sole place we ever *open* it - never
+  // close, because a pointerdown on an already-open trigger is also seen by
+  // the open tooltip's own dismissable layer as an "outside" press (the
+  // trigger isn't part of the portaled content), which closes it for us.
+  // Deciding to close here too would race that, since our own pointerdown
+  // handler runs in the bubble phase, after the layer's capture-phase
+  // dismissal has already fired.
   const handlePointerDown = (event: React.PointerEvent) => {
-    if (event.pointerType !== 'touch') return;
     event.preventDefault();
-    setOpen((prev) => !prev);
+    pointerDownRef.current = true;
+    document.addEventListener(
+      'pointerup',
+      () => {
+        pointerDownRef.current = false;
+      },
+      { once: true }
+    );
+    if (!open) setOpen(true);
+  };
+
+  // preventDefault() on pointerdown doesn't stop the resulting click event
+  // for mouse pointers (only for touch, where it suppresses the
+  // compatibility click outright) - so on desktop, Radix's own "click
+  // always closes" trigger handler would still fire right after the
+  // pointerdown above opens it. Taking the click event over too stops that.
+  const handleClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+  };
+
+  // Suppress Radix's hover-driven open/close entirely - hover is cursor
+  // affordance only now, never a way to open or close the tooltip.
+  const suppressHover = (event: React.PointerEvent) => {
+    event.preventDefault();
+  };
+
+  const handleFocus = (event: React.FocusEvent) => {
+    event.preventDefault();
+    if (!pointerDownRef.current) setOpen(true);
   };
 
   return (
     <TooltipPrimitive.Root open={open} onOpenChange={setOpen}>
-      <TooltipPrimitive.Trigger asChild onPointerDown={handlePointerDown}>
+      <TooltipPrimitive.Trigger
+        asChild
+        className={styles.trigger}
+        onPointerDown={handlePointerDown}
+        onClick={handleClick}
+        onPointerMove={suppressHover}
+        onPointerLeave={suppressHover}
+        onFocus={handleFocus}
+      >
         {children}
       </TooltipPrimitive.Trigger>
       <TooltipPrimitive.Portal>

--- a/frontend/src/components/Turnstile/Turnstile.test.tsx
+++ b/frontend/src/components/Turnstile/Turnstile.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+import Turnstile from './Turnstile';
+
+type Options = {
+  sitekey: string;
+  callback?: (token: string) => void;
+  'expired-callback'?: () => void;
+  'error-callback'?: () => void;
+};
+
+function installTurnstile() {
+  const rendered: { container: HTMLElement; options: Options; id: string }[] = [];
+  const remove = vi.fn();
+  let nextId = 0;
+  window.turnstile = {
+    render: (container: HTMLElement, options: Options) => {
+      const id = `widget-${nextId++}`;
+      rendered.push({ container, options, id });
+      return id;
+    },
+    remove,
+    reset: vi.fn(),
+  };
+  return { rendered, remove };
+}
+
+describe('Turnstile', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete window.turnstile;
+  });
+
+  it('renders the widget explicitly when the script is already loaded', () => {
+    const { rendered } = installTurnstile();
+
+    render(<Turnstile sitekey="test-key" onToken={vi.fn()} />);
+
+    expect(rendered).toHaveLength(1);
+    expect(rendered[0].options.sitekey).toBe('test-key');
+    expect(rendered[0].container).toBe(screen.getByTestId('turnstile'));
+  });
+
+  it('renders the widget once the async script becomes available', () => {
+    render(<Turnstile sitekey="test-key" onToken={vi.fn()} />);
+
+    // Script not loaded yet — nothing rendered, but the component keeps waiting.
+    const { rendered } = installTurnstile();
+    expect(rendered).toHaveLength(0);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(rendered).toHaveLength(1);
+  });
+
+  it('reports the token from the widget callback', () => {
+    const { rendered } = installTurnstile();
+    const onToken = vi.fn();
+
+    render(<Turnstile sitekey="test-key" onToken={onToken} />);
+    rendered[0].options.callback?.('tok-123');
+
+    expect(onToken).toHaveBeenCalledWith('tok-123');
+  });
+
+  it('clears the token when the widget expires or errors', () => {
+    const { rendered } = installTurnstile();
+    const onToken = vi.fn();
+
+    render(<Turnstile sitekey="test-key" onToken={onToken} />);
+    rendered[0].options.callback?.('tok-123');
+    rendered[0].options['expired-callback']?.();
+    expect(onToken).toHaveBeenLastCalledWith('');
+
+    rendered[0].options['error-callback']?.();
+    expect(onToken).toHaveBeenLastCalledWith('');
+  });
+
+  it('removes the widget on unmount', () => {
+    const { rendered, remove } = installTurnstile();
+
+    const { unmount } = render(<Turnstile sitekey="test-key" onToken={vi.fn()} />);
+    unmount();
+
+    expect(remove).toHaveBeenCalledWith(rendered[0].id);
+  });
+
+  it('stops polling after the timeout', () => {
+    render(<Turnstile sitekey="test-key" onToken={vi.fn()} />);
+
+    act(() => {
+      vi.advanceTimersByTime(20000);
+    });
+
+    const { rendered } = installTurnstile();
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(rendered).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/Turnstile/Turnstile.tsx
+++ b/frontend/src/components/Turnstile/Turnstile.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useRef } from 'react';
+
+interface TurnstileRenderOptions {
+  sitekey: string;
+  callback?: (token: string) => void;
+  'expired-callback'?: () => void;
+  'error-callback'?: () => void;
+  'timeout-callback'?: () => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        container: HTMLElement,
+        options: TurnstileRenderOptions
+      ) => string | undefined;
+      remove: (widgetId: string) => void;
+      reset: (widgetId?: string) => void;
+    };
+  }
+}
+
+interface TurnstileProps {
+  sitekey: string;
+  /** Called with the current token, or '' when it expires or errors. */
+  onToken: (token: string) => void;
+  className?: string;
+}
+
+// The Cloudflare script is loaded async from index.html, so it may not be
+// available yet when this component mounts. Poll for it rather than relying on
+// implicit rendering: implicit rendering only scans the DOM once, when the
+// script loads, which never matches a widget mounted later by SPA navigation.
+const POLL_INTERVAL_MS = 100;
+const POLL_TIMEOUT_MS = 15000;
+
+export default function Turnstile({
+  sitekey,
+  onToken,
+  className,
+}: TurnstileProps): React.ReactElement {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Keep the latest callback in a ref so re-renders don't re-render the widget.
+  const onTokenRef = useRef(onToken);
+  useEffect(() => {
+    onTokenRef.current = onToken;
+  }, [onToken]);
+
+  useEffect(() => {
+    let widgetId: string | undefined;
+    let pollTimer: ReturnType<typeof setInterval> | undefined;
+    let cancelled = false;
+    const startedAt = Date.now();
+
+    const renderWidget = () => {
+      const container = containerRef.current;
+      if (cancelled || !container || !window.turnstile) return false;
+
+      widgetId = window.turnstile.render(container, {
+        sitekey,
+        callback: (token: string) => onTokenRef.current(token),
+        'expired-callback': () => onTokenRef.current(''),
+        'error-callback': () => onTokenRef.current(''),
+        'timeout-callback': () => onTokenRef.current(''),
+      });
+      return true;
+    };
+
+    if (!renderWidget()) {
+      pollTimer = setInterval(() => {
+        if (renderWidget() || Date.now() - startedAt > POLL_TIMEOUT_MS) {
+          if (pollTimer) clearInterval(pollTimer);
+        }
+      }, POLL_INTERVAL_MS);
+    }
+
+    return () => {
+      cancelled = true;
+      if (pollTimer) clearInterval(pollTimer);
+      if (widgetId && window.turnstile) {
+        window.turnstile.remove(widgetId);
+      }
+      onTokenRef.current('');
+    };
+  }, [sitekey]);
+
+  return <div ref={containerRef} className={className} data-testid="turnstile" />;
+}

--- a/frontend/src/components/WaitlistForm/WaitlistForm.tsx
+++ b/frontend/src/components/WaitlistForm/WaitlistForm.tsx
@@ -3,7 +3,7 @@ import Form from '../Form/Form';
 import useWaitlistJoin from '../../hooks/useWaitlistJoin';
 import styles from './WaitlistForm.module.scss';
 
-export default function WaitlistForm() {
+export default function WaitlistForm({ title = 'Join the Waitlist' }: { title?: string }) {
   const [email, setEmail] = useState('');
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -34,7 +34,7 @@ export default function WaitlistForm() {
   return (
     <>
       <Form
-        title="Join the Waitlist"
+        title={title}
         fields={[
           {
             name: 'email',

--- a/frontend/src/featureFlags.ts
+++ b/frontend/src/featureFlags.ts
@@ -7,9 +7,9 @@ const featureFlags: Record<FeatureFlagKey, FeatureFlagValue> = {
   // Empty array = disabled for everyone.
   activityList: ['all'],
   tasksFeature: ['testers'],
-  categoriesPage: [],
-  skillsPage: [],
-  projectsPage: [],
+  categoriesFeature: [],
+  skillsFeature: [],
+  projectsFeature: [],
   toastsFeature: [],
   announcements: ['testers'],
   onlinePlayerCount: ['testers'],

--- a/frontend/src/pages/Home/Home.test.tsx
+++ b/frontend/src/pages/Home/Home.test.tsx
@@ -10,6 +10,8 @@ const mockNavigate = vi.fn();
 const mockUseAuth = vi.fn();
 const mockTrackEvent = vi.fn();
 const mockRequestWaitlistSignup = vi.fn();
+const mockJoinWaitlist = vi.fn();
+const mockUseRegistrationStatus = vi.fn();
 
 vi.mock('../../context/AuthContext', () => ({
   useAuth: () => mockUseAuth(),
@@ -23,6 +25,16 @@ vi.mock('../../hooks/useWaitlistSignup', () => ({
   default: () => ({
     requestWaitlistSignup: (...args) => mockRequestWaitlistSignup(...args),
   }),
+}));
+
+vi.mock('../../hooks/useWaitlistJoin', () => ({
+  default: () => ({
+    joinWaitlist: (...args) => mockJoinWaitlist(...args),
+  }),
+}));
+
+vi.mock('../../hooks/useRegistrationStatus', () => ({
+  useRegistrationStatus: () => mockUseRegistrationStatus(),
 }));
 
 vi.mock('react-router-dom', async () => {
@@ -56,6 +68,12 @@ describe('Home', () => {
     mockUseAuth.mockReset();
     mockTrackEvent.mockReset();
     mockRequestWaitlistSignup.mockReset();
+    mockJoinWaitlist.mockReset();
+    mockUseRegistrationStatus.mockReset();
+    mockUseRegistrationStatus.mockReturnValue({
+      data: { waitlist_signup_provider: 'mailchimp' },
+      isLoading: false,
+    });
   });
 
   it('renders the logged-out landing page', () => {
@@ -166,6 +184,25 @@ describe('Home', () => {
       form_name: 'mailchimp_waitlist',
       page: 'home',
     });
+  });
+
+  it('renders the internal waitlist form instead of the Mailchimp form when configured', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+    mockUseRegistrationStatus.mockReturnValue({
+      data: { waitlist_signup_provider: 'internal' },
+      isLoading: false,
+    });
+    const user = userEvent.setup();
+    mockJoinWaitlist.mockResolvedValue({ success: true, message: "You're on the waitlist." });
+
+    renderHome();
+
+    expect(screen.queryByLabelText('Email address')).not.toBeInTheDocument();
+    await user.type(screen.getByLabelText(/^email:/i), 'newperson@example.com');
+    await user.click(screen.getByRole('button', { name: 'Join Waitlist' }));
+
+    expect(mockJoinWaitlist).toHaveBeenCalledWith('newperson@example.com');
+    expect(await screen.findByText("You're on the waitlist.")).toBeInTheDocument();
   });
 
   it('redirects authenticated users to the timer', async () => {

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import BackToTopButton from '../../components/BackToTopButton/BackToTopButton';
 import Button from '../../components/Button/Button';
 import Seo from '../../components/Seo/Seo';
+import WaitlistForm from '../../components/WaitlistForm/WaitlistForm';
+import { useRegistrationStatus } from '../../hooks/useRegistrationStatus';
 import styles from './Home.module.scss';
 import { useHomePage, useMailchimpSignupForm } from './useHomePage';
 const HOME_URL = 'https://progressrpg.com/';
@@ -131,6 +133,8 @@ const features = [
 
 export default function Home(): React.ReactElement | null {
   const { shouldRender } = useHomePage();
+  const { data: registrationStatus } = useRegistrationStatus();
+  const useInternalWaitlist = registrationStatus?.waitlist_signup_provider === 'internal';
 
   if (!shouldRender) {
     return null;
@@ -180,7 +184,7 @@ export default function Home(): React.ReactElement | null {
               Sign up for the waiting list and newsletter for updates on early
               access, new features, and the next steps for Progress RPG.
             </p>
-            <MailchimpSignupForm />
+            {useInternalWaitlist ? <WaitlistForm title="" /> : <MailchimpSignupForm />}
             <p className={styles.heroSignupNote}>
               Already have access? <Link to="/login">Log in</Link>
             </p>

--- a/frontend/src/pages/LibraryPage/LibraryPage.tsx
+++ b/frontend/src/pages/LibraryPage/LibraryPage.tsx
@@ -10,7 +10,7 @@ import styles from "./LibraryPage.module.scss";
 
 export default function LibraryPage(): React.ReactElement {
   const hasTasksFeature = useFeatureFlag("tasksFeature");
-  const hasSkillsFeature = useFeatureFlag("skillsPage");
+  const hasSkillsFeature = useFeatureFlag("skillsFeature");
 
   return (
     <div className={styles.page}>

--- a/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
@@ -1,19 +1,53 @@
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import RegisterPage from "./RegisterPage";
 
 const mockUseRegistrationStatus = vi.fn();
+const mockRegister = vi.fn();
 
 vi.mock("../../hooks/useRegistrationStatus", () => ({
   useRegistrationStatus: () => mockUseRegistrationStatus(),
 }));
 
 vi.mock("../../hooks/useRegister", () => ({
-  default: () => ({ register: vi.fn(), characterAvailable: true }),
+  default: () => ({ register: mockRegister, characterAvailable: true }),
 }));
+
+type TurnstileOptions = { sitekey: string; callback?: (token: string) => void };
+const turnstileWidgets: { options: TurnstileOptions }[] = [];
+
+function installTurnstile() {
+  window.turnstile = {
+    render: (_container: HTMLElement, options: TurnstileOptions) => {
+      turnstileWidgets.push({ options });
+      return `widget-${turnstileWidgets.length}`;
+    },
+    remove: vi.fn(),
+    reset: vi.fn(),
+  };
+}
+
+function openRegistration() {
+  mockUseRegistrationStatus.mockReturnValue({
+    data: {
+      registration_open: true,
+      registration_enabled: true,
+      self_serve_registration: true,
+    },
+    isLoading: false,
+  });
+}
+
+async function fillForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/^email/i), "new@example.com");
+  await user.type(screen.getByLabelText(/^password/i), "sup3rs3cret!");
+  await user.type(screen.getByLabelText(/confirm password/i), "sup3rs3cret!");
+  await user.click(screen.getByRole("checkbox"));
+}
 
 function renderRegisterPage() {
   return render(
@@ -24,6 +58,17 @@ function renderRegisterPage() {
 }
 
 describe("RegisterPage", () => {
+  beforeEach(() => {
+    turnstileWidgets.length = 0;
+    mockRegister.mockReset();
+    mockRegister.mockResolvedValue({ success: true, confirmationRequired: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete window.turnstile;
+  });
+
   it("renders the kill-switch fallback when registration_enabled is false", () => {
     mockUseRegistrationStatus.mockReturnValue({
       data: {
@@ -109,5 +154,82 @@ describe("RegisterPage", () => {
     renderRegisterPage();
 
     expect(screen.getByLabelText(/invite code \(optional\)/i)).not.toBeRequired();
+  });
+
+  it("renders the Turnstile widget when the form mounts after the script has loaded", () => {
+    // Reproduces the SPA bug: the form only mounts once the registration-status
+    // query resolves, long after Cloudflare's implicit DOM scan has run.
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
+    installTurnstile();
+    openRegistration();
+
+    renderRegisterPage();
+
+    expect(turnstileWidgets).toHaveLength(1);
+    expect(turnstileWidgets[0].options.sitekey).toBe("site-key-123");
+  });
+
+  it("blocks submission until the security check produces a token", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
+    installTurnstile();
+    openRegistration();
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+    await fillForm(user);
+    await user.click(screen.getByRole("button", { name: "Create Account" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /complete the security check/i
+    );
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it("submits with the token once the security check completes", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
+    installTurnstile();
+    openRegistration();
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+    await fillForm(user);
+    act(() => turnstileWidgets[0].options.callback?.("tok-abc"));
+
+    await user.click(screen.getByRole("button", { name: "Create Account" }));
+
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    expect(mockRegister.mock.calls[0][5]).toBe("tok-abc");
+  });
+
+  it("does not gate submission on a token when no site key is configured", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
+    openRegistration();
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+    expect(screen.queryByTestId("turnstile")).not.toBeInTheDocument();
+
+    await fillForm(user);
+    await user.click(screen.getByRole("button", { name: "Create Account" }));
+
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+  });
+
+  it("requires the terms checkbox before submitting", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
+    installTurnstile();
+    openRegistration();
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+    await user.type(screen.getByLabelText(/^email/i), "new@example.com");
+    await user.type(screen.getByLabelText(/^password/i), "sup3rs3cret!");
+    await user.type(screen.getByLabelText(/confirm password/i), "sup3rs3cret!");
+    act(() => turnstileWidgets[0].options.callback?.("tok-abc"));
+
+    await user.click(screen.getByRole("button", { name: "Create Account" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/agree to the Terms/i);
+    expect(mockRegister).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
@@ -31,12 +31,13 @@ function installTurnstile() {
   };
 }
 
-function openRegistration() {
+function openRegistration(turnstileSiteKey = "site-key-123") {
   mockUseRegistrationStatus.mockReturnValue({
     data: {
       registration_open: true,
       registration_enabled: true,
       self_serve_registration: true,
+      turnstile_site_key: turnstileSiteKey,
     },
     isLoading: false,
   });
@@ -159,7 +160,6 @@ describe("RegisterPage", () => {
   it("renders the Turnstile widget when the form mounts after the script has loaded", () => {
     // Reproduces the SPA bug: the form only mounts once the registration-status
     // query resolves, long after Cloudflare's implicit DOM scan has run.
-    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
     installTurnstile();
     openRegistration();
 
@@ -170,7 +170,6 @@ describe("RegisterPage", () => {
   });
 
   it("blocks submission until the security check produces a token", async () => {
-    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
     installTurnstile();
     openRegistration();
     const user = userEvent.setup();
@@ -186,7 +185,6 @@ describe("RegisterPage", () => {
   });
 
   it("submits with the token once the security check completes", async () => {
-    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
     installTurnstile();
     openRegistration();
     const user = userEvent.setup();
@@ -203,7 +201,7 @@ describe("RegisterPage", () => {
 
   it("does not gate submission on a token when no site key is configured", async () => {
     vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "");
-    openRegistration();
+    openRegistration("");
     const user = userEvent.setup();
 
     renderRegisterPage();
@@ -215,8 +213,18 @@ describe("RegisterPage", () => {
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
   });
 
+  it("falls back to the build-time site key when the API returns none", () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "env-key-456");
+    installTurnstile();
+    openRegistration("");
+
+    renderRegisterPage();
+
+    expect(turnstileWidgets).toHaveLength(1);
+    expect(turnstileWidgets[0].options.sitekey).toBe("env-key-456");
+  });
+
   it("requires the terms checkbox before submitting", async () => {
-    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key-123");
     installTurnstile();
     openRegistration();
     const user = userEvent.setup();

--- a/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
@@ -112,12 +112,12 @@ describe("RegisterPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the registration form when registration is enabled and cap not reached", () => {
+  it("renders the registration form when registration is enabled, self-serve is on, and cap not reached", () => {
     mockUseRegistrationStatus.mockReturnValue({
       data: {
         registration_open: true,
         registration_enabled: true,
-        self_serve_registration: false,
+        self_serve_registration: true,
       },
       isLoading: false,
     });
@@ -127,7 +127,7 @@ describe("RegisterPage", () => {
     expect(screen.getByRole("button", { name: "Create Account" })).toBeInTheDocument();
   });
 
-  it("requires an invite code when self-serve registration is off", () => {
+  it("renders the waitlist form (not the register form) when self-serve registration is off", () => {
     mockUseRegistrationStatus.mockReturnValue({
       data: {
         registration_open: true,
@@ -139,7 +139,32 @@ describe("RegisterPage", () => {
 
     renderRegisterPage();
 
-    expect(screen.getByLabelText(/invite code/i)).toBeRequired();
+    expect(
+      screen.getByRole("heading", { name: "Registration is by invite only" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create Account" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Join Waitlist" })).toBeInTheDocument();
+  });
+
+  it("still renders the registration form for an invited user even when self-serve registration is off", () => {
+    mockUseRegistrationStatus.mockReturnValue({
+      data: {
+        registration_open: true,
+        registration_enabled: true,
+        self_serve_registration: false,
+      },
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/waitlist/redeem/some-invite-token"]}>
+        <Routes>
+          <Route path="/waitlist/redeem/:token" element={<RegisterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("button", { name: "Create Account" })).toBeInTheDocument();
   });
 
   it("makes the invite code optional when self-serve registration is on", () => {

--- a/frontend/src/pages/RegisterPage/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.tsx
@@ -230,17 +230,21 @@ export default function RegisterPage(): React.ReactElement {
   }
 
   // Invited users always get the registration form, even if the cap has
-  // since been reached again — their invite is proof of a slot at invite time.
-  if (!inviteToken && data && !data.registration_open) {
+  // since been reached again, or self-serve is off — their invite is proof
+  // of a slot at invite time.
+  if (!inviteToken && data && (!data.registration_open || !data.self_serve_registration)) {
+    const title = !data.registration_open
+      ? 'Registration is temporarily full'
+      : 'Registration is by invite only';
+    const body = !data.registration_open
+      ? "We've reached our current capacity for new players. Join the waitlist and we'll be in touch."
+      : "We're inviting new players from the waitlist. Join the waitlist and we'll be in touch.";
     return (
       <div className={styles.page}>
         <div className={styles.formFrame}>
-          <h1 className={styles.title}>Registration is temporarily full</h1>
+          <h1 className={styles.title}>{title}</h1>
           <div className={styles.content}>
-            <p>
-              We&apos;ve reached our current capacity for new players. Join the waitlist and
-              we&apos;ll be in touch.
-            </p>
+            <p>{body}</p>
             <WaitlistForm />
             <p className={styles.footer}>
               Already have an account? <a href="/login">Log in here</a>.

--- a/frontend/src/pages/RegisterPage/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.tsx
@@ -8,12 +8,21 @@ import useRegister from '../../hooks/useRegister';
 import { useRegistrationStatus } from '../../hooks/useRegistrationStatus';
 import styles from './RegisterPage.module.scss';
 
+// The site key comes from the backend (see /registration_status/) so rotating
+// it or turning Turnstile on doesn't need a frontend rebuild. The build-time
+// env var stays supported as a local override.
+function resolveTurnstileSiteKey(apiSiteKey?: string): string | undefined {
+  return apiSiteKey || (import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined) || undefined;
+}
+
 function RegistrationForm({
   inviteToken,
   selfServe,
+  turnstileSiteKey,
 }: {
   inviteToken?: string;
   selfServe?: boolean;
+  turnstileSiteKey?: string;
 }): React.ReactElement {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -27,7 +36,6 @@ function RegistrationForm({
   const [agreeToTerms, setAgreeToTerms] = useState(false);
   const [formState, setFormState] = useState<'default' | 'submitted'>('default');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
 
   const handleTurnstileToken = useCallback((token: string) => {
     setTurnstileToken(token);
@@ -250,6 +258,7 @@ export default function RegisterPage(): React.ReactElement {
           key={location.key}
           inviteToken={inviteToken}
           selfServe={data?.self_serve_registration}
+          turnstileSiteKey={resolveTurnstileSiteKey(data?.turnstile_site_key)}
         />
       </div>
     </div>

--- a/frontend/src/pages/RegisterPage/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.tsx
@@ -1,19 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import Form from '../../components/Form/Form';
 import Input from '../../components/Input/Input';
+import Turnstile from '../../components/Turnstile/Turnstile';
 import WaitlistForm from '../../components/WaitlistForm/WaitlistForm';
 import useRegister from '../../hooks/useRegister';
 import { useRegistrationStatus } from '../../hooks/useRegistrationStatus';
 import styles from './RegisterPage.module.scss';
-
-declare global {
-  interface Window {
-    __turnstileCallback?: (token: string) => void;
-  }
-}
-
-const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
 
 function RegistrationForm({
   inviteToken,
@@ -34,13 +27,10 @@ function RegistrationForm({
   const [agreeToTerms, setAgreeToTerms] = useState(false);
   const [formState, setFormState] = useState<'default' | 'submitted'>('default');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
 
-  useEffect(() => {
-    // Expose a global callback for the Turnstile widget to call
-    window.__turnstileCallback = (token: string) => setTurnstileToken(token);
-    return () => {
-      delete window.__turnstileCallback;
-    };
+  const handleTurnstileToken = useCallback((token: string) => {
+    setTurnstileToken(token);
   }, []);
 
   const handleRegister = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -54,7 +44,14 @@ function RegistrationForm({
       return;
     }
 
-    if (!turnstileToken) {
+    if (!agreeToTerms) {
+      setError('Please agree to the Terms of Service and Privacy Policy.');
+      return;
+    }
+
+    // Without a site key there is no widget to complete, so don't gate on a
+    // token the user has no way of producing (the backend still verifies).
+    if (turnstileSiteKey && !turnstileToken) {
       setError('Please complete the security check.');
       return;
     }
@@ -164,6 +161,7 @@ function RegistrationForm({
             checked={agreeToTerms}
             onChange={(e) => setAgreeToTerms(e.target.checked)}
             required
+            aria-invalid={!!error && !agreeToTerms}
           />
           <label htmlFor="agree_to_terms">
             I agree to the{' '}
@@ -177,11 +175,9 @@ function RegistrationForm({
             .
           </label>
         </div>
-        <div
-          className="cf-turnstile"
-          data-sitekey={TURNSTILE_SITE_KEY}
-          data-callback="__turnstileCallback"
-        />
+        {turnstileSiteKey && (
+          <Turnstile sitekey={turnstileSiteKey} onToken={handleTurnstileToken} />
+        )}
       </Form>
       {error && (
         <p className={styles.error} role="alert">

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -46,6 +46,8 @@ export interface RegistrationStatus {
   registration_open: boolean;
   registration_enabled: boolean;
   self_serve_registration: boolean;
+  /** Which waitlist signup flow the "join the waitlist" forms should use. */
+  waitlist_signup_provider: 'mailchimp' | 'internal';
   /** Public Cloudflare Turnstile site key; empty when Turnstile is unconfigured. */
   turnstile_site_key?: string;
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -46,6 +46,8 @@ export interface RegistrationStatus {
   registration_open: boolean;
   registration_enabled: boolean;
   self_serve_registration: boolean;
+  /** Public Cloudflare Turnstile site key; empty when Turnstile is unconfigured. */
+  turnstile_site_key?: string;
 }
 
 /** Game settings returned in fetch_info and /game_settings/ */

--- a/frontend/src/types/enums.ts
+++ b/frontend/src/types/enums.ts
@@ -16,9 +16,9 @@ export type FeatureFlagValue = AccessGroup[];
 export type FeatureFlagKey =
   | "activityList"
   | "tasksFeature"
-  | "categoriesPage"
-  | "skillsPage"
-  | "projectsPage"
+  | "categoriesFeature"
+  | "skillsFeature"
+  | "projectsFeature"
   | "toastsFeature"
   | "announcements"
   | "onlinePlayerCount"

--- a/frontend/tests/utils/authenticatedPage.ts
+++ b/frontend/tests/utils/authenticatedPage.ts
@@ -97,9 +97,9 @@ function withStableAppConfig(payload: unknown, opts: { unifiedHomepage?: boolean
     feature_flags: {
       ...rawFeatureFlags,
       tasksFeature: ['all'],
-      projectsPage: ['all'],
-      categoriesPage: ['all'],
-      skillsPage: ['all'],
+      projectsFeature: ['all'],
+      categoriesFeature: ['all'],
+      skillsFeature: ['all'],
       activityList: ['all'],
       unified_homepage: opts.unifiedHomepage ? ['all'] : [],
     },

--- a/server_management/admin.py
+++ b/server_management/admin.py
@@ -24,17 +24,16 @@ _ACCESS_GROUP_CHOICES = [
 ]
 
 
-def _load_flag_key_choices():
+def _load_flag_key_choices(exclude=()):
     try:
         text = _FEATURE_FLAGS_TS.read_text()
         keys = _FLAG_KEY_RE.findall(text)
-        return [(k, k) for k in keys]
     except FileNotFoundError:
         return []
+    return [(k, k) for k in keys if k not in exclude]
 
 
 class FeatureFlagForm(forms.ModelForm):
-    key = forms.ChoiceField(choices=_load_flag_key_choices)
     access_groups = forms.MultipleChoiceField(
         choices=_ACCESS_GROUP_CHOICES,
         widget=forms.CheckboxSelectMultiple,
@@ -44,6 +43,20 @@ class FeatureFlagForm(forms.ModelForm):
     class Meta:
         model = FeatureFlag
         fields = "__all__"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Exclude keys already assigned to another FeatureFlag row, so the
+        # dropdown only offers keys that don't have one yet. When editing an
+        # existing row, its own key stays selectable.
+        already_used = set(
+            FeatureFlag.objects.exclude(pk=self.instance.pk).values_list(
+                "key", flat=True
+            )
+        )
+        self.fields["key"] = forms.ChoiceField(
+            choices=_load_flag_key_choices(exclude=already_used)
+        )
 
 
 logger = logging.getLogger("general")

--- a/server_management/tests.py
+++ b/server_management/tests.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from server_management.admin import FeatureFlagForm
+from server_management.models import FeatureFlag
+
+_FAKE_FEATURE_FLAGS_TS = """
+const featureFlags = {
+  activityList: ['all'],
+  tasksFeature: ['testers'],
+  categoriesFeature: [],
+  skillsFeature: [],
+  projectsFeature: [],
+};
+"""
+
+
+@patch("server_management.admin._FEATURE_FLAGS_TS")
+class FeatureFlagFormKeyChoicesTests(TestCase):
+    def test_excludes_keys_already_created(self, mock_path):
+        mock_path.read_text.return_value = _FAKE_FEATURE_FLAGS_TS
+        FeatureFlag.objects.create(key="tasksFeature", access_groups=["testers"])
+
+        form = FeatureFlagForm()
+
+        choice_keys = [key for key, _ in form.fields["key"].choices]
+        self.assertNotIn("tasksFeature", choice_keys)
+        self.assertIn("activityList", choice_keys)
+        self.assertIn("categoriesFeature", choice_keys)
+
+    def test_editing_existing_flag_keeps_its_own_key_selectable(self, mock_path):
+        mock_path.read_text.return_value = _FAKE_FEATURE_FLAGS_TS
+        flag = FeatureFlag.objects.create(key="tasksFeature", access_groups=["testers"])
+        FeatureFlag.objects.create(key="activityList", access_groups=["all"])
+
+        form = FeatureFlagForm(instance=flag)
+
+        choice_keys = [key for key, _ in form.fields["key"].choices]
+        self.assertIn("tasksFeature", choice_keys)
+        self.assertNotIn("activityList", choice_keys)

--- a/templates/emails/waitlist_signup_confirmation.html
+++ b/templates/emails/waitlist_signup_confirmation.html
@@ -1,0 +1,48 @@
+<!-- templates/emails/waitlist_signup_confirmation.html -->
+<html>
+<head>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            color: #333;
+            padding: 20px;
+        }
+        .email-container {
+            background-color: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        }
+        .email-header {
+            text-align: center;
+            font-size: 24px;
+            color: #333;
+        }
+        .email-content {
+            margin-top: 20px;
+            font-size: 16px;
+        }
+        .email-footer {
+            margin-top: 40px;
+            font-size: 14px;
+            text-align: center;
+            color: #888;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="email-header">
+            You're on the Progress RPG waitlist!
+        </div>
+        <div class="email-content">
+            <p>Hello,</p>
+            <p>Thanks for signing up! You're on the Progress RPG waitlist, and we'll email you as soon as a spot opens up for you to register.</p>
+            <p>Best wishes, <br/> Duncan (Founder, Progress RPG)</p>
+        </div>
+        <div class="email-footer">
+            <p>&copy; {{ current_year }} Progress RPG. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/emails/waitlist_signup_confirmation.txt
+++ b/templates/emails/waitlist_signup_confirmation.txt
@@ -1,0 +1,10 @@
+You're on the Progress RPG waitlist
+
+Hello,
+
+Thanks for signing up! You're on the Progress RPG waitlist, and we'll email you as soon as a spot opens up for you to register.
+
+Best wishes,
+Duncan (Founder, Progress RPG)
+
+© {{ current_year }} Progress RPG. All rights reserved.

--- a/users/admin.py
+++ b/users/admin.py
@@ -15,6 +15,7 @@ from .models import (
     Waitlist,
 )
 from .services import waitlist_service
+from .services.registration_services import ensure_player_setup_for_user
 from character.models import PlayerCharacterLink, Character
 from core.models import GameSettings
 from payments.models import UserSubscription
@@ -245,6 +246,11 @@ class CustomUserAdmin(UserAdmin):
             # path as everyone else, keeping the registration cap accurate.
             obj.is_confirmed = True
         super().save_model(request, obj, form, change)
+        if not change:
+            # UserAdmin.save_model() just does obj.save() - it doesn't go
+            # through CustomUserManager.create_user(), so player setup
+            # (Player + ActivityTimer) has to be triggered explicitly here.
+            ensure_player_setup_for_user(obj)
 
     readonly_fields = [
         "created_at",

--- a/users/services/waitlist_service.py
+++ b/users/services/waitlist_service.py
@@ -40,6 +40,20 @@ def build_invite_url(token: str) -> str:
     return f"{frontend_url}/waitlist/redeem/{token}"
 
 
+def send_signup_confirmation_email(entry: Waitlist) -> None:
+    """Sends the "you're on the waitlist" confirmation for a new signup."""
+    context: dict[str, Any] = {"current_year": timezone.now().year}
+    transaction.on_commit(
+        lambda: send_email_to_users(
+            users=[entry.email],
+            subject="You're on the Progress RPG waitlist",
+            template_base="emails/waitlist_signup_confirmation",
+            context=context,
+            cc_admin=False,
+        )
+    )
+
+
 def send_invite_email(entry: Waitlist) -> None:
     """Queues (or re-queues) the invitation email for an already-invited entry."""
     assert entry.invite_token, "send_invite_email requires an already-invited entry"

--- a/users/tests/test_waitlist.py
+++ b/users/tests/test_waitlist.py
@@ -77,6 +77,18 @@ class RegistrationStatusAPITest(APITestCase):
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertTrue(res.json()["self_serve_registration"])
 
+    def test_turnstile_site_key_reported_when_configured(self):
+        with override_settings(CF_TURNSTILE_SITE_KEY="0x-site-key"):
+            res = self.client.get("/api/v1/registration_status/")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.json()["turnstile_site_key"], "0x-site-key")
+
+    def test_turnstile_site_key_blank_when_unconfigured(self):
+        with override_settings(CF_TURNSTILE_SITE_KEY=None):
+            res = self.client.get("/api/v1/registration_status/")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.json()["turnstile_site_key"], "")
+
 
 class RegistrationKillSwitchTest(APITestCase):
     def setUp(self):

--- a/users/tests/test_waitlist.py
+++ b/users/tests/test_waitlist.py
@@ -89,6 +89,18 @@ class RegistrationStatusAPITest(APITestCase):
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.json()["turnstile_site_key"], "")
 
+    def test_waitlist_signup_provider_defaults_to_mailchimp(self):
+        res = self.client.get("/api/v1/registration_status/")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.json()["waitlist_signup_provider"], "mailchimp")
+
+    def test_waitlist_signup_provider_reports_internal_when_set(self):
+        self.settings.waitlist_signup_provider = GameSettings.WaitlistSignupProvider.INTERNAL
+        self.settings.save()
+        res = self.client.get("/api/v1/registration_status/")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.json()["waitlist_signup_provider"], "internal")
+
 
 class RegistrationKillSwitchTest(APITestCase):
     def setUp(self):
@@ -162,9 +174,14 @@ class RegistrationKillSwitchTest(APITestCase):
         self.assertTrue(User.objects.filter(email="newuser@example.com").exists())
 
 
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True,
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+)
 class WaitlistJoinAPITest(APITestCase):
     def setUp(self):
         cache.clear()
+        mail.outbox.clear()
 
     def tearDown(self):
         cache.clear()
@@ -177,6 +194,16 @@ class WaitlistJoinAPITest(APITestCase):
         entry = Waitlist.objects.get(email="waiter@example.com")
         self.assertEqual(entry.status, Waitlist.Status.WAITING)
 
+    def test_valid_email_sends_confirmation_email(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            res = self.client.post(
+                "/api/v1/waitlist_join/", {"email": "waiter@example.com"}
+            )
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ["waiter@example.com"])
+        self.assertIn("waitlist", mail.outbox[0].subject.lower())
+
     def test_duplicate_email_while_waiting_does_not_create_second_row(self):
         Waitlist.objects.create(email="waiter@example.com")
         res = self.client.post(
@@ -184,6 +211,15 @@ class WaitlistJoinAPITest(APITestCase):
         )
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(Waitlist.objects.filter(email="waiter@example.com").count(), 1)
+
+    def test_duplicate_email_while_waiting_does_not_resend_confirmation(self):
+        Waitlist.objects.create(email="waiter@example.com")
+        with self.captureOnCommitCallbacks(execute=True):
+            res = self.client.post(
+                "/api/v1/waitlist_join/", {"email": "waiter@example.com"}
+            )
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mail.outbox), 0)
 
     def test_email_normalized_to_lowercase(self):
         res = self.client.post(
@@ -246,6 +282,13 @@ class SignupIgnoresCapTest(APITestCase):
 class WaitlistServiceEmailTest(TestCase):
     def setUp(self):
         self.entry = Waitlist.objects.create(email="waiter@example.com")
+
+    def test_send_signup_confirmation_email_sends_to_entry_email(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            waitlist_service.send_signup_confirmation_email(self.entry)
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ["waiter@example.com"])
 
     def test_invite_entry_sends_email_and_sets_fields(self):
         with self.captureOnCommitCallbacks(execute=True):

--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -20,6 +20,7 @@ from progress_rpg.middleware.timezone import UserTimezoneMiddleware
 from users.adapters import CustomAccountAdapter
 from users.achievements import achievement_goals_for_player
 from users.serializers import PlayerSerializer
+from gameplay.models import ActivityTimer
 from users.models import Player, UserLogin
 from progression.models import PlayerActivity
 from users.tasks import (
@@ -96,6 +97,31 @@ class UserCreationTest(TestCase):
 
         self.assertEqual(generated_name, generate_default_player_name(12345))
         self.assertRegex(generated_name, r"^player_\d{8}$")
+
+    def test_create_user_creates_activity_timer(self):
+        """Test that a new user's player gets an ActivityTimer."""
+        user = self.UserModel.objects.create_user(
+            email="testuser5@example.com", password="testpassword123"
+        )
+        self.assertTrue(ActivityTimer.objects.filter(player=user.player).exists())
+
+    def test_admin_created_user_gets_player_and_activity_timer(self):
+        """UserAdmin.save_model() just does obj.save() - it doesn't go
+        through CustomUserManager.create_user() - so CustomUserAdmin must
+        explicitly run player setup for admin-created users."""
+        from users.admin import CustomUserAdmin
+        from django.contrib import admin as django_admin
+
+        user = self.UserModel(email="testuser6@example.com")
+        user.set_password("testpassword123")
+
+        model_admin = CustomUserAdmin(self.UserModel, django_admin.site)
+        model_admin.save_model(request=None, obj=user, form=None, change=False)
+
+        self.assertTrue(Player.objects.filter(user=user).exists())
+        self.assertTrue(
+            ActivityTimer.objects.filter(player__user=user).exists()
+        )
 
 
 class PlayerNameValidationTest(TestCase):


### PR DESCRIPTION
## Summary

This branch stacks several previously-separate fixes/features (originally on top of each other because each built on the last). Full list of what merging this PR would introduce:

- **Feature flags**: renamed the vestigial `categoriesPage`/`skillsPage`/`projectsPage` flags to `categoriesFeature`/`skillsFeature`/`projectsFeature` — these now gate tab content inside `LibraryPage`, not standalone routes (folded into tabs in an earlier refactor), so the `*Page` naming was misleading. No behavioural change; `CategoriesPanel`/`ProjectsPanel` remain unwired into Library tabs, left for a future pass (part of #618).
- **Admin**: `FeatureFlag` "key" dropdown now excludes keys that already have a row, so admins can't accidentally create duplicates. Editing an existing row still allows its own key.
- **Admin**: `CustomUserAdmin.save_model()` now runs `ensure_player_setup_for_user()` for new users, fixing `Player.activity_timer.RelatedObjectDoesNotExist` when a user is created directly via Django admin instead of the normal signup flow.
- **Tooltip**: unified click/tap-to-toggle behaviour across desktop and mobile, superseding the mobile-only pointerdown workaround from #566 (which left tap broken and didn't address the native text-selection gesture). Hover is now cursor-affordance only; a single pointerdown handler opens/closes on both mouse and touch, relying on the tooltip's dismissable layer to close it on repeat press. `touch-action`/`-webkit-touch-callout` on the trigger stop the long-press text-selection/context-menu gesture. Map's tooltip tests and `TooltipProvider` config updated for the new model.
- **Registration/Turnstile**: Turnstile site key is now served from `/registration_status/` instead of relying on a build-time env var (neither prod nor staging env groups set `VITE_TURNSTILE_SITE_KEY`, so the widget never had a key). Added an explicit-render `<Turnstile />` component, since the form mounts after Cloudflare's implicit one-shot scan has already run, so the widget never appeared. Submission isn't gated on a token when no site key is configured. Fixes #425.
- **Registration/waitlist**: `RegisterPage` now shows the waitlist form whenever the registration cap is full *or* self-serve registration is off (previously only the cap-full case was handled, leaving self-serve-off users at a dead-end invite-code form). Invited users (via invite token) still always get the registration form.
- **Waitlist**: joining now sends a confirmation email (mirroring the existing invite/nudge pattern). Added `GameSettings.waitlist_signup_provider` (mailchimp/internal, admin-editable) so the Home page's waitlist widget can be switched between the Mailchimp form and the internal `WaitlistForm` without a deploy.
- **economy_forecast**: guarded the verdict output against a crash when `--days 0` (or any run that never bakes bread) leaves `min_bread` as `None` — `format_quantity('bread', None)` was crashing inside the `transaction.atomic` block, silently rolling back `--seed-wheat` seeding too.
- **Tooling**: fixed the `PostToolUse:Edit` pre-commit hook in `.claude/settings.json`, which hardcoded a personal path and venv location and errored outside that exact environment; now uses `$CLAUDE_PROJECT_DIR` and falls back gracefully when no venv/pre-commit is available.
- **Docs**: `CLAUDE.md` now defines concrete criteria for basing a feature-branch PR on `staging` instead of `development` (no local dev tooling, or a change only observable in a live/staging-like environment), and clarifies it's a user call, not something to infer from the working environment.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — no new failures (pre-existing `LibraryPage.test.tsx`/`NavDrawer.test.tsx` failures confirmed present on `development` before this branch, unrelated to these changes — tracked in #638)
- [x] `npm run lint` — no new issues
- [x] Admin dropdown-filtering logic verified via a standalone regex/mock simulation and a new `server_management/tests.py` (`FeatureFlagFormKeyChoicesTests`) — could not run `manage.py test` in this environment (no Docker/Postgres available), so please run `docker compose run --rm web python manage.py test server_management` to confirm against the real DB before merging
- [x] Hook fix verified live by triggering `PostToolUse:Edit` on a `.py` file and confirming no error, both with and without a local pre-commit install

**Note:** this branch diverged from `development` before #626 (apiFetch retry/handler injection, Sentry trace-rate reduction) merged, so it's a few commits behind current `development` tip — worth a rebase/merge check before landing to confirm no drift beyond the usual auto-resolvable catch-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ko7NfA8kZkrDkcebCCRsFH)_
