### PR TITLE
Extract beforeunload guard out of useActivityTimer

### DIFF
--- a/frontend/src/context/GameContext.tsx
+++ b/frontend/src/context/GameContext.tsx
@@ -6,6 +6,7 @@ import { useBootstrapGameData } from '../hooks/useBootstrapGameData';
 import { useEventCallback } from '../hooks/useEventCallback';
 import { apiFetch } from "../utils/api";
 import useActivityTimer from '../hooks/useActivityTimer';
+import useUnloadWarning from '../hooks/useUnloadWarning';
 import { useAuth } from './AuthContext';
 import { GameContext, type GameContextValue } from './gameContext';
 import type {
@@ -81,6 +82,8 @@ export const GameProvider = ({ children }: ProviderProps): ReactElement => {
 
   const activityTimer = useActivityTimer();
   const { loadFromServer } = activityTimer;
+
+  useUnloadWarning(activityTimer.status === 'active');
 
 
   // ----------------------------------------

--- a/frontend/src/hooks/useActivityTimer.ts
+++ b/frontend/src/hooks/useActivityTimer.ts
@@ -333,14 +333,6 @@ export default function useActivityTimer(): ActivityTimerReturn {
   // ----------------------------
 
 
-  // Block tab close / refresh / external navigation while timer is active
-  useEffect(() => {
-    if (status !== 'active') return;
-    const handler = (e: BeforeUnloadEvent): void => { e.preventDefault(); e.returnValue = ''; };
-    window.addEventListener('beforeunload', handler);
-    return () => window.removeEventListener('beforeunload', handler);
-  }, [status]);
-
   // Cleanup on unmount
   useEffect(() => {
     //console.log(`[useActivityTimer] mounted`);

--- a/frontend/src/hooks/useUnloadWarning.test.tsx
+++ b/frontend/src/hooks/useUnloadWarning.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import useUnloadWarning from './useUnloadWarning';
+
+describe('useUnloadWarning', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers a beforeunload handler while active and removes it on deactivation', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { rerender } = renderHook(({ active }) => useUnloadWarning(active), {
+      initialProps: { active: true },
+    });
+
+    expect(addSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+
+    rerender({ active: false });
+
+    expect(removeSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('does not register a handler when inactive', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+
+    renderHook(() => useUnloadWarning(false));
+
+    expect(addSpy).not.toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('prevents default and clears returnValue on the beforeunload event', () => {
+    renderHook(() => useUnloadWarning(true));
+
+    const event = new Event('beforeunload') as BeforeUnloadEvent;
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+    window.dispatchEvent(event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(event.returnValue).toBe('');
+  });
+});

--- a/frontend/src/hooks/useUnloadWarning.ts
+++ b/frontend/src/hooks/useUnloadWarning.ts
@@ -1,0 +1,18 @@
+// hooks/useUnloadWarning.ts
+import { useEffect } from "react";
+
+// Warns the user before closing/refreshing/navigating away from the tab
+// while `active` is true. No-op when `window` isn't available (e.g. native).
+export default function useUnloadWarning(active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+    if (typeof window === "undefined") return;
+
+    const handler = (e: BeforeUnloadEvent): void => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [active]);
+}


### PR DESCRIPTION
## Summary

`useActivityTimer` had one browser-only dependency: a `beforeunload` listener that warns the user before closing the tab mid-activity. This extracts it into a new, web-only `useUnloadWarning(active)` hook so the timer hook itself is platform-neutral (zero `window` references), per #572.

- Added `frontend/src/hooks/useUnloadWarning.ts`: takes `active: boolean`, registers/unregisters a `beforeunload` handler, and is a no-op when `window` is unavailable.
- Removed the `beforeunload` `useEffect` from `frontend/src/hooks/useActivityTimer.ts`.
- Wired `useUnloadWarning(activityTimer.status === 'active')` into `frontend/src/context/GameContext.tsx`, which owns the timer.
- Added `frontend/src/hooks/useUnloadWarning.test.tsx` covering registration/teardown and the `preventDefault`/`returnValue` behavior.

## Acceptance criteria

- [x] No `window` reference remains in `useActivityTimer.ts`
- [x] The browser still warns on tab close / refresh while an activity timer is `active`, and does not warn when it isn't (now driven from `GameContext`)
- [x] The extracted hook is a no-op (not a crash) in an environment without `window`
- [x] `useActivityTimer.test.tsx` still passes

## Test plan

- [x] `npx vitest run` — 410 tests pass (pre-existing Playwright browser-launch error is unrelated to this change)
- [x] `npx tsc --noEmit` — no errors
- [x] `npx eslint` on changed files — no new errors (pre-existing `react-hooks/set-state-in-effect` errors in `GameContext.tsx`/`useBootstrapGameData.ts` predate this change)

Fixes #572

---
⚠️ Per the issue notes, this touches the timer hook, which is in-flight redesign territory (#569). The change here is small and additive.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fg56v9v8eCtj6XLKqRi9X2)_