### PR TITLE
Bump dependencies: axios, django-filter, and locust

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -162,7 +162,9 @@ django-ratelimit==4.1.0
 django-redis==7.0.0
     # via -r requirements.in
 django-stubs==5.2.9
-    # via -r dev-requirements.in
+    # via
+    #   -r dev-requirements.in
+    #   djangorestframework-stubs
 django-stubs-ext==5.2.9
     # via
     #   -r dev-requirements.in
@@ -179,10 +181,10 @@ djangorestframework==3.17.1
     #   dj-rest-auth
     #   djangorestframework-simplejwt
     #   drf-spectacular
-djangorestframework-stubs==3.16.9
-    # via -r dev-requirements.in
 djangorestframework-simplejwt==5.5.1
     # via -r requirements.in
+djangorestframework-stubs==3.16.9
+    # via -r dev-requirements.in
 drf-spectacular==0.29.0
     # via -r requirements.in
 filelock==3.29.5
@@ -243,7 +245,7 @@ kombu==5.6.2
     #   celery
 librt==0.12.0
     # via mypy
-locust==2.44.4
+locust==2.46.2
     # via -r dev-requirements.in
 markupsafe==3.0.3
     # via
@@ -390,12 +392,14 @@ types-pyyaml==6.0.12.20260518
     # via
     #   -r dev-requirements.in
     #   django-stubs
+    #   djangorestframework-stubs
 typing-extensions==4.16.0
     # via
     #   -r requirements.in
     #   django-redis
     #   django-stubs
     #   django-stubs-ext
+    #   djangorestframework-stubs
     #   mypy
     #   pyopenssl
     #   referencing

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -155,14 +155,16 @@ django-environ==0.14.0
     # via -r requirements.in
 django-extensions==4.1
     # via -r requirements.in
-django-filter==25.2
+django-filter==26.1
     # via -r requirements.in
 django-ratelimit==4.1.0
     # via -r requirements.in
 django-redis==7.0.0
     # via -r requirements.in
 django-stubs==5.2.9
-    # via -r dev-requirements.in
+    # via
+    #   -r dev-requirements.in
+    #   djangorestframework-stubs
 django-stubs-ext==5.2.9
     # via
     #   -r dev-requirements.in
@@ -179,10 +181,10 @@ djangorestframework==3.17.1
     #   dj-rest-auth
     #   djangorestframework-simplejwt
     #   drf-spectacular
-djangorestframework-stubs==3.16.9
-    # via -r dev-requirements.in
 djangorestframework-simplejwt==5.5.1
     # via -r requirements.in
+djangorestframework-stubs==3.16.9
+    # via -r dev-requirements.in
 drf-spectacular==0.29.0
     # via -r requirements.in
 filelock==3.29.5
@@ -390,12 +392,14 @@ types-pyyaml==6.0.12.20260518
     # via
     #   -r dev-requirements.in
     #   django-stubs
+    #   djangorestframework-stubs
 typing-extensions==4.16.0
     # via
     #   -r requirements.in
     #   django-redis
     #   django-stubs
     #   django-stubs-ext
+    #   djangorestframework-stubs
     #   mypy
     #   pyopenssl
     #   referencing

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@tanstack/react-query": "^5.90.12",
         "@tanstack/react-query-devtools": "^5.91.1",
         "@vitejs/plugin-react": "^5.2.0",
-        "axios": "^1.16.0",
+        "axios": "^1.18.0",
         "classnames": "^2.5.1",
         "framer-motion": "^12.42.2",
         "fuse.js": "^7.0.0",
@@ -5383,14 +5383,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
     "@vitejs/plugin-react": "^5.2.0",
-    "axios": "^1.16.0",
+    "axios": "^1.18.0",
     "classnames": "^2.5.1",
     "framer-motion": "^12.42.2",
     "fuse.js": "^7.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -132,7 +132,7 @@ django-environ==0.14.0
     # via -r requirements.in
 django-extensions==4.1
     # via -r requirements.in
-django-filter==25.2
+django-filter==26.1
     # via -r requirements.in
 django-ratelimit==4.1.0
     # via -r requirements.in


### PR DESCRIPTION
This pull request updates several dependencies in both the backend and frontend to keep the project up-to-date and improve compatibility, security, and performance. The most important changes are grouped below.

**Frontend Dependency Updates:**

* Upgraded `axios` from version `1.16.0` to `1.18.0` in both `package.json` and `package-lock.json`, which also introduces new sub-dependencies such as `https-proxy-agent` and `agent-base` for improved proxy support. [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL23-R23) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL5416-R5451) [[3]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L37-R37)

**Backend (Python) Dependency Updates:**

* Upgraded `django-filter` from `25.2` to `26.1` in `dev-requirements.txt`, ensuring compatibility and access to the latest features and fixes.
* Upgraded `locust` from `2.44.4` to `2.46.2` in `dev-requirements.txt`, providing the latest performance testing capabilities.

**Development and Type Checking Improvements:**

* Updated dependency comments in `dev-requirements.txt` to reflect that `django-stubs` and `djangorestframework-stubs` now require `types-pyyaml` and `typing-extensions`, which clarifies the dependency graph for type checking.
* Adjusted the ordering and comments for `djangorestframework-stubs` in `dev-requirements.txt` for clarity, but no version change was made.