### PR TITLE
Village-level progress display on map view

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -196,6 +196,33 @@ class TestMeViewSet(APITestCase):
         self.assertTrue(player_for(self.user).onboarding_completed)
         self.assertEqual(res.data, {"onboarding_completed": True})
 
+    def test_today_points_null_when_no_active_link(self):
+        self.authenticate()
+        player = player_for(self.user)
+        self.assertIsNone(player.active_link)
+
+        res = self.client.get(reverse("me-today-points"))
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertIsNone(res.data["points_today"])
+
+    def test_today_points_reflects_todays_completed_activities(self):
+        self.authenticate()
+        player = player_for(self.user)
+        PlayerCharacterLink.objects.create(player=player, character=self.character)
+
+        PlayerActivity.objects.create(
+            player=player,
+            is_complete=True,
+            duration=1200,  # 20 minutes -> 2 points
+            completed_at=datetime.now(timezone.utc),
+        )
+
+        res = self.client.get(reverse("me-today-points"))
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["points_today"], 2)
+
 
 class CustomTokenObtainPairViewTests(APITestCase):
     def setUp(self):

--- a/api/views.py
+++ b/api/views.py
@@ -348,6 +348,27 @@ class MeViewSet(viewsets.ViewSet):
 
     @extend_schema(
         responses=inline_serializer(
+            name="TodayPointsResponse",
+            fields={
+                "points_today": drf_serializers.IntegerField(allow_null=True),
+            },
+        )
+    )
+    @action(detail=False, methods=["get"])
+    def today_points(self, request):
+        """
+        Personal "points earned today" for the map view's badge (issue #673).
+        `points_today` is null - not zero - when the player has no active
+        PlayerCharacterLink, so the frontend can tell "no link" apart from
+        "linked but nothing earned yet today" and hide the badge entirely.
+        """
+        player = request.user.player
+        link = player.active_link
+
+        return Response({"points_today": link.points_today if link else None})
+
+    @extend_schema(
+        responses=inline_serializer(
             name="OnboardingCompletedResponse",
             fields={"onboarding_completed": drf_serializers.BooleanField()},
         )

--- a/character/models/character.py
+++ b/character/models/character.py
@@ -324,6 +324,36 @@ class PlayerCharacterLink(models.Model):
 
         return total_days_points + login_points + time_points
 
+    @property
+    def player_time_today(self):
+        """
+        Completed activity time for this link so far today (in minutes) -
+        a date-filtered variant of player_time, bounded to the current UTC
+        day instead of the whole link lifetime.
+        """
+        start_of_day = timezone.now().replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        start = max(start_of_day, self.linked_at)
+
+        qs = self.player.activities.filter(is_complete=True, completed_at__gte=start)
+        if self.unlinked_at:
+            qs = qs.filter(completed_at__lte=self.unlinked_at)
+
+        total_seconds = qs.aggregate(total=Sum("duration"))["total"] or 0
+        return int(total_seconds // 60)
+
+    @property
+    def points_today(self):
+        """
+        Points earned today (issue #673's map-view "today" badge) - only the
+        activity-time component of link_points, date-filtered to today.
+        link_points' other terms (days_linked * 20, login_points) aren't
+        "earned today" in the same sense, so they're deliberately left out
+        here rather than prorated.
+        """
+        return self.player_time_today // 10
+
     @classmethod
     def get_character(cls, player: Player) -> Character:
         return link_services.player_link_get_character(cls, player)

--- a/character/tests/test_models.py
+++ b/character/tests/test_models.py
@@ -454,3 +454,65 @@ class CharacterNPCTests(TestCase):
         self.assertFalse(self.npc2.can_link)
 
         self.assertFalse(Character.has_available())
+
+
+class PlayerCharacterLinkPointsTodayTests(TestCase):
+    """Tests for PlayerCharacterLink.player_time_today/points_today (issue #673)."""
+
+    def setUp(self):
+        from users.models import CustomUser
+        from progression.models import PlayerActivity
+
+        self.PlayerActivity = PlayerActivity
+        self.user = CustomUser.objects.create_user(
+            email="today-points@example.com", password="pass12345"
+        )
+        self.player = self.user.player
+        character = Character.objects.create(first_name="Hero", last_name="Link")
+        self.link = PlayerCharacterLink.objects.create(
+            player=self.player, character=character
+        )
+        # Backdated well before "today" so player_time_today's max(start_of_day,
+        # linked_at) resolves to start_of_day in these tests, rather than to
+        # whatever moment setUp happened to run at.
+        self.link.linked_at = now() - timedelta(days=30)
+        self.link.save(update_fields=["linked_at"])
+
+    def _complete_activity(self, *, duration_seconds, completed_at):
+        return self.PlayerActivity.objects.create(
+            player=self.player,
+            is_complete=True,
+            duration=duration_seconds,
+            completed_at=completed_at,
+        )
+
+    def test_points_today_counts_only_activities_completed_today(self):
+        today_start = now().replace(hour=0, minute=0, second=0, microsecond=0)
+        self._complete_activity(
+            duration_seconds=1800, completed_at=today_start + timedelta(hours=2)
+        )  # 30 min today
+        self._complete_activity(
+            duration_seconds=3600, completed_at=today_start - timedelta(hours=1)
+        )  # 60 min yesterday - excluded
+
+        self.assertEqual(self.link.player_time_today, 30)
+        self.assertEqual(self.link.points_today, 3)
+
+    def test_points_today_excludes_activity_before_link_started(self):
+        today_start = now().replace(hour=0, minute=0, second=0, microsecond=0)
+        self.link.linked_at = today_start + timedelta(hours=5)
+        self.link.save(update_fields=["linked_at"])
+
+        self._complete_activity(
+            duration_seconds=1800, completed_at=today_start + timedelta(hours=1)
+        )  # today, but before the link started - excluded
+        self._complete_activity(
+            duration_seconds=600, completed_at=today_start + timedelta(hours=6)
+        )  # 10 min, after linked_at
+
+        self.assertEqual(self.link.player_time_today, 10)
+        self.assertEqual(self.link.points_today, 1)
+
+    def test_points_today_zero_with_no_activities(self):
+        self.assertEqual(self.link.player_time_today, 0)
+        self.assertEqual(self.link.points_today, 0)

--- a/frontend/src/api/player.ts
+++ b/frontend/src/api/player.ts
@@ -40,3 +40,14 @@ export const deleteAccount = async (): Promise<unknown> => {
   });
   return response;
 };
+
+export interface TodayPointsResponse {
+  // null (not 0) when the player has no active PlayerCharacterLink - see
+  // MeViewSet.today_points in api/views.py. Callers use this to hide the
+  // map view's "today" badge entirely rather than showing a zero (issue #673).
+  points_today: number | null;
+}
+
+export const fetchTodayPoints = async (): Promise<TodayPointsResponse> => {
+  return apiFetch<TodayPointsResponse>("/me/today_points/");
+};

--- a/frontend/src/components/ActivityInput/useActivityInput.test.ts
+++ b/frontend/src/components/ActivityInput/useActivityInput.test.ts
@@ -32,11 +32,13 @@ vi.mock('../../utils/sounds', () => ({
   primeAudio: vi.fn(),
 }));
 
+const invalidateQueries = vi.fn();
+
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-query')>();
   return {
     ...actual,
-    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+    useQueryClient: () => ({ invalidateQueries }),
   };
 });
 
@@ -79,6 +81,7 @@ describe('useActivityInput unified handlers', () => {
     startActivity.mockReset();
     labelActivity.mockReset();
     addEntityToCache.mockReset();
+    invalidateQueries.mockReset();
 
     mockUseSupportFlow.mockReturnValue({
       openWelcomeMessage: vi.fn(),
@@ -254,5 +257,20 @@ describe('useActivityInput unified handlers', () => {
 
     expect(labelActivity).toHaveBeenCalledWith('Deeper work', null);
     expect(result.current.isEditingLabel).toBe(false);
+  });
+
+  it('invalidates the today-points query after completing an activity, so the map badge updates immediately (#673)', async () => {
+    mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+    stop.mockResolvedValue({ xp_gained: 10 });
+
+    const { result } = renderHook(() => useActivityInput());
+
+    await act(async () => {
+      await result.current.handleToggle();
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['me', 'today-points'],
+    });
   });
 });

--- a/frontend/src/components/ActivityInput/useActivityInput.ts
+++ b/frontend/src/components/ActivityInput/useActivityInput.ts
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useGame } from "../../hooks/useGame";
 import { useEntitySearchCache } from "../../hooks/useEntitySearchCache";
 import { useSupportFlow } from "../../hooks/useSupportFlow";
+import { TODAY_POINTS_QUERY_KEY } from "../../hooks/usePlayer";
 import type { PlayerActivity } from "../../types";
 import { playLimitReachedSound, primeAudio } from "../../utils/sounds";
 
@@ -250,6 +251,7 @@ export function useActivityInput() {
           fetchPlayerAndCharacter(),
           fetchCharacterCurrent(),
           fetchActivities(),
+          queryClient.invalidateQueries({ queryKey: TODAY_POINTS_QUERY_KEY }),
           completedTaskId ? queryClient.invalidateQueries({ queryKey: ["tasks"] }) : Promise.resolve(),
         ]);
       } catch (err) {

--- a/frontend/src/components/Map/Map.module.scss
+++ b/frontend/src/components/Map/Map.module.scss
@@ -50,6 +50,10 @@
   top: 10px;
   left: 10px;
   z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .tooltipHost {

--- a/frontend/src/components/Map/Map.test.tsx
+++ b/frontend/src/components/Map/Map.test.tsx
@@ -736,6 +736,77 @@ describe('PopulationCentreMap', () => {
     expect(uniquePoints.size).toBe(3);
   });
 
+  it('colours each village marker by its state, not by a shared default', () => {
+    const geojsonWithVillageMarker = {
+      ...baseGeojson,
+      features: [
+        ...baseGeojson.features,
+        {
+          geometry: { type: 'Point', coordinates: [30, 30] },
+          properties: {
+            feature_type: 'population_centre_label',
+            name: 'Driftmoor village',
+            population_centre_id: 7,
+            state: 'Thriving',
+            progress: 42,
+          },
+        },
+      ],
+    };
+    renderMap({ geojson: geojsonWithVillageMarker });
+
+    const markerLayer = currentMap().layers.find((l) => l.id === 'village-marker') as
+      | { paint?: { 'circle-color'?: unknown } }
+      | undefined;
+    // A ["match", ["get", "state"], ...] expression, not a single flat colour
+    // - every state needs its own colour, not one shared default.
+    expect(markerLayer?.paint?.['circle-color']).toEqual(
+      expect.arrayContaining(['match', ['get', 'state']])
+    );
+
+    const feature = villageSourceFeatures().find(
+      (f) => f.properties.feature_type === 'population_centre_label'
+    );
+    expect(feature?.properties.state).toBe('Thriving');
+  });
+
+  it('expands a tapped village marker into its progress bar and state label', async () => {
+    const geojsonWithVillageMarker = {
+      ...baseGeojson,
+      features: [
+        ...baseGeojson.features,
+        {
+          geometry: { type: 'Point', coordinates: [30, 30] },
+          properties: {
+            feature_type: 'population_centre_label',
+            name: 'Driftmoor village',
+            population_centre_id: 7,
+            state: 'Recovering',
+            progress: 65,
+          },
+        },
+      ],
+    };
+    renderMap({ geojson: geojsonWithVillageMarker });
+    const feature = villageSourceFeatures().find(
+      (f) => f.properties.feature_type === 'population_centre_label'
+    );
+
+    act(() => {
+      currentMap().trigger(
+        'click',
+        { features: [feature], lngLat: { lng: 30, lat: 30 } },
+        'village-marker'
+      );
+    });
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Driftmoor village');
+    expect(tooltip).toHaveTextContent('Recovering');
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '65');
+  });
+
   it('renders path lines invisibly (line-opacity 0)', () => {
     const geojsonWithPath = {
       ...baseGeojson,

--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -12,7 +12,7 @@ import {
 } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { fromLngLat, quantizeBbox, toLngLat } from "./utils";
-import { CharacterTooltipContent } from "./MapTooltips";
+import { CharacterTooltipContent, PopulationCentreTooltipContent } from "./MapTooltips";
 import { scatterCharacters } from "./characters/placement";
 import {
   buildingFootprintRings,
@@ -20,7 +20,12 @@ import {
   styledLineFeatures,
   styledPolygonFeatures,
 } from "./geojson";
-import { addCharacterImage, addVillageLayers, CLICKABLE_LAYERS } from "./layers";
+import {
+  addCharacterImage,
+  addVillageLayers,
+  CLICKABLE_LAYERS,
+  VILLAGE_MARKER_LAYER,
+} from "./layers";
 import { buildVillageSourceData, type WalkerState } from "./sourceData";
 import styles from "./Map.module.scss";
 
@@ -211,6 +216,36 @@ export default function PopulationCentreMap({
         map.getCanvas().style.cursor = "";
       });
 
+      // Tapping/selecting a village marker expands it into its progress bar
+      // + state label (issue #673) - the marker itself only shows a
+      // state-coded dot at rest (see VILLAGE_MARKER_LAYER in layers.ts).
+      map.on(
+        "click",
+        VILLAGE_MARKER_LAYER,
+        (e: MapMouseEvent & { features?: MapGeoJSONFeature[] }) => {
+          const feature = e.features?.[0];
+          if (!feature) return;
+          e.originalEvent?.stopPropagation?.();
+          setTooltip({
+            key: `population-centre-${feature.properties?.population_centre_id ?? JSON.stringify(feature.properties)}`,
+            content: (
+              <PopulationCentreTooltipContent
+                name={feature.properties?.name as string | undefined}
+                state={feature.properties?.state as string | null | undefined}
+                progress={feature.properties?.progress as number | null | undefined}
+              />
+            ),
+            lngLat: [e.lngLat.lng, e.lngLat.lat],
+          });
+        }
+      );
+      map.on("mouseenter", VILLAGE_MARKER_LAYER, () => {
+        map.getCanvas().style.cursor = "pointer";
+      });
+      map.on("mouseleave", VILLAGE_MARKER_LAYER, () => {
+        map.getCanvas().style.cursor = "";
+      });
+
       refreshVillageSource();
 
       for (const layerId of CLICKABLE_LAYERS) {
@@ -241,7 +276,7 @@ export default function PopulationCentreMap({
         // per-layer listeners above and stops here; a click on empty map
         // area closes whatever tooltip is open.
         const hits = map.queryRenderedFeatures(e.point, {
-          layers: ["characters", ...CLICKABLE_LAYERS],
+          layers: ["characters", VILLAGE_MARKER_LAYER, ...CLICKABLE_LAYERS],
         });
         if (hits.length === 0) closeTooltip();
       });

--- a/frontend/src/components/Map/MapTooltips.tsx
+++ b/frontend/src/components/Map/MapTooltips.tsx
@@ -1,6 +1,8 @@
 // Structured tooltip content for building/character map markers, kept out
 // of Map.tsx since the trigger elements (polygons/glyphs) already carry a
 // lot of pan/zoom/rendering logic.
+import ProgressBar from "../ProgressBar/ProgressBar";
+import { VILLAGE_STATE_PROGRESS_COLORS } from "./layers";
 
 interface GoodEntry {
   good_type?: string;
@@ -68,6 +70,35 @@ export function CharacterTooltipContent({ name, home, work, hungerLabel }: Chara
       {home && <div>Lives at: {home}</div>}
       {work && <div>Works at: {work}</div>}
       {hungerLabel && <div>{hungerLabel}</div>}
+    </div>
+  );
+}
+
+interface PopulationCentreTooltipProps {
+  name?: string;
+  state?: string | null;
+  progress?: number | null;
+}
+
+// Expanded content shown when a village marker is tapped/selected - the
+// marker itself only shows a state-coded dot at rest (see VILLAGE_MARKER_LAYER
+// in layers.ts); this is where the full progress bar + state label live.
+export function PopulationCentreTooltipContent({
+  name,
+  state,
+  progress,
+}: PopulationCentreTooltipProps) {
+  return (
+    <div>
+      <div>{name}</div>
+      {state && (
+        <ProgressBar
+          value={progress ?? 0}
+          max={100}
+          label={state}
+          color={VILLAGE_STATE_PROGRESS_COLORS[state] ?? "default"}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Map/layers.ts
+++ b/frontend/src/components/Map/layers.ts
@@ -7,6 +7,7 @@ export const SUBZONES_FILL_LAYER = "subzones-fill";
 export const PATHS_LINE_LAYER = "paths-line";
 export const ROADS_LINE_LAYER = "roads-line";
 export const VILLAGE_LABEL_LAYER = "village-label";
+export const VILLAGE_MARKER_LAYER = "village-marker";
 export const CLICKABLE_LAYERS = [
 	BOUNDARY_FILL_LAYER,
 	BUILDINGS_FILL_LAYER,
@@ -14,6 +15,30 @@ export const CLICKABLE_LAYERS = [
 ];
 
 const CHARACTERS_LAYER = "characters";
+
+// Marker colour per PopulationCentre.state (see locations/models.py) - a
+// placeholder palette (issue #673 explicitly leaves the exact icon/colour
+// set as an open design question). Mirrors ProgressBar.module.scss's own
+// danger/warning/default/success classes (rather than inventing a separate
+// palette) so a village's marker colour and its tooltip progress bar
+// (VILLAGE_STATE_PROGRESS_COLORS below) read as the same colour per state.
+export const VILLAGE_STATE_COLORS: Record<string, string> = {
+	Struggling: "#c62828", // ProgressBar .danger (c.$color-error)
+	Recovering: "#ff9800", // ProgressBar .warning (c.$color-warning)
+	Stable: "#007a32", // ProgressBar .default (c.$color-progress-bar)
+	Thriving: "#00612a", // ProgressBar .success (c.$color-status-success)
+};
+const VILLAGE_STATE_DEFAULT_COLOR = "#888";
+
+// ProgressBar `color` prop values per state, for the "tap a marker" expanded
+// tooltip - see VILLAGE_STATE_COLORS above for how these line up with the
+// marker's own fill colour.
+export const VILLAGE_STATE_PROGRESS_COLORS: Record<string, string> = {
+	Struggling: "danger",
+	Recovering: "warning",
+	Stable: "default",
+	Thriving: "success",
+};
 
 function createCharacterIcon(): ImageData {
     const size = 256;
@@ -111,6 +136,37 @@ export function addVillageLayers(map: MapLibreMap): void {
 		paint: {
 			"line-color": "#8b5a2b",
 			"line-width": ["*", ["coalesce", ["get", "width"], 6], 0.5],
+		},
+	});
+	map.addLayer({
+		id: VILLAGE_MARKER_LAYER,
+		type: "circle",
+		source: "village",
+		filter: [
+			"==",
+			["get", "feature_type"],
+			"population_centre_label",
+		],
+		paint: {
+			"circle-radius": [
+				"interpolate",
+				["linear"],
+				["zoom"],
+				2, 3,
+				10, 5,
+				14, 9,
+			],
+			"circle-color": [
+				"match",
+				["get", "state"],
+				"Struggling", VILLAGE_STATE_COLORS.Struggling,
+				"Recovering", VILLAGE_STATE_COLORS.Recovering,
+				"Stable", VILLAGE_STATE_COLORS.Stable,
+				"Thriving", VILLAGE_STATE_COLORS.Thriving,
+				VILLAGE_STATE_DEFAULT_COLOR,
+			],
+			"circle-stroke-width": 1.5,
+			"circle-stroke-color": "#fff",
 		},
 	});
 	map.addLayer({

--- a/frontend/src/components/ProgressBar/ProgressBar.module.scss
+++ b/frontend/src/components/ProgressBar/ProgressBar.module.scss
@@ -85,6 +85,10 @@
   background-color: c.$color-error;
 }
 
+.success {
+  background-color: c.$color-status-success;
+}
+
 .paused {
   opacity: 0.5;
 }

--- a/frontend/src/components/TodayPointsBadge/TodayPointsBadge.module.scss
+++ b/frontend/src/components/TodayPointsBadge/TodayPointsBadge.module.scss
@@ -1,0 +1,12 @@
+@use '../../styles/semantic/colors' as c;
+@use '../../styles/semantic/typography' as t;
+@use '../../styles/semantic/spacing' as sp;
+
+.badge {
+  background: c.$color-bg;
+  border: 1px solid c.$color-border-primary;
+  border-radius: sp.$border-radius;
+  padding: 0.25rem 0.6rem;
+  white-space: nowrap;
+  @include t.apply-text-style(t.$text-body);
+}

--- a/frontend/src/components/TodayPointsBadge/TodayPointsBadge.test.tsx
+++ b/frontend/src/components/TodayPointsBadge/TodayPointsBadge.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TodayPointsBadge from './TodayPointsBadge';
+
+const mockUseTodayPoints = vi.fn<() => { data: { points_today: number | null } | undefined }>(
+  () => ({ data: { points_today: 12 } })
+);
+
+vi.mock('../../hooks/usePlayer', () => ({
+  useTodayPoints: () => mockUseTodayPoints(),
+}));
+
+describe('TodayPointsBadge', () => {
+  it("shows the player's points earned today", () => {
+    mockUseTodayPoints.mockReturnValue({ data: { points_today: 12 } });
+
+    render(<TodayPointsBadge />);
+
+    expect(screen.getByText('You contributed 12 today')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the player has no active character link', () => {
+    mockUseTodayPoints.mockReturnValue({ data: { points_today: null } });
+
+    const { container } = render(<TodayPointsBadge />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing (not a zero) while the query has no data yet', () => {
+    mockUseTodayPoints.mockReturnValue({ data: undefined });
+
+    const { container } = render(<TodayPointsBadge />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows zero points as a real value, not treating it as "no link"', () => {
+    mockUseTodayPoints.mockReturnValue({ data: { points_today: 0 } });
+
+    render(<TodayPointsBadge />);
+
+    expect(screen.getByText('You contributed 0 today')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TodayPointsBadge/TodayPointsBadge.tsx
+++ b/frontend/src/components/TodayPointsBadge/TodayPointsBadge.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useTodayPoints } from "../../hooks/usePlayer";
+import styles from "./TodayPointsBadge.module.scss";
+
+// Personal "points earned today" badge for the map view (issue #673) -
+// deliberately not attached to any village marker, and deliberately silent
+// about the player/character link: framed as "you contributed today" rather
+// than naming a character, since players don't yet know about the link.
+// Renders nothing (not a zero) when the player has no active
+// PlayerCharacterLink - see MeViewSet.today_points in api/views.py.
+export default function TodayPointsBadge(): React.ReactElement | null {
+  const { data } = useTodayPoints();
+
+  if (data?.points_today == null) {
+    return null;
+  }
+
+  return (
+    <div className={styles.badge} aria-live="polite" role="status">
+      You contributed {data.points_today} today
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePlayer.ts
+++ b/frontend/src/hooks/usePlayer.ts
@@ -1,6 +1,29 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { updatePlayer, downloadUserData, deleteAccount } from "../api/player";
+import { updatePlayer, downloadUserData, deleteAccount, fetchTodayPoints } from "../api/player";
+import { useAuth } from "../context/AuthContext";
+
+// Query key shared with useActivityInput's refreshAfterActivityChange, which
+// invalidates it after every completed task/session so the map view's
+// "today" badge (issue #673) updates immediately instead of waiting for the
+// next poll.
+export const TODAY_POINTS_QUERY_KEY = ["me", "today-points"];
+
+// Polled lightly (rather than one-shot like other /me/ data) so the badge
+// still rolls over to the new day's value on its own if the map view is left
+// open across midnight, without needing a dedicated push mechanism for that.
+const TODAY_POINTS_POLL_INTERVAL_MS = 60_000;
+
+export function useTodayPoints() {
+  const { isAuthenticated } = useAuth();
+
+  return useQuery({
+    queryKey: TODAY_POINTS_QUERY_KEY,
+    queryFn: fetchTodayPoints,
+    enabled: isAuthenticated,
+    refetchInterval: TODAY_POINTS_POLL_INTERVAL_MS,
+  });
+}
 
 export function useUpdatePlayer() {
   const queryClient = useQueryClient();

--- a/frontend/src/pages/MapPage/MapPage.tsx
+++ b/frontend/src/pages/MapPage/MapPage.tsx
@@ -4,6 +4,7 @@ import Button from "../../components/Button/Button";
 import PopulationCentreMap, {
   type PopulationCentreMapHandle,
 } from "../../components/Map/Map";
+import TodayPointsBadge from "../../components/TodayPointsBadge/TodayPointsBadge";
 import {
   useInitialMapCentre,
   useMapViewport,
@@ -85,6 +86,7 @@ export default function MapPage(): React.ReactElement {
             onViewportChange={setBbox}
             worldBounds={worldBounds?.bbox}
           >
+            <TodayPointsBadge />
             {nextVillage && (
               <Button
                 type="button"

--- a/locations/serializers.py
+++ b/locations/serializers.py
@@ -70,6 +70,8 @@ class PopulationCentreLabelFeatureSerializer(PointFeatureSerializer):
         return {
             "name": obj.name,
             "population_centre_id": obj.id,
+            "progress": obj.progress,
+            "state": obj.state,
         }
 
 

--- a/locations/tests/test_map_serializers.py
+++ b/locations/tests/test_map_serializers.py
@@ -9,6 +9,7 @@ from ..models import Building, LandArea, PopulationCentre, Subzone
 from ..serializers import (
     BuildingFeatureSerializer,
     CharacterPointFeatureSerializer,
+    PopulationCentreLabelFeatureSerializer,
     SubzoneFeatureSerializer,
 )
 
@@ -185,3 +186,51 @@ class SubzoneFeatureSerializerTest(TestCase):
         props = self.properties()
         self.assertEqual(props["crop_stage"], "ready")
         self.assertIsNone(props["crop_progress"])
+
+
+class PopulationCentreLabelFeatureSerializerTest(TestCase):
+    """
+    The marker feature MapViewportView sends for each village on the
+    cross-village map (see issue #673) - needs state/progress alongside the
+    name/id it already carried, so the frontend can colour each marker by
+    state without an extra per-village fetch.
+    """
+
+    def setUp(self):
+        self.centre = PopulationCentre.objects.create(
+            name="Testville", location=Point(0, 0, srid=3857)
+        )
+
+    def properties(self):
+        return PopulationCentreLabelFeatureSerializer(self.centre).data["properties"]
+
+    def test_includes_state_and_progress_with_no_residents(self):
+        props = self.properties()
+        self.assertEqual(props["name"], "Testville")
+        self.assertEqual(props["population_centre_id"], self.centre.id)
+        self.assertEqual(props["state"], "Struggling")
+        self.assertEqual(props["progress"], 0)
+
+    def test_reflects_village_points_derived_state(self):
+        from character.models import Character, PlayerCharacterLink
+        from users.models import CustomUser
+
+        resident = Character.objects.create(
+            first_name="Res", last_name="Ident", population_centre=self.centre
+        )
+        user = CustomUser.objects.create_user(email="villager@example.com", password="x")
+        # Deactivate the auto-assigned link/character so only `resident`
+        # (with a controllable link_points via days_linked) counts here.
+        for link in PlayerCharacterLink.objects.filter(player=user.player, is_active=True):
+            link.unlink()
+        link = PlayerCharacterLink.objects.create(player=user.player, character=resident)
+        link.linked_at = timezone.now() - timezone.timedelta(days=10)
+        link.save(update_fields=["linked_at"])
+
+        # village_points is a cached_property read fresh per PopulationCentre
+        # instance, so re-fetch rather than reuse self.centre.
+        centre = PopulationCentre.objects.get(pk=self.centre.pk)
+        props = PopulationCentreLabelFeatureSerializer(centre).data["properties"]
+
+        self.assertEqual(props["state"], centre.state)
+        self.assertEqual(props["progress"], centre.progress)


### PR DESCRIPTION
## Summary

Closes #673.

- Each `PopulationCentre` marker on the multi-village map now shows an icon/color coded to its `state` (Struggling/Recovering/Stable/Thriving); tapping/selecting a marker expands it into that village's `progress` bar + `state` label.
- Added a persistent "today" points badge on the map view: `you contributed N today`, using a new date-filtered `PlayerCharacterLink.points_today` (mirrors `player_time`/`link_points`, scoped to today's completed activities). The badge is hidden entirely — not shown as zero — for players with no active `PlayerCharacterLink`, and updates immediately after completing an activity (no page reload) via query invalidation.
- `village_points`, `progress`, `state`, and `village_multiplier` are unchanged, as required by the issue.

## Design notes / open questions (flagged per the issue, not resolved unilaterally)

The issue explicitly leaves several presentation choices open. I picked reasonable placeholders so the feature is usable, but these are worth a design pass:
- **Marker icon/colour set**: used a 4-colour palette (red/orange/blue-green/dark-green) mirroring `ProgressBar`'s existing `danger`/`warning`/`default`/`success` classes, added a `.success` variant to `ProgressBar.module.scss` for this.
- **Badge copy/visual treatment**: plain text `"You contributed {N} today"`, no animation on increment.
- **Daily reset boundary**: implemented as UTC midnight, consistent with the existing `completed_at__date=timezone.now().date()` convention elsewhere in the codebase (`TIME_ZONE = "UTC"`).

## Backend

- `character/models/character.py`: `PlayerCharacterLink.player_time_today` / `points_today` — today-only variant of `player_time`/`link_points`, bounded by `max(start_of_today, linked_at)`.
- `api/views.py`: `MeViewSet.today_points` (`GET /me/today_points/`) returns `{"points_today": int | null}` — `null` (not `0`) when the player has no active link, so the frontend can distinguish "no link" from "linked, nothing earned yet."
- `locations/serializers.py`: `PopulationCentreLabelFeatureSerializer` now includes `state`/`progress` (both pre-existing model properties) so the cross-village map marker can be coloured without an extra per-village fetch.

## Frontend

- `components/Map/layers.ts`: new `village-marker` circle layer, coloured via a `state` match expression.
- `components/Map/MapTooltips.tsx`: `PopulationCentreTooltipContent` (name + `ProgressBar` + state label) for the expanded marker view.
- `components/Map/Map.tsx`: click/hover wiring for the new marker layer.
- `components/TodayPointsBadge/`: the "today" badge component + `usePlayer.ts`'s `useTodayPoints()` query hook (polls lightly so it also rolls over at the day boundary if left open).
- `components/ActivityInput/useActivityInput.ts`: invalidates the today-points query in `refreshAfterActivityChange`, alongside the existing player/character/activities refresh, so the badge updates immediately after a completed task/session.

## Test plan

- [x] Backend: `character.tests.test_models.PlayerCharacterLinkPointsTodayTests`, `api.tests.TestMeViewSet` (today-points cases), `locations.tests.test_map_serializers.PopulationCentreLabelFeatureSerializerTest` — plus the full `character`, `api`, `locations` app suites (180 tests) for regressions.
- [x] Frontend: new `Map.test.tsx` cases (marker colouring + tap-to-expand), new `TodayPointsBadge.test.tsx`, new `useActivityInput.test.ts` case for query invalidation — plus the full `vitest run` suite (407 tests) for regressions.
- [x] `npm run lint` / `tsc --noEmit` / `npm run build:production` — no new errors introduced (pre-existing lint/type issues in untouched code confirmed via `git stash` diff).
- [ ] Manual verification in a running app (no browser available in this session) — worth a once-over before merge, especially the marker's visual density on a multi-village viewport.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017Tyh7dBiqNRgZy1wgR8xxs)_