### PR TITLE
fix: pass import_village's file arg positionally in setup_world

### DIFF
--- a/locations/management/commands/setup_world.py
+++ b/locations/management/commands/setup_world.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
                 # village_names.VILLAGE_NAMES, same as spawn_villages does.
                 call_command(
                     "import_village",
-                    file=str(village_file),
+                    str(village_file),
                     overwrite=True,
                     interactive=False,
                 )


### PR DESCRIPTION
`setup_world` calls `call_command("import_village", file=str(village_file), overwrite=True, interactive=False)`, but `file` is a required positional argument in `import_village` (not an option). Django's `call_command` crashes trying to serialize it back into an option string (`min()` on the positional action's empty `option_strings`), raising `ValueError: min() arg is an empty sequence` — hit when running `setup_world` on staging just now.

Fix: pass `file` positionally instead of as a kwarg.