### PR TITLE
hotfix: pass import_village's file arg positionally in setup_world

### DIFF
--- a/locations/management/commands/setup_world.py
+++ b/locations/management/commands/setup_world.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
                 # village_names.VILLAGE_NAMES, same as spawn_villages does.
                 call_command(
                     "import_village",
-                    file=str(village_file),
+                    str(village_file),
                     overwrite=True,
                     interactive=False,
                 )


### PR DESCRIPTION
Cherry-pick of #663 onto staging so `setup_world` can be re-run there without waiting for the next development→staging sync. See #663 for the root cause.