### PR TITLE
Migrate react-router-dom -> react-router 8.x (GHSA-qwww-vcr4-c8h2)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,7 @@
         "react-dom": "^19.2.0",
         "react-error-boundary": "^6.0.0",
         "react-ga4": "^2.1.0",
-        "react-router-dom": "^7.18.0",
+        "react-router": "^8.3.0",
         "uuid": "^14.0.0",
         "vite": "^8.0.16",
         "wscat": "^6.1.0"
@@ -5317,18 +5317,11 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -8166,41 +8159,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
-      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {
@@ -8453,12 +8429,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^19.2.0",
     "react-error-boundary": "^6.0.0",
     "react-ga4": "^2.1.0",
-    "react-router-dom": "^7.18.0",
+    "react-router": "^8.3.0",
     "uuid": "^14.0.0",
     "vite": "^8.0.16",
     "wscat": "^6.1.0"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { ToastProvider } from './context/ToastContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { GameProvider } from './context/GameContext';
 import { OnlineCountProvider } from './context/OnlineCountContext';
-import { BrowserRouter, useLocation } from 'react-router-dom';
+import { BrowserRouter, useLocation } from 'react-router';
 import { WebSocketProvider } from './context/WebSocketContext';
 
 import MaintenanceWatcher from './components/MaintenanceWatcher';

--- a/frontend/src/AppContent.tsx
+++ b/frontend/src/AppContent.tsx
@@ -1,6 +1,6 @@
 // src/AppContent.tsx
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import Navbar from './layout/Navbar/Navbar';
 import NavDrawer from './layout/NavDrawer/NavDrawer';
 import StaticBanner from './components/StaticBanner/StaticBanner';

--- a/frontend/src/components/MaintenanceWatcher.test.tsx
+++ b/frontend/src/components/MaintenanceWatcher.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, render } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import MaintenanceWatcher from "./MaintenanceWatcher";
 import { MaintenanceProvider, useMaintenanceContext } from "../context/MaintenanceContext";

--- a/frontend/src/components/MaintenanceWatcher.tsx
+++ b/frontend/src/components/MaintenanceWatcher.tsx
@@ -1,6 +1,6 @@
 // components/MaintenanceWatcher.tsx
 import React, { useEffect, useRef } from "react";
-import { useNavigate, Navigate, useLocation } from "react-router-dom";
+import { useNavigate, Navigate, useLocation } from "react-router";
 import { useMaintenanceContext } from "../context/MaintenanceContext";
 import { setMaintenanceHandler, setNetworkErrorHandler } from "../utils/api";
 

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,6 +1,6 @@
 // PrivateRoute.tsx
 import React from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useAuth } from '../context/AuthContext';
 
 interface PrivateRouteProps {

--- a/frontend/src/components/TasksPanel/TasksPanel.test.tsx
+++ b/frontend/src/components/TasksPanel/TasksPanel.test.tsx
@@ -35,7 +35,7 @@ vi.mock("../../hooks/useTasks", () => ({
   useDeleteTask: () => mockUseDeleteTask(),
 }));
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
   useNavigate: () => navigate,
 }));
 

--- a/frontend/src/components/TasksPanel/useTasksPanel.tsx
+++ b/frontend/src/components/TasksPanel/useTasksPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { useTasks, useCreateTask, useUpdateTask, useDeleteTask } from "../../hooks/useTasks";
 import { useGame } from "../../hooks/useGame";

--- a/frontend/src/hooks/usePlayer.ts
+++ b/frontend/src/hooks/usePlayer.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { updatePlayer, downloadUserData, deleteAccount, fetchTodayPoints } from "../api/player";
 import { useAuth } from "../context/AuthContext";
 

--- a/frontend/src/layout/Footer/Footer.tsx
+++ b/frontend/src/layout/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useAuth } from "../../context/AuthContext";
 import styles from "./Footer.module.scss";
 import { API_BASE_URL } from "../../config";

--- a/frontend/src/layout/NavDrawer/NavDrawer.test.tsx
+++ b/frontend/src/layout/NavDrawer/NavDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import NavDrawer from "./NavDrawer";
 

--- a/frontend/src/layout/NavDrawer/NavDrawer.tsx
+++ b/frontend/src/layout/NavDrawer/NavDrawer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import styles from "./NavDrawer.module.scss";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useAuth } from "../../context/AuthContext";
 import { useFeatureFlag } from "../../hooks/useFeatureFlag";
 

--- a/frontend/src/layout/Navbar/Navbar.test.tsx
+++ b/frontend/src/layout/Navbar/Navbar.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import Navbar from "./Navbar";
 

--- a/frontend/src/layout/Navbar/Navbar.tsx
+++ b/frontend/src/layout/Navbar/Navbar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useLocation, Link } from "react-router-dom";
+import { useLocation, Link } from "react-router";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as Popover from "@radix-ui/react-popover";
 import * as Accordion from "@radix-ui/react-accordion";

--- a/frontend/src/layout/Player/PlayerContent.tsx
+++ b/frontend/src/layout/Player/PlayerContent.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "./PlayerContent.module.scss";
 import FeatureToggle from "../../components/FeatureToggle";
 import ActivityList from "../ActivityList/ActivityList";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 // PlayerContent accepts arbitrary props and forwards them to ActivityList.
 // The props are not formally typed here because ActivityList itself accepts none —

--- a/frontend/src/pages/Account/Account.test.tsx
+++ b/frontend/src/pages/Account/Account.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/pages/Account/useAccountPage.ts
+++ b/frontend/src/pages/Account/useAccountPage.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useMutation } from "@tanstack/react-query";
 
 import { useGame } from "../../hooks/useGame";

--- a/frontend/src/pages/CancelPage.tsx
+++ b/frontend/src/pages/CancelPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export default function CancelPage(): React.ReactElement {
   return (

--- a/frontend/src/pages/ConfirmationPage.tsx
+++ b/frontend/src/pages/ConfirmationPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { useAuth } from "../context/AuthContext";
 import { API_BASE_URL } from "../config";
 

--- a/frontend/src/pages/EditAccount/EditAccount.tsx
+++ b/frontend/src/pages/EditAccount/EditAccount.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import styles from "./EditAccount.module.scss";
 
 export default function EditAccount(): React.ReactElement {

--- a/frontend/src/pages/Home/Home.test.tsx
+++ b/frontend/src/pages/Home/Home.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import Home from './Home';
 
@@ -37,8 +37,8 @@ vi.mock('../../hooks/useRegistrationStatus', () => ({
   useRegistrationStatus: () => mockUseRegistrationStatus(),
 }));
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import BackToTopButton from '../../components/BackToTopButton/BackToTopButton';
 import Button from '../../components/Button/Button';
 import Seo from '../../components/Seo/Seo';

--- a/frontend/src/pages/Home/useHomePage.ts
+++ b/frontend/src/pages/Home/useHomePage.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useId, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { useAuth } from "../../context/AuthContext";
 import { trackEvent } from "../../utils/analytics";

--- a/frontend/src/pages/LoginPage/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -20,8 +20,8 @@ vi.mock("../../context/AuthContext", () => ({
   }),
 }));
 
-vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual("react-router-dom");
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import useLogin from '../../hooks/useLogin';
 import { useAuth } from '../../context/AuthContext';
 import Form from '../../components/Form/Form';

--- a/frontend/src/pages/LogoutPage/LogoutPage.tsx
+++ b/frontend/src/pages/LogoutPage/LogoutPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useAuth } from '../../context/AuthContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useWebSocket } from '../../hooks/useWebSocket';
 
 export default function LogoutPage(): React.ReactElement {

--- a/frontend/src/pages/MaintenancePage/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage/MaintenancePage.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import styles from './MaintenancePage.module.scss';
 import { useMaintenanceStatus } from '../../hooks/useMaintenanceStatus';
 import { useMaintenanceContext } from '../../context/MaintenanceContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Button from '../../components/Button/Button';
 import ButtonFrame from '../../components/Button/ButtonFrame';
 

--- a/frontend/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import Button from "../../components/Button/Button";
 import styles from "./NotFoundPage.module.scss";
 

--- a/frontend/src/pages/PasswordResetConfirmPage/PasswordResetConfirmPage.test.tsx
+++ b/frontend/src/pages/PasswordResetConfirmPage/PasswordResetConfirmPage.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import PasswordResetConfirmPage from './PasswordResetConfirmPage';
 
 describe('PasswordResetConfirmPage', () => {

--- a/frontend/src/pages/PasswordResetConfirmPage/PasswordResetConfirmPage.tsx
+++ b/frontend/src/pages/PasswordResetConfirmPage/PasswordResetConfirmPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import Form from '../../components/Form/Form';
 import usePasswordReset from '../../hooks/usePasswordReset';
 import styles from '../PasswordResetPage.module.scss';

--- a/frontend/src/pages/PasswordResetRequestPage/PasswordResetRequestPage.test.tsx
+++ b/frontend/src/pages/PasswordResetRequestPage/PasswordResetRequestPage.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import PasswordResetRequestPage from './PasswordResetRequestPage';
 
 describe('PasswordResetRequestPage', () => {

--- a/frontend/src/pages/PasswordResetRequestPage/PasswordResetRequestPage.tsx
+++ b/frontend/src/pages/PasswordResetRequestPage/PasswordResetRequestPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Form from '../../components/Form/Form';
 import usePasswordReset from '../../hooks/usePasswordReset';
 import styles from '../PasswordResetPage.module.scss';

--- a/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { MemoryRouter, Routes, Route } from "react-router";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 

--- a/frontend/src/pages/RegisterPage/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router';
 import Form from '../../components/Form/Form';
 import Input from '../../components/Input/Input';
 import Turnstile from '../../components/Turnstile/Turnstile';

--- a/frontend/src/pages/SuccessPage.tsx
+++ b/frontend/src/pages/SuccessPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 import { apiFetch } from "../utils/api";
 import { useGame } from "../hooks/useGame";
 import Button from "../components/Button/Button";

--- a/frontend/src/pages/TermsOfServicePage/TermsOfServicePage.tsx
+++ b/frontend/src/pages/TermsOfServicePage/TermsOfServicePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styles from '../LegalPage/LegalPage.module.scss';
 import BackToTopButton from '../../components/BackToTopButton/BackToTopButton';
 

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route } from "react-router";
 import { routes } from "./routesConfig";
 
 function AppRoutes() {

--- a/frontend/src/routes/routesConfig.jsx
+++ b/frontend/src/routes/routesConfig.jsx
@@ -1,5 +1,5 @@
 import React, { lazy } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import FeatureToggle from "../components/FeatureToggle";
 
 // Lazy load pages


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert [#228](https://github.com/progressrpg/ProgressRPG/security/dependabot/228) (GHSA-qwww-vcr4-c8h2, high severity) by moving off `react-router-dom` (which pulls in the vulnerable `react-router@7.18.x` transitively and has not published an 8.x release) onto `react-router@^8.3.0` directly, per the [official migration guide](https://reactrouter.com/upgrading/v7).
- Updated every import across `frontend/src` (routes, hooks, components, tests) from `react-router-dom` to `react-router` — all APIs used here (`BrowserRouter`, `Routes`, `Route`, `Link`, `useNavigate`, `useParams`, `useLocation`, `useSearchParams`, `Navigate`, `MemoryRouter`) are exported directly from the `react-router` root entry point for a non-RSC Vite SPA, so no API renames were needed beyond the import specifier.
- Confirmed the app doesn't use `RouterProvider`, `HydratedRouter`, or `createBrowserRouter` (the only APIs that moved to `react-router/dom` in v8), and doesn't reference any removed `future.*` flags.
- Regenerated `package-lock.json` via `npm install`.

## Test plan
- [x] `npm run lint` — pre-existing errors unrelated to this change (verified identical count/content on `development`)
- [x] `npx vitest run` — 407/407 tests passed (1 unrelated environment error from Storybook's browser-mode tests needing a Playwright browser variant not installed in this sandbox)
- [x] `npm run build:production` — production build succeeds
- [x] Manual smoke test: ran the Vite dev server, loaded the app in a headless browser, and navigated between routes (home, `/login`) — no module resolution or routing errors in console, pages render and `Link` navigation works correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCoC76q2hXmYNp871cbZvJ)_