### PR TITLE
Fix movement tick to use real elapsed time instead of assumed 1s cadence

### DIFF
--- a/locations/tasks.py
+++ b/locations/tasks.py
@@ -1,14 +1,45 @@
 import random
+import time
 
 from celery import shared_task
+from django.core.cache import cache
 from django.core.management import call_command
+
+# Nominal real-world cadence the self-rescheduling tick loop aims for.
+# Celery's `countdown` is only a lower bound on the delay before a task is
+# *eligible* to run, not a guarantee of when it actually runs - broker/worker
+# load can push the real gap between ticks past this. move_characters_tick
+# measures that real gap itself (see time_delta below) rather than assuming
+# it's always exactly this value, so simulated movement stays in step with
+# real elapsed time - which is what the frontend's between-poll walker
+# animation assumes (see issue #624: server/client disagreeing about how far
+# a character should have moved surfaced as a visible correction, in sync
+# across every moving character, roughly every poll).
+MOVE_TICK_NOMINAL_SECONDS = 1.0
+# Ceiling on how much elapsed real time a single tick will credit as
+# movement, so a long stall (worker restart, deploy, broker backlog) doesn't
+# let characters teleport once ticking resumes - they just take a few more,
+# still real-time-accurate, ticks to catch up.
+MOVE_TICK_MAX_SECONDS = 5.0
+
+_LAST_TICK_CACHE_KEY = "locations:move_characters_tick:last_run_at"
 
 
 @shared_task
-def move_characters_tick(time_delta=1.0):
+def move_characters_tick(time_delta=None):
     """Process character movement in batches. Avoid loading all movers into memory."""
     from character.models import Character
     from .models import Journey
+
+    now = time.time()
+    if time_delta is None:
+        last_run_at = cache.get(_LAST_TICK_CACHE_KEY)
+        time_delta = (
+            min(now - last_run_at, MOVE_TICK_MAX_SECONDS)
+            if last_run_at is not None
+            else MOVE_TICK_NOMINAL_SECONDS
+        )
+    cache.set(_LAST_TICK_CACHE_KEY, now, timeout=None)
 
     batch_size = 100
     movers_to_update = []
@@ -60,9 +91,11 @@ def move_characters_tick(time_delta=1.0):
             ),
         )
 
-    # Check if there are still moving characters
+    # Check if there are still moving characters. Reschedule at the nominal
+    # cadence, not `time_delta` - `time_delta` is how much time this tick
+    # measured as *having already elapsed*, not how long to wait next.
     if Character.objects.filter(is_moving=True).exists():
-        move_characters_tick.apply_async(countdown=time_delta)
+        move_characters_tick.apply_async(countdown=MOVE_TICK_NOMINAL_SECONDS)
 
 
 @shared_task

--- a/locations/tests.py
+++ b/locations/tests.py
@@ -1,8 +1,10 @@
 import random
+import time
 from datetime import datetime
 
 from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Point, Polygon
+from django.core.cache import cache
 from django.core.management import call_command
 from django.db import connection
 from django.test import TestCase
@@ -215,6 +217,43 @@ class LocationsModelsTestCase(TestCase):
 
         journey = Journey.objects.filter(character=char).first()
         self.assertEqual(journey.status, "complete")
+
+    def test_move_characters_tick_uses_real_elapsed_time_when_not_given(self):
+        """Regression test for issue #624: a tick left to infer its own
+        time_delta must move characters by how much real time actually
+        passed since the previous tick, not a hardcoded assumption -
+        otherwise the server's simulated position drifts away from what the
+        frontend (which extrapolates using the real clock) expects, causing
+        a visible correction every poll."""
+        from locations.tasks import _LAST_TICK_CACHE_KEY
+
+        char = Character.objects.create(
+            first_name="Drifter",
+            location=Point(0, 0, srid=3857),
+            current_node=self.node_a,
+            movement_speed=1.0,
+        )
+        char.set_destination(node=self.node_c)  # far enough not to arrive early
+
+        # Cache is a real (Redis) backend shared across tests, not reset per
+        # test - clear it first so this test doesn't inherit a near-"now"
+        # timestamp left behind by another test's tick.
+        cache.delete(_LAST_TICK_CACHE_KEY)
+        self.addCleanup(cache.delete, _LAST_TICK_CACHE_KEY)
+        with patch("locations.tasks.move_characters_tick.apply_async"):
+            # First tick with no prior recorded run: falls back to the
+            # nominal 1s cadence, moving the character 1 unit (speed 1.0).
+            move_characters_tick()
+            char.refresh_from_db()
+            self.assertAlmostEqual(char.location.x, 1.0, places=6)
+
+            # Second tick, 3 real seconds later (simulating a delayed
+            # worker/broker): should move the character by 3 units, not 1.
+            first_tick_at = cache.get(_LAST_TICK_CACHE_KEY)
+            with patch("locations.tasks.time.time", return_value=first_tick_at + 3.0):
+                move_characters_tick()
+            char.refresh_from_db()
+            self.assertAlmostEqual(char.location.x, 4.0, places=6)
 
 
 class CharacterPointFeatureSerializerJourneyTest(TestCase):


### PR DESCRIPTION
## Summary

Fixes #624 — village map's moving characters visibly jump back and forth in sync, roughly every couple of seconds.

Root cause: `move_characters_tick` (`locations/tasks.py`) always assumed exactly **1.0s** of movement per tick, and self-rescheduled using that same assumed value as the next `countdown`. But Celery's `countdown` is only a lower bound on when a task becomes *eligible* to run — broker/worker load can push the real gap between ticks past that. Since this single task processes every currently-moving character in one batch, any drift between the assumed 1.0s and the actual elapsed time showed up as a position correction on the frontend's *next* poll (`Map.tsx`'s checkpoint-reset), synchronized across every moving character simultaneously — matching the reported symptom exactly.

## Fix

- `move_characters_tick` now measures actual elapsed wall-clock time (via a cached `last_run_at` timestamp) when no explicit `time_delta` is passed, so simulated movement stays in step with real time.
- Elapsed time is capped at 5s so a stalled worker (restart/deploy/broker backlog) doesn't let characters teleport once ticking resumes — they just take a few extra, still-accurate, ticks to catch up.
- Self-rescheduling now always uses a fixed nominal cadence (1.0s) for the next `countdown`, rather than the (now variable) measured elapsed time — previously these were conflated.
- No frontend changes: `Map.tsx`'s walker interpolation already mirrors the server's `step_toward` algorithm and uses a self-consistent client clock, so once the server's assumed tick timing matches reality, the client's smooth interpolation should track it without visible corrections.

## Test plan

- [x] Added regression test `test_move_characters_tick_uses_real_elapsed_time_when_not_given` (`locations/tests.py`) — verifies a tick 3 real seconds after the previous one moves a character 3 units, not 1.
- [x] `locations` test suite: 69/69 passing.
- [x] `economy` test suite: 39/39 passing (exercises the movement pipeline via `economy_forecast`).
- [ ] Manual check on staging: watch multiple moving characters across several poll cycles for a steady, monotonic walk with no visible correction at poll boundaries (per issue #624's test plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)