### PR TITLE
Fix village map rendering nothing but characters in production builds

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -66,6 +66,7 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.0",
         "vite-plugin-dts": "^5.0.3",
+        "vite-plugin-static-copy": "^4.1.1",
         "vitest": "^4.1.10"
       }
     },
@@ -4838,6 +4839,33 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5011,6 +5039,19 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
@@ -5022,6 +5063,19 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -6011,6 +6065,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -6459,6 +6526,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
@@ -6531,6 +6611,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -7451,6 +7541,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -7598,6 +7698,19 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8652,6 +8765,19 @@
       "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
       "license": "MIT"
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -9072,6 +9198,93 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-static-copy": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-4.1.1.tgz",
+      "integrity": "sha512-GrlA8YklrAfSyxJ4M3fdQLOo9oNkp56IM9FYgX/WtEgeIFkPwhu4wzpufBCIuNKCa6Fn77FkRdYxkHqV0FwjAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.6.0",
+        "p-map": "^7.0.4",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "engines": {
+        "node": "^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/sapphi-red"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/vite/node_modules/fsevents": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,6 +86,7 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",
     "vite-plugin-dts": "^5.0.3",
+    "vite-plugin-static-copy": "^4.1.1",
     "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/components/Map/Map.test.tsx
+++ b/frontend/src/components/Map/Map.test.tsx
@@ -152,6 +152,7 @@ vi.mock('maplibre-gl', () => ({
   Marker: FakeMarker,
   NavigationControl: FakeNavigationControl,
   LngLatBounds: FakeLngLatBounds,
+  setWorkerUrl: vi.fn(),
 }));
 
 // Imported after the mock so Map.tsx picks up the faked maplibre-gl module.

--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -6,6 +6,7 @@ import {
   Marker,
   NavigationControl,
   LngLatBounds,
+  setWorkerUrl,
   type GeoJSONSource,
   type MapGeoJSONFeature,
   type MapMouseEvent,
@@ -15,6 +16,24 @@ import Tooltip, { TooltipProvider } from "../Tooltip/Tooltip";
 import { coordsToLngLat, fieldFillFor, fromLngLat, quantizeBbox, toLngLat } from "./utils";
 import { BuildingTooltipContent, CharacterTooltipContent } from "./MapTooltips";
 import styles from "./Map.module.scss";
+
+// maplibre-gl loads its own tile-processing worker via a runtime
+// `new URL('./${name}.mjs', import.meta.url)` where `name` is a variable,
+// not a string literal - Vite/Rollup's static asset analysis only bundles
+// (and emits) worker URLs it can resolve at build time, so this pattern
+// silently produces no build output for the production build (dev mode
+// isn't affected - see the optimizeDeps.exclude comment in vite.config.ts,
+// which addresses a different, dev-only version of this same underlying
+// problem). Without this fix, the worker request 404s (silently, since the
+// static host's SPA fallback serves index.html instead of a real 404) and
+// every vector layer (fills/lines - anything that isn't a DOM-positioned
+// Marker) renders nothing, with no error surfaced anywhere (issue #624
+// investigation, 2026-07-31). vite.config.ts's viteStaticCopy plugin copies
+// the worker file and its own sibling import (maplibre-gl-shared.mjs) to a
+// fixed, unhashed path verbatim - the exact relative filename the worker's
+// own `import "./maplibre-gl-shared.mjs"` expects - and setWorkerUrl is
+// maplibre-gl's own public override for exactly this bundler scenario.
+setWorkerUrl("/maplibre-gl/maplibre-gl-worker.mjs");
 
 interface GeoJSONFeatureProperties {
   feature_type?: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,13 +5,43 @@ import { fileURLToPath } from 'url'
 import path from 'node:path'
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin'
 import { playwright } from '@vitest/browser-playwright'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 const dirname = fileURLToPath(new URL('.', import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig(() => {
   return {
-    plugins: [react()],
+    plugins: [
+      react(),
+      // maplibre-gl loads its own tile-processing worker via a runtime
+      // `new URL('./maplibre-gl-worker.mjs', import.meta.url)` where the
+      // filename is a variable, not a string literal Rollup can statically
+      // resolve - so the production build never emits that file (or its
+      // own sibling import, maplibre-gl-shared.mjs), and the map silently
+      // renders zero vector layers (fills/lines) in production while DOM
+      // markers keep working, since they don't go through the worker at
+      // all (issue #624 investigation, 2026-07-31). optimizeDeps.exclude
+      // above only fixes the equivalent dev-server-only version of this
+      // problem. Copying both files verbatim (same relative names, so the
+      // worker's own `./maplibre-gl-shared.mjs` import still resolves) and
+      // pointing setWorkerUrl at the copy (see Map.tsx) is MapLibre's own
+      // documented workaround for bundlers that can't auto-detect this.
+      viteStaticCopy({
+        targets: [
+          {
+            src: 'node_modules/maplibre-gl/dist/maplibre-gl-worker.mjs',
+            dest: 'maplibre-gl',
+            rename: { stripBase: true },
+          },
+          {
+            src: 'node_modules/maplibre-gl/dist/maplibre-gl-shared.mjs',
+            dest: 'maplibre-gl',
+            rename: { stripBase: true },
+          },
+        ],
+      }),
+    ],
     base: '/',
     // maplibre-gl loads its own worker via a dynamically-constructed URL;
     // Vite's dependency pre-bundler rewrites that URL to a path


### PR DESCRIPTION
maplibre-gl offloads GeoJSON tile processing to a worker, loaded via a
runtime `new URL('./${name}.mjs', import.meta.url)` where `name` is a
variable, not a string literal - Vite/Rollup's build-time asset analysis
can't statically resolve that, so the production build never emits the
worker file (or its own sibling import, maplibre-gl-shared.mjs). The
static host's SPA fallback then serves index.html instead of a real 404
for the missing worker request, so it fails silently with no error
surfaced anywhere - every vector layer (village boundary, buildings,
subzones, paths) renders nothing, while character markers stay visible
since they're plain positioned DOM elements that don't touch the worker.

vite.config.ts's existing optimizeDeps.exclude only fixes the equivalent
dev-server-only version of this problem (a different rewrite done by
Vite's dependency pre-bundler, which doesn't run during `vite build`) -
verifying the map only via `npm run dev` never exercised the production
bundle path that staging (and any deployed build) actually serves.

Fixed by copying the worker file and its sibling import verbatim (same
relative names, via vite-plugin-static-copy) to a fixed path, and
pointing maplibre-gl's own setWorkerUrl override at it - its documented
workaround for bundlers that can't auto-detect the worker.

Found via issue #624 investigation: reproduced locally by diffing
`npm run dev` (11/11 buildings render) against `npm run build:production`
(zero rendered features anywhere on the map) against the same seeded
village data.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
