### PR TITLE
Move DOM event handling out of useEntitySearchInput into its component

### DIFF
--- a/frontend/src/components/EntitySearchInput/EntitySearchInput.tsx
+++ b/frontend/src/components/EntitySearchInput/EntitySearchInput.tsx
@@ -1,4 +1,5 @@
-import type { CSSProperties } from "react";
+import { useEffect, useRef } from "react";
+import type { CSSProperties, KeyboardEvent } from "react";
 import classNames from "classnames";
 
 import { useEntitySearchInput, type SearchEntity } from "./useEntitySearchInput";
@@ -44,7 +45,6 @@ export default function EntitySearchInput({
   emptyMessage,
 }: EntitySearchInputProps) {
   const {
-    rootRef,
     canSearch,
     taskItems,
     activityItems,
@@ -53,8 +53,11 @@ export default function EntitySearchInput({
     activeHighlightedIndex,
     handleInputFocus,
     handleInputChange,
-    handleKeyDown,
     commitSelection,
+    onSelectNext,
+    onSelectPrevious,
+    onDismiss,
+    onCommit,
   } = useEntitySearchInput({
     type,
     value,
@@ -67,6 +70,45 @@ export default function EntitySearchInput({
     alwaysOpen,
     maxVisibleRows,
   });
+
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Dismiss on outside click — the hook exposes the semantic action, this
+  // component owns the DOM listener that detects the gesture.
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        onDismiss();
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [onDismiss]);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) return;
+
+    switch (event.key) {
+      case "ArrowDown":
+        if (isDropdownOpen) event.preventDefault();
+        onSelectNext();
+        return;
+      case "ArrowUp":
+        if (isDropdownOpen) event.preventDefault();
+        onSelectPrevious();
+        return;
+      case "Escape":
+        if (isDropdownOpen) event.preventDefault();
+        onDismiss();
+        return;
+      case "Enter":
+        if (onCommit()) event.preventDefault();
+        return;
+      default:
+        return;
+    }
+  };
 
   const renderOption = (entity: SearchEntity, index: number) => {
     const isHighlighted = index === activeHighlightedIndex;

--- a/frontend/src/components/EntitySearchInput/useEntitySearchInput.ts
+++ b/frontend/src/components/EntitySearchInput/useEntitySearchInput.ts
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Fuse from "fuse.js";
 
 import { useEntitySearchCache } from "../../hooks/useEntitySearchCache";
@@ -63,11 +62,11 @@ function useEntitySearchResults({
   );
 
   useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       setDebouncedQuery(value);
     }, DEBOUNCE_MS);
 
-    return () => window.clearTimeout(timeoutId);
+    return () => clearTimeout(timeoutId);
   }, [value]);
 
   const fuse = useMemo(
@@ -162,27 +161,21 @@ function useEntitySearchResults({
   };
 }
 
-function useEntitySearchDropdown(rootRef: React.RefObject<HTMLDivElement | null>) {
+function useEntitySearchDropdown() {
   const [isFocused, setIsFocused] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
 
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setIsFocused(false);
-        setHighlightedIndex(-1);
-      }
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [rootRef]);
+  const dismiss = useCallback(() => {
+    setIsFocused(false);
+    setHighlightedIndex(-1);
+  }, []);
 
   return {
     isFocused,
     setIsFocused,
     highlightedIndex,
     setHighlightedIndex,
+    dismiss,
   };
 }
 
@@ -198,13 +191,12 @@ export function useEntitySearchInput({
   alwaysOpen = false,
   maxVisibleRows,
 }: UseEntitySearchInputProps) {
-  const rootRef = useRef<HTMLDivElement>(null);
   const { entities, addEntityToCache } = useEntitySearchCache(type);
 
   const canSearch = searchEnabled && !disabled;
 
-  const { isFocused, setIsFocused, highlightedIndex, setHighlightedIndex } =
-    useEntitySearchDropdown(rootRef);
+  const { isFocused, setIsFocused, highlightedIndex, setHighlightedIndex, dismiss } =
+    useEntitySearchDropdown();
 
   const { results, taskItems, activityItems } = useEntitySearchResults({
     entities,
@@ -225,10 +217,9 @@ export function useEntitySearchInput({
     (entity: SearchEntity) => {
       onChange?.(entity.name);
       onSelect?.(entity);
-      setIsFocused(false);
-      setHighlightedIndex(-1);
+      dismiss();
     },
-    [onChange, onSelect, setHighlightedIndex, setIsFocused]
+    [onChange, onSelect, dismiss]
   );
 
   const commitCreate = useCallback(async () => {
@@ -238,9 +229,8 @@ export function useEntitySearchInput({
     addEntityToCache(nextName);
     onChange?.(nextName);
     await onCreate?.(nextName);
-    setIsFocused(false);
-    setHighlightedIndex(-1);
-  }, [addEntityToCache, onChange, onCreate, setHighlightedIndex, setIsFocused, value]);
+    dismiss();
+  }, [addEntityToCache, onChange, onCreate, dismiss, value]);
 
   const handleInputFocus = useCallback(() => {
     setIsFocused(true);
@@ -253,73 +243,49 @@ export function useEntitySearchInput({
     [onChange]
   );
 
-  const handleKeyDown = useCallback(
-    async (event: KeyboardEvent<HTMLInputElement>) => {
-      if (disabled) return;
+  /** Move the highlight to the next result, wrapping to the top. No-op while closed. */
+  const onSelectNext = useCallback(() => {
+    if (!isDropdownOpen) return;
+    setHighlightedIndex(activeHighlightedIndex < results.length - 1 ? activeHighlightedIndex + 1 : 0);
+  }, [activeHighlightedIndex, isDropdownOpen, results.length, setHighlightedIndex]);
 
-      if (event.key === "ArrowDown" && isDropdownOpen) {
-        event.preventDefault();
-        setHighlightedIndex(
-          activeHighlightedIndex < results.length - 1 ? activeHighlightedIndex + 1 : 0
-        );
-        return;
-      }
+  /** Move the highlight to the previous result, wrapping to the bottom. No-op while closed. */
+  const onSelectPrevious = useCallback(() => {
+    if (!isDropdownOpen) return;
+    setHighlightedIndex(activeHighlightedIndex > 0 ? activeHighlightedIndex - 1 : results.length - 1);
+  }, [activeHighlightedIndex, isDropdownOpen, results.length, setHighlightedIndex]);
 
-      if (event.key === "ArrowUp" && isDropdownOpen) {
-        event.preventDefault();
-        setHighlightedIndex(
-          activeHighlightedIndex > 0 ? activeHighlightedIndex - 1 : results.length - 1
-        );
-        return;
-      }
+  /** Close the dropdown and clear the highlight, e.g. on Escape or an outside click/tap. */
+  const onDismiss = useCallback(() => {
+    dismiss();
+  }, [dismiss]);
 
-      if (event.key === "Escape") {
-        if (isDropdownOpen) {
-          event.preventDefault();
-        }
-        setIsFocused(false);
-        setHighlightedIndex(-1);
-        return;
-      }
+  /**
+   * Commit the highlighted result, or create a new entity from the typed
+   * value when nothing is highlighted. Returns whether it took action, so
+   * callers translating a "commit" gesture (e.g. Enter) know whether to
+   * suppress its default behaviour.
+   */
+  const onCommit = useCallback(() => {
+    if (!canSearch) return false;
 
-      if (event.key !== "Enter") return;
+    const hasHighlightedResult =
+      isDropdownOpen && activeHighlightedIndex >= 0 && activeHighlightedIndex < results.length;
 
-      if (!canSearch) {
-        return;
-      }
+    if (hasHighlightedResult) {
+      commitSelection(results[activeHighlightedIndex]);
+      return true;
+    }
 
-      const hasHighlightedResult =
-        isDropdownOpen &&
-        activeHighlightedIndex >= 0 &&
-        activeHighlightedIndex < results.length;
+    if (normalizeQuery(value)) {
+      void commitCreate();
+      return true;
+    }
 
-      if (hasHighlightedResult) {
-        event.preventDefault();
-        commitSelection(results[activeHighlightedIndex]);
-        return;
-      }
-
-      if (normalizeQuery(value)) {
-        event.preventDefault();
-        await commitCreate();
-      }
-    },
-    [
-      activeHighlightedIndex,
-      canSearch,
-      commitCreate,
-      commitSelection,
-      disabled,
-      isDropdownOpen,
-      results,
-      setHighlightedIndex,
-      setIsFocused,
-      value,
-    ]
-  );
+    return false;
+  }, [activeHighlightedIndex, canSearch, commitCreate, commitSelection, isDropdownOpen, results, value]);
 
   return {
-    rootRef,
     canSearch,
     results,
     taskItems,
@@ -327,10 +293,12 @@ export function useEntitySearchInput({
     showGroupLabels,
     isDropdownOpen,
     activeHighlightedIndex,
-    highlightedIndex,
     handleInputFocus,
     handleInputChange,
-    handleKeyDown,
     commitSelection,
+    onSelectNext,
+    onSelectPrevious,
+    onDismiss,
+    onCommit,
   };
 }


### PR DESCRIPTION
## Summary

`useEntitySearchInput` was named and positioned as a logic hook, but it reached into the DOM directly for click-outside dismissal and typed its keydown handler against DOM element interfaces. This splits it along the platform boundary, per #573.

- **Stays in the hook** (portable): fuzzy search via `fuse.js`, result derivation, selection state, the debounce, and the semantic intent of keyboard actions — now exposed as `onSelectNext`, `onSelectPrevious`, `onDismiss`, `onCommit` instead of a DOM-typed `handleKeyDown`. `onCommit` returns whether it took action, so the caller knows whether to suppress the key's default behaviour.
- **Moved to `EntitySearchInput.tsx`** (web): the `document` mousedown listener for click-outside dismissal (component now owns `rootRef` and calls `onDismiss()`), and translation of raw `KeyboardEvent`s into the hook's semantic actions.
- `window.setTimeout` / `window.clearTimeout` → bare `setTimeout` / `clearTimeout`.

This branch is stacked on #680 (extracting the `beforeunload` guard out of `useActivityTimer`), since both are part of the #569 DOM-decoupling epic and this one was started from that branch.

## Acceptance criteria

- [x] No `document` or `window` reference remains in `useEntitySearchInput.ts`
- [x] No DOM-element-typed parameters (`HTMLInputElement`, `KeyboardEvent`) in the hook's public surface
- [x] Clicking outside still dismisses the dropdown
- [x] Keyboard behaviour is unchanged: arrow-key selection, Enter to commit, Escape to dismiss
- [x] Debounce timing behaviour is unchanged
- [x] `EntitySearchInput.test.tsx` still passes

## Test plan

- [x] `npx tsc --noEmit` — no errors
- [x] `npx eslint src/components/EntitySearchInput/` — no errors
- [x] `npx vitest run` — 410/410 pass (pre-existing Playwright browser-launch error is unrelated to this change)

Fixes #573

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPE61e7gP3d7PWrGxWg3BC)_