### PR TITLE
Rebase: unified timer Doing/Planning mode + task due dates/subtasks

### DIFF
--- a/.claude/plans/task-due-date-and-subtasks-plan.md
+++ b/.claude/plans/task-due-date-and-subtasks-plan.md
@@ -1,0 +1,165 @@
+# Extend Task model: due date + parent/child subtasks
+
+## Context
+
+Tasks now live inside the timer's Planning mode (`UnifiedTimerHome` → `TasksPanel`, see the unified-timer-task-mode work), and the next step is making the Task model richer: a due date, and the ability to break a task into subtasks. This plan adds both end-to-end — backend model/API through to a fully nested subtask UI — since `PlayerItemList` (the shared list component behind `TasksPanel` and `ProjectsPanel`) currently has zero grouping/nesting support, and building it now unblocks subtasks rendering as an actual indented tree rather than a flat annotated list.
+
+`UnifiedTimerHome` already renders `<TasksPanel />` directly and unmodified inside Planning mode (from the prior mode-switch work) — since this plan extends `TasksPanel`/`useTasksPanel` in place rather than forking them, every capability added here (due-date editing, the parent picker, the "add subtask" row action, nested subtask rendering) is automatically available from Planning mode too, with no separate integration step.
+
+Decisions already confirmed with the user:
+- **Due date**: one field, `due_at` (DateTimeField), not separate date/time fields — matches the codebase's existing convention (every date/time field in the app is a DateTimeField; no bare DateField anywhere; closest precedent is `CharacterActivity.scheduled_start`/`scheduled_end`). Displayed as a single `datetime-local` input.
+- **Subtasks**: single level only — a task with a `parent` cannot itself have subtasks (enforced server-side). No arbitrary-depth trees, no cycle detection needed beyond "reject nesting a subtask under a subtask."
+- **Parent deletion**: cascades — deleting a parent deletes its subtasks (`on_delete=CASCADE`).
+- **fetchTasks pagination bug**: `frontend/src/api/tasks.ts`'s `fetchTasks()` only fetches page 1 today. This must be fixed as a prerequisite — subtask grouping needs the full flat list, and a parent on page 2+ would silently lose its children in the UI otherwise.
+- **Add-subtask flow**: a row action on a top-level task pre-fills the existing "add task" form with that task as the parent (one creation code path, no separate dialog).
+- **Hide-complete rule**: parent-scoped — a completed parent (and all its subtasks, regardless of their own status) disappears as one unit when "Hide complete" is on; an incomplete, visible parent shows each subtask independently based on its own completion.
+- **Overdue styling**: minimal — red/warning style on the due-date meta text when `due_at` is in the past and the task isn't complete.
+- **Rollup**: a parent task's `total_time` must include its subtasks' time, not just its own directly-linked activities (a parent is a container for its children's work as well as any of its own). `total_records` stays own-only (not requested) — flagged explicitly below so this isn't silently extended beyond what was asked.
+
+---
+
+## Backend
+
+### 1. Model (`progression/models.py`, `Task` class, ~line 648)
+
+```python
+due_at = models.DateTimeField(null=True, blank=True)
+parent = models.ForeignKey(
+    "self", on_delete=models.CASCADE, related_name="subtasks",
+    null=True, blank=True,
+)
+```
+
+Add `Task.clean()` as the single source of validation truth:
+
+```python
+def clean(self):
+    super().clean()
+    if self.parent_id is None:
+        return
+    if self.parent_id == self.id:
+        raise ValidationError({"parent": "A task cannot be its own parent."})
+    if self.parent.parent_id is not None:
+        raise ValidationError({"parent": "Cannot nest more than one level deep."})
+    if self.parent.player_id != self.player_id:
+        raise ValidationError({"parent": "Parent task must belong to the same player."})
+    if self.pk and self.subtasks.exists():
+        raise ValidationError({"parent": "A task with subtasks cannot itself have a parent."})
+```
+
+Update the existing `total_time` property to roll up subtasks' time. Since nesting is single-level (a subtask can never have its own subtasks), this needs no recursion — just add each direct child's own `total_time`:
+
+```python
+@property
+def total_time(self):
+    own_total = (
+        self.records.filter(is_complete=True).aggregate(total=Sum("duration"))["total"]
+        or 0
+    )
+    children_total = sum(child.total_time for child in self.subtasks.all())
+    return own_total + children_total
+```
+
+`total_records` is intentionally left own-only (not requested) — a parent's `total_records` still counts only its own directly-linked activity records, not its subtasks'. The serializer needs no change: `total_time` is already exposed via `serializers.IntegerField(read_only=True)` reading the model property directly, so the rollup flows through automatically once the property changes, and so does the frontend display (`formatRewardDuration(task.total_time)` in `TasksPanel.tsx`) with no changes needed there either.
+
+### 2. Serializer (`progression/serializers.py`, `TaskSerializer`, ~line 207)
+
+- Add `due_at`, `parent` to `Meta.fields` (read-write).
+- Add `subtask_count = serializers.IntegerField(source="subtasks.count", read_only=True)` — no nested subtasks payload; the frontend already fetches the full flat list and groups client-side, so a nested payload would just be N+1 duplication.
+- Add `validate()` that builds the candidate instance (falling back to `self.instance` for fields not present in a PATCH) and calls `instance.clean()`, translating `django.core.exceptions.ValidationError` into `serializers.ValidationError`. This is required because DRF doesn't call `full_clean()` automatically, and the single-level/ownership checks must run on partial updates too (e.g. a PATCH that only sends `{"parent": 5}`).
+
+### 3. Filter (`progression/filters.py`, `TaskFilter`, ~line 93)
+
+Add `due_at` as a `DateFromToRangeFilter`, plus `parent` (`NumberFilter` on `parent_id`) and `parent__isnull` (`BooleanFilter`, `lookup_expr="isnull"`).
+
+### 4. ViewSet (`progression/views.py`, `TaskViewSet`)
+
+No changes to `partial_update`'s first-completion XP-bonus logic — parent and subtask completion are fully independent, no auto-complete-parent cascade, no XP interaction. This keeps the XP logic untouched and avoids the double-fire risk of adding auto-complete semantics.
+
+### 5. Migration
+
+New file `progression/migrations/0006_task_due_at_parent.py`, depends on `0005_task_first_completed_at`, two `AddField` operations (see backend design notes — standard pattern matching `0005`). No DB-level CHECK constraint for the single-level rule; enforced in `clean()` only, consistent with how the rest of this model already validates.
+
+### 6. Tests
+
+Extend `progression/tests/test_task_models.py`: optional `due_at`, valid parent/subtask assignment, self-parent rejected, grandparent nesting rejected, parent-with-subtasts-cannot-get-a-parent rejected, cross-player parent rejected, cascade delete removes subtasks, **`total_time` on a parent equals its own completed-record duration plus the sum of its subtasks' `total_time`** (including the zero-subtasks case, to confirm the rollup doesn't change existing behavior for tasks without children).
+
+Extend `progression/tests/test_task_api.py`: create with `due_at`, create subtask via `parent`, reject subtask-of-subtask (400), reject giving a parent to a task with existing subtasks (400, verifying the PATCH-only-`parent` case exercises the instance-fallback path), filter by `parent`/`parent__isnull`/`due_at` range, DELETE parent cascades via API, `subtask_count` accuracy in list/detail responses.
+
+---
+
+## Frontend
+
+### 1. Types / API / hooks (mechanical)
+
+- `frontend/src/types/domain.ts` — add `due_at: string | null`, `parent: number | null`, `subtask_count: number` to `Task`.
+- `frontend/src/api/tasks.ts` — **fix `fetchTasks()` to page through all results** (loop on the paginated response's `next` field) instead of returning only page 1's `results`. This is a prerequisite, not optional, since subtask grouping needs the complete list.
+- `useTasks.ts` — no structural changes; `Partial<Task>` payloads already pass `due_at`/`parent` through untouched on create/update.
+
+### 2. Due-date utility (extend `frontend/src/utils/formatUtils.ts`, alongside the existing `formatRewardDuration`)
+
+```ts
+formatDueAt(dueAt: string | null): string          // display string, "-" when null
+toDatetimeLocalValue(dueAt: string | null): string  // "" or "YYYY-MM-DDTHH:mm" for the input
+fromDatetimeLocalValue(value: string): string | null // input value -> ISO string or null
+isOverdue(dueAt: string | null, isComplete: boolean): boolean
+```
+
+### 3. Subtask grouping (`useTasksPanel.tsx`)
+
+Add a pure derivation, run after the existing `hideCompleted`/sort logic:
+
+```ts
+interface ParentGroup { parent: ItemRecord; children: ItemRecord[] }
+```
+
+Single pass over the (already sorted) visible flat list: `Map<parentId, ItemRecord[]>` for children, top-level = tasks with `parent == null`. A task whose `parent` points to a filtered-out/missing id defensively renders as top-level (never silently drops a row). Hide-complete applies in two steps per the confirmed parent-scoped rule: drop completed top-level tasks first (removing their children with them), then independently drop completed children within each remaining group. Sort applies once to the flat list before grouping (same `compareFn`, so ordering is consistent at both levels — no separate "children always sort by X" rule to explain to users).
+
+`useTasksPanel` exposes `groupedTasks: ParentGroup[]` (top-level list) alongside a `getChildren(task): ItemRecord[]` lookup, replacing the current flat `visibleTasks` as what `TasksPanel` passes down.
+
+Add `due-date` to `taskSortOptions` (missing due dates sort last). Extend `getTaskMeta` with `dueAt`/`isOverdue`.
+
+`handleCreateTask`/`handleEdit` gain an optional `parent`/`due_at` pass-through to the mutation payload (mechanical — `updateTask.mutate`/`createTask.mutate` already accept `Partial<Task>`).
+
+### 4. Rendering — reuse `PlayerItemList` without touching `List.tsx`
+
+Confirmed via reading `PlayerItemList.tsx`/`List.tsx`/`Li.tsx`/`usePlayerItemModal.ts` directly: `List`'s `renderItem(item)` prop already returns arbitrary JSX rendered inside one `<Li>` per top-level item — there's no need to make `List` itself nesting-aware. The plan is:
+
+- In `PlayerItemList.tsx`, extract the existing big inline `renderItem={(item) => (...)}` block (checkbox, name, meta, row actions, hover-edit — all of it, unchanged) into a `renderRow(item: T)` helper.
+- Add an optional prop `getChildren?: (item: T) => T[] | undefined`.
+- The `renderItem` passed to `List` becomes: `renderRow(item)` followed by, if `getChildren(item)` is non-empty, a nested `<ul className={styles.childList}>` of `<li>` elements — reusing the `Li` component directly (imported from `../List/Li`) for each child so children get identical tone/hover/selected styling for free, each wrapping `renderRow(child)`.
+- `usePlayerItemListControls`, `usePlayerItemModal`, sort/filter, and the edit/delete modal are all **untouched** — a child task clicked via its row opens the exact same modal (`handleOpenItem(child)` already works generically over any `T`), so editing/completing/deleting a subtask needs zero new modal code.
+- `items` passed into `PlayerItemList` (which also feeds `usePlayerItemModal`'s live-sync lookup) should be the full flat visible list (parents + children), not just top-level — only the `List`-bound `displayItems`/`getChildren` split needs to distinguish top-level from nested for rendering purposes.
+- `ProjectsPanel` (the other `PlayerItemList` consumer) simply doesn't pass `getChildren`, so it's entirely unaffected.
+
+Styling: `styles.childList` (indent via `margin-left`) and a borderless/muted `styles.childItem` variant added to `PlayerItemList.module.scss`.
+
+### 5. Due-date + parent editing in the modal
+
+`renderEditSummary` (already a render-prop returning arbitrary `ReactNode` into the modal) gets extended in `TasksPanel.tsx` to include:
+- A `datetime-local` input bound to `toDatetimeLocalValue(task.due_at)`, committing via `updateTask.mutate({ id: task.id, data: { due_at: fromDatetimeLocalValue(value) } })` immediately on change/blur (same "commit immediately, don't gate behind the modal's Save button" pattern already used elsewhere for the complete-checkbox) — a "Clear" button nulls it.
+- A parent `<select>` populated from top-level tasks only (excluding the task being edited and any task that already has `parent != null`), disabled with an explanatory tooltip if the task being edited already has `subtask_count > 0` (pre-empting the server's 400 rather than surfacing a raw error). Commits immediately via the same `updateTask.mutate` pattern.
+
+This avoids extending `usePlayerItemModal.ts` at all — the modal's own Save/Cancel flow stays name-only, exactly as today; due date and parent are independent immediate-commit fields rendered into the existing summary slot.
+
+### 6. Add-subtask flow
+
+A small row action (via the existing `renderRowActions` slot, alongside the current "start working on this task" play button) on top-level tasks only, that pre-fills/focuses `TasksPanel`'s existing add-task form with a `parent: task.id` chip shown next to the name input (clearable). One creation path — `handleCreateTask` gains the optional `parent` param threaded through to `createTask.mutate`.
+
+### 7. Files
+
+**Change:** `frontend/src/types/domain.ts`, `frontend/src/api/tasks.ts`, `frontend/src/utils/formatUtils.ts`, `frontend/src/components/TasksPanel/useTasksPanel.tsx`, `frontend/src/components/TasksPanel/TasksPanel.tsx`, `frontend/src/components/TasksPanel/TasksPanel.module.scss`, `frontend/src/components/PlayerItemList/PlayerItemList.tsx`, `frontend/src/components/PlayerItemList/PlayerItemList.module.scss`.
+
+**Untouched:** `frontend/src/components/List/List.tsx`, `List/Li.tsx`, `PlayerItemList/usePlayerItemListControls.ts`, `PlayerItemList/usePlayerItemModal.ts`, `ProjectsPanel/*`.
+
+**Tests to extend:** `frontend/src/components/TasksPanel/TasksPanel.test.tsx` (grouping/indentation, parent-scoped hide-complete, due-date input commit, add-subtask flow, parent picker exclusions), `frontend/src/components/PlayerItemList/PlayerItemList.test.tsx` (`getChildren` nested rendering, confirm `ProjectsPanel`-style usage without `getChildren` is unaffected), `frontend/src/utils/formatUtils.test.ts` (new due-date functions — create if it doesn't already exist, otherwise extend).
+
+---
+
+## Verification
+
+1. Backend: `docker compose run --rm web python manage.py test progression.tests.test_task_models progression.tests.test_task_api` (prompt Duncan to run this rather than running it directly, per standing preference).
+2. Frontend unit: `npm run test` (Vitest) covering the new/extended test files above.
+3. Typecheck + lint: `npx tsc --noEmit` and `npm run lint`.
+4. Manual/browser verification via the Browser pane against the running dev server + Docker backend (same flow used for the mode-switch work): create a task with a due date, add a subtask, confirm indentation renders, toggle "Hide complete" on a completed parent and confirm its subtasks disappear too, confirm an overdue due date renders with warning styling, confirm the parent picker excludes tasks that already have subtasks.
+5. E2E: extend `frontend/tests/flows/tasks-core-loop.spec.ts` (or a new spec) with a due-date + subtask happy path once the `/tasks` heading regression from the LibraryPage refactor (tracked separately, see prior session) is resolved or worked around.

--- a/.claude/plans/unified-timer-task-mode-plan.md
+++ b/.claude/plans/unified-timer-task-mode-plan.md
@@ -1,0 +1,276 @@
+# Unified Timer — "Doing" / "Planning" Mode Switch — Implementation Plan
+
+Base branch: `feat/unified-timer-task-mode-plan`, cut from `development` at
+`2d200d18` (already includes the merged `UnifiedTimerHome` work — the prior
+`unified-timer-homepage-plan.md` is fully implemented on `development`, not a
+future dependency).
+
+No new feature flag. `UnifiedTimerHome` is already gated end-to-end by
+`unified_homepage` (`ActivityTimelinePage.tsx:10`); the mode switch is
+additive UI inside that already-flagged tree, so a second flag would just be
+extra ceremony around a sub-feature of something already dark-launched.
+
+---
+
+## Assumptions
+
+1. "Timer page" = `UnifiedTimerHome` (the only place this brief makes sense —
+   the legacy `CurrentActivity`/`ActivityTimeline` pair is out of scope and
+   untouched, consistent with the original unified-homepage plan).
+2. Mode switch is visible regardless of `isActive` — nothing in the brief
+   restricts it to "only while a timer is running"; it says the *planning*
+   mode is for managing tasks *while* the timer runs, not that the switch
+   itself is hidden when idle. Defaulting to "doing" preserves today's
+   behaviour byte-for-byte when the user never touches the switch.
+3. Only two modes exist today ("doing", "planning") but the brief explicitly
+   flags more arriving later — the chip control and the mode-storage shape
+   must not hardcode a boolean.
+4. "Tasks CRUD window below the activity label/input" means below the entire
+   Row 1 + Row 2 control card (toggle/timer + label-or-search), not
+   interleaved between them — that block is the identity of the running
+   timer and shouldn't be split up.
+5. Switching modes never stops or otherwise mutates the running timer —
+   it's purely a view switch over the same `useActivityInput`/`useGame`
+   state that already exists.
+
+---
+
+## 1. High-level strategy
+
+Add a small piece of local UI state to `UnifiedTimerHome` — `mode: "doing" |
+"planning"` — and a new chip-style switcher component to change it. Render
+`TasksPanel` unmodified when `mode === "planning"`, below the existing
+controls card. Everything else in `UnifiedTimerHome` (toggle, timer, label/
+search row, support button) keeps rendering in both modes, since planning is
+a *view added alongside* doing, not a replacement of the timer chrome — the
+timer must stay visible/controllable while the user plans.
+
+Two new small pieces, both additive:
+
+- **`ModeSwitcher`**: a tiny new presentational component (chip group,
+  `role="radiogroup"`) — there's no existing segmented-control/tab component
+  in the frontend to reuse (checked: no chip/segmented/tab pattern exists
+  outside ad-hoc buttons), so this is a genuinely new, minimal component
+  rather than a duplicate of something already there.
+- **Local `mode` state in `UnifiedTimerHome`**: `useState<TimerMode>("doing")`,
+  no persistence beyond the session — resets to "doing" on reload, matching
+  how `isEditingLabel`/`submitConfirmOpen` are already handled as ephemeral
+  UI state in this component rather than round-tripped anywhere.
+
+`TasksPanel` is reused wholesale, unmodified — no prop changes, no new
+"embedded" variant. Its own `<div className={styles.page}>` wrapper uses the
+`page-layout` mixin (`padding: v.$padding-base`, `max-width: 1000px/576px`
+per child) — nested inside `UnifiedTimerHome`'s own `max-width: 720px`
+wrapper, the inner max-width never binds (720 < 1000), so the only visible
+effect is one extra padding ring, which is acceptable and avoids forking the
+component.
+
+---
+
+## 2. Files likely to change
+
+| File | Change | Exists? |
+|---|---|---|
+| `frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx` | Add `mode` state, render `ModeSwitcher`, conditionally render `TasksPanel` | Yes, extend |
+| `frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss` | Layout for the switcher row + planning-mode panel spacing | Yes, extend |
+| `frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx` | New tests for mode switching | Yes, extend |
+| `frontend/src/components/ModeSwitcher/ModeSwitcher.tsx` | New chip-group component | New |
+| `frontend/src/components/ModeSwitcher/ModeSwitcher.module.scss` | New | New |
+| `frontend/src/components/ModeSwitcher/ModeSwitcher.test.tsx` | New | New |
+| `frontend/src/components/TasksPanel/*` | **No changes** — reused as-is | Existing, untouched |
+
+No backend, hook (`useActivityInput`/`useActivityTimer`/`useTasksPanel`), or
+routing changes — this is a pure presentational addition on top of state that
+already exists (`useTasksPanel` already has everything the CRUD window
+needs; `useGame`'s `activityTimer` is unaffected by which mode is showing).
+
+---
+
+## 3. Implementation plan
+
+**Phase 1 — `ModeSwitcher` component**
+- Generic chip-group: `modes: { key: string; label: string }[]`,
+  `activeKey: string`, `onSelect: (key: string) => void`.
+- Renders a `role="radiogroup"` wrapper with one button per mode
+  (`role="radio"`, `aria-checked`), styled as pill/chip buttons — active chip
+  visually distinct (matches existing `Button` `variant` convention: reuse
+  the same primary/secondary color tokens `TasksPanel`'s `filterToggle`
+  already uses, rather than inventing new colors).
+- Deliberately generic over the mode list (not hardcoded to "doing"/
+  "planning") so a third mode later is a data change, not a component change.
+- Full ARIA radiogroup keyboard behaviour (per Open questions, resolved):
+  only the active chip is a Tab stop (`tabIndex={0}`, others `-1`); Left/Up
+  and Right/Down move selection to the previous/next chip (wrapping at the
+  ends); Home/End jump to the first/last chip. Arrow/Home/End both move
+  focus and fire `onSelect` together, matching the standard "selection
+  follows focus" radiogroup pattern.
+- Unit tests: renders a chip per mode; `aria-checked`/`tabIndex` reflect
+  `activeKey`; click calls `onSelect` with the right key; arrow key
+  navigation moves selection and wraps at the ends; Home/End jump to
+  first/last chip.
+
+**Phase 2 — wire `mode` state into `UnifiedTimerHome`**
+- `const [mode, setMode] = useState<"doing" | "planning">("doing");`
+- Render `<ModeSwitcher modes={[{key: "doing", label: "Doing"}, {key:
+  "planning", label: "Planning"}]} activeKey={mode} onSelect={setMode} />`
+  directly under the existing controls card (`.container`), above the
+  auto-stop warning / support button row.
+- When `mode === "planning"`, render `<TasksPanel />` below the switcher;
+  when `"doing"`, render nothing extra — today's output.
+- No change to `showLabelDisplay`/`statusMessage`/toggle logic — those stay
+  keyed off `isActive`/`isUnlabelled` exactly as today, independent of
+  `mode`.
+- Component tests: default mode is "doing" (no `TasksPanel` in the tree);
+  clicking the "Planning" chip renders `TasksPanel`; switching back to
+  "Doing" unmounts it; timer controls (`Start`/`Stop`, elapsed time) remain
+  visible and functional in both modes.
+
+**Phase 3 — layout/spacing polish**
+- SCSS for the switcher row (small gap above/below, centered or left-aligned
+  to match the card's existing rhythm) and for the planning panel's
+  top margin so `TasksPanel`'s own padding doesn't look cramped against the
+  switcher.
+- Manual QA: switch modes while a timer is running and while idle; confirm
+  no layout jump in the controls card itself (only content *below* it should
+  change) — reuses the same "row 1 never reacts to row 2" principle already
+  established in `UnifiedTimerHome.module.scss`.
+
+**Phase 4 — accessibility pass**
+- `aria-live` region update (or confirm the existing one) so switching modes
+  doesn't need a separate announcement beyond the radiogroup's own state
+  change; verify focus doesn't jump unexpectedly when `TasksPanel` mounts.
+- Playwright/a11y test extending existing `/timer` coverage: flag-on, switch
+  to Planning, add/complete/delete a task inline, switch back to Doing.
+
+---
+
+## 4. Design decisions
+
+**1. New small `ModeSwitcher` component vs. reusing `Button` in a row.**
+Alternative: two adjacent `Button` components with manual active-state
+styling. Rejected — a two-way (soon N-way) exclusive-choice control is
+semantically a radiogroup, not two independent buttons; getting
+`aria-checked`/keyboard behavior right once in a dedicated component is
+cheaper than re-deriving it at every call site, and this brief explicitly
+asks for "some sort of chip visual," i.e. a recognizable, reusable pattern —
+not a one-off. Scoped as its own component (not inlined in
+`UnifiedTimerHome`) so the "more modes in future" requirement doesn't force
+edits to the host component later.
+
+**2. Mode state lives in `UnifiedTimerHome`, not in `useActivityInput`.**
+Alternative: add `mode`/`setMode` to `useActivityInput` alongside
+`isEditingLabel` etc. Rejected — `useActivityInput` is shared timer/activity
+business logic consumed elsewhere (`ActivityInput.tsx` legacy tree, `Support
+Flow`); "which view is currently showing" is presentational state specific
+to `UnifiedTimerHome`'s layout, with zero bearing on activity/timer
+behaviour. Keeping it local avoids widening a shared hook's surface for a
+concern that only one consumer has, and matches how `submitConfirmOpen` is
+already local to the component for the same reason.
+
+**3. Render `TasksPanel` unmodified vs. extracting a props-driven "embedded"
+variant.**
+Alternative: add an `embedded`/`hideChrome` prop to `TasksPanel` to strip its
+outer `page-layout` wrapper. Rejected for a first pass — the only visible
+cost of not doing this is one extra padding ring (quantified in strategy
+section above), which is a minor visual nit, not a functional problem.
+Forking `TasksPanel`'s rendering behind a prop is exactly the kind of
+premature abstraction the brief's "reuse as much as possible" points away
+from; if the padding genuinely looks wrong in manual QA (Phase 3), the fix
+is a single optional prop added then, with evidence, not speculatively now.
+
+**4. No persistence of the selected mode (resets to "doing" on reload).**
+Alternative: persist to `localStorage` (`TasksPanel` already has precedent
+for this with `TASKS_HIDE_COMPLETED_KEY`). Rejected for v1 — the brief
+describes this as "the first version of task mode"; defaulting to "doing"
+every load keeps the change fully invisible to anyone who never touches the
+switch, and persistence is a one-line follow-up once the mode-switching
+mechanism itself is validated. Flagged as a likely fast-follow, not a gap.
+
+---
+
+## 5. Edge cases
+
+- **Switching to Planning mid-timer, then stopping the timer from within
+  Planning mode**: the Stop button lives in the controls card, which renders
+  in both modes (Design/Strategy above), so this works without extra
+  wiring — `handleToggle` doesn't know or care what `mode` is.
+- **Starting a task from within `TasksPanel`'s row-action (▷ "start working
+  on this task") while already in Planning mode with a *different* timer
+  running**: `useTasksPanel.handleStartTask` already guards on
+  `activityTimer?.status === "active"` and no-ops if so (existing behaviour,
+  untouched) — worth an explicit test since this is the one place the two
+  panels' state can collide.
+- **Rapid mode toggling**: pure client-side state flip, no network calls, no
+  race conditions to guard against.
+- **Mode switch while `isEditingLabel` is true (click-to-edit in
+  progress)**: switching to Planning mid-edit doesn't call `handleLabelBlur`
+  or `handleLabelCancel` — the edit state is preserved and still resolves
+  normally if the user switches back to Doing and blurs/confirms. Worth a
+  test to confirm `isEditingLabel` isn't reset by the mode change (it
+  shouldn't be, since `mode` and `isEditingLabel` are independent state, but
+  this is an easy thing to accidentally couple).
+- **Empty task list in Planning mode**: already handled by `TasksPanel`'s
+  existing empty state — no new work.
+
+---
+
+## 6. Tests
+
+**Frontend unit (Vitest)**
+- `ModeSwitcher`: renders one chip per mode; `aria-checked` reflects
+  `activeKey`; click calls `onSelect(key)`; renders correctly for 2 and 3+
+  modes (guards against hardcoding the two-mode case).
+
+**Frontend component (RTL)**
+- `UnifiedTimerHome`: defaults to Doing (no `TasksPanel` rendered); clicking
+  the Planning chip mounts `TasksPanel` and keeps the controls card
+  (Start/Stop, timer) rendered and functional; switching back to Doing
+  unmounts `TasksPanel`; `isEditingLabel` state survives a mode round-trip
+  (edge case above).
+
+**E2E (Playwright)**
+- Extend the existing flag-on `/timer` spec (kept isolated from the flaky
+  spec per project memory, same as the original unified-homepage plan): start
+  a timer, switch to Planning, add a task, mark it complete, switch back to
+  Doing, stop the timer — confirms no interference between the two panels'
+  state.
+
+---
+
+## 7. Risks
+
+- **Padding/visual mismatch from nesting `TasksPanel` as-is** (Design
+  decision 3) — low risk, but flag it explicitly in the PR description so
+  the reviewer checks it visually rather than assuming it's pixel-perfect
+  merely because it compiles.
+- **Accidentally coupling `mode` to `isActive`** — e.g. auto-switching back
+  to "Doing" on Stop, which isn't asked for and would surprise a user who's
+  mid-way through planning tasks around a just-finished timer. Keep the two
+  fully independent.
+- **Radiogroup a11y correctness** — this is the first `role="radiogroup"` in
+  the frontend (no existing precedent to copy from), so it's easy to get the
+  roving-`tabIndex`/arrow-key/Home-End behaviour subtly wrong (e.g. making
+  every chip a separate Tab stop instead of one roving stop). Worth explicit
+  reviewer attention since there's no local example to diff against.
+
+---
+
+## 8. Open questions
+
+All resolved:
+
+1. **Keyboard semantics**: implement full radiogroup behaviour in Phase 1 —
+   arrow keys (Left/Right or Up/Down) move selection between chips, Home/End
+   jump to first/last, matching the standard ARIA radiogroup pattern (only
+   the active chip is in the Tab order; arrow keys move focus + selection
+   together). Since there's no existing precedent in this codebase, Phase 1
+   implements this from the ARIA APG radiogroup pattern directly rather than
+   copying local code.
+2. **Visual spec**: match existing styling — same color tokens/border
+   treatment as `TasksPanel`'s `filterToggle` (`Button` secondary/primary
+   variant colors), no new colors or icons introduced.
+3. **Persistence**: confirmed — default to `"doing"` every load, no
+   `localStorage` persistence in v1 (Design decision 4 stands as written).
+
+None outstanding — implementation can proceed through Phase 4 without
+further product input.

--- a/.claude/plans/unified-timer-task-mode-plan.md
+++ b/.claude/plans/unified-timer-task-mode-plan.md
@@ -274,3 +274,44 @@ All resolved:
 
 None outstanding — implementation can proceed through Phase 4 without
 further product input.
+
+---
+
+## 9. Addendum — blank Start auto-labels "Planning"
+
+Post-implementation adjustment, on top of Phase 2 as originally shipped.
+
+**Change**: clicking Start with nothing typed no longer starts a genuinely
+unlabelled timer. It now labels the timer `"Planning"` — via the same
+`handleCreateActivity` path any typed name goes through (so it behaves like
+any other named activity: shows up in activity history, gets cached as a
+suggestion) — and sets `mode` to `"planning"` immediately, so the task list
+is right there instead of an empty search box.
+
+**Rationale**: someone who hits Start with nothing typed usually doesn't
+have a specific activity in mind yet — that's a "let me figure out what I'm
+doing" moment, which is exactly what Planning mode is for. Defaulting that
+path to an explicit "Planning" activity + Planning mode removes a click
+(the same one this feature exists to remove) for what's likely the most
+common way people land in Planning mode in practice.
+
+**What doesn't change**:
+- Starting with a typed name is unchanged — still labels with whatever's
+  typed via `handleToggle`, mode stays wherever it already was.
+- `handleBlankStart`/`isUnlabelled` stay as-is in `useActivityInput` —
+  `UnifiedTimerHome`'s Start-button branch just stops calling
+  `handleBlankStart`. Unlabelled-while-running is still reachable through
+  other paths (e.g. clicking a labelled running timer to edit it, clearing
+  the field, and blurring), so removing the primitive itself wasn't in
+  scope.
+- The separate "activity name contains 'plan'" auto-switch added during
+  Phase 2 (not documented elsewhere in this plan — flagged here for
+  completeness) is untouched and coexists without conflict: a blank start's
+  name is `""`, which never matches that substring check, so the two
+  triggers fire on disjoint inputs.
+
+**Tests updated**: `UnifiedTimerHome.test.tsx`'s blank-start case now
+asserts the `"Planning"` label, the Planning radio's `aria-checked`, and
+the task list rendering; the Playwright happy-path spec starts blank,
+confirms Planning mode opens immediately, then click-to-edits the label to
+rename it for the rest of that flow.

--- a/.claude/plans/unified-timer-task-mode-plan.md
+++ b/.claude/plans/unified-timer-task-mode-plan.md
@@ -315,3 +315,57 @@ asserts the `"Planning"` label, the Planning radio's `aria-checked`, and
 the task list rendering; the Playwright happy-path spec starts blank,
 confirms Planning mode opens immediately, then click-to-edits the label to
 rename it for the rest of that flow.
+
+---
+
+## 10. Known deviations from the plan (found during post-implementation review)
+
+Phase 2 shipped two behaviors that don't match what's written above, neither
+with an accompanying design-decision entry. Documented here after the fact,
+rather than quietly rewriting the Assumptions/Phase 2 sections to match,
+so the record of what was planned vs. what shipped stays honest.
+
+**1. The switcher is hidden while idle, not "visible regardless of
+`isActive`" (contradicts Assumption 2).**
+Assumption 2 states explicitly that "nothing in the brief restricts [the
+switch] to 'only while a timer is running'" and that hiding it while idle
+was considered and rejected. The shipped code does the opposite —
+`{isActive && <ModeSwitcher .../>}` in `UnifiedTimerHome.tsx` — the
+switcher and the planning panel only render once a timer is running. No
+design-decision entry explains the reversal.
+- *Effect*: before this plan's blank-start addendum (§9) existed, a user
+  had no way to open Planning mode, or even see the switcher, before
+  starting a timer. §9 narrows the practical gap — hitting Start with
+  nothing typed now reaches Planning mode in one click — but it's still not
+  what Assumption 2 describes, and there's still no way to preview or
+  reach Planning mode from the idle state through any other affordance.
+- *Disposition*: left as shipped. Showing the switcher while idle (with
+  `mode` defaulting to "doing" until a timer starts, so the timer's own
+  first-load behaviour stays unchanged) is a separate, deliberate product
+  decision to make — not folded into this addendum.
+
+**2. Undocumented auto-switch: typing "plan" in the activity name switches
+to Planning mode.**
+`UnifiedTimerHome` has a render-time check —
+`inputValue.toLowerCase().includes("plan")` — that force-switches `mode` to
+`"planning"` the first time it becomes true for a given `inputValue`,
+one-directional (removing "plan" from the name afterwards doesn't switch
+back). This isn't mentioned anywhere above: not in Assumptions, Strategy,
+Phases, Design decisions, Edge cases, or Open questions (§8, which was
+marked "None outstanding" at the time).
+- *Rationale (reconstructed from the shipping commit and its code comment,
+  since none was recorded in this plan)*: naming an activity around
+  planning ("plan my week", "Planning session") is treated as a
+  strong-enough signal to drop the user into Planning mode without an
+  extra click; one-directional because the user may have since interacted
+  with the tasks panel, and automatically yanking them back out on a later
+  edit would be more surprising than helpful.
+- *Interaction with §9*: the two auto-switch triggers are independent and
+  don't conflict — a blank start's `inputValue` is `""`, which never
+  matches this substring check.
+- *Disposition*: left as shipped — it's tested (`UnifiedTimerHome.test.tsx`
+  has three dedicated cases: matches, case-insensitive/substring match,
+  no-match for unrelated names) and works as designed; it should simply
+  have been written down here when it was built. No behaviour change made
+  as part of this addendum — documenting it so a future reader isn't
+  finding it cold in the diff.

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -2,8 +2,17 @@
 import type { Task, PaginatedResponse } from "../types";
 import { apiFetch } from "../utils/api";
 
-export function fetchTasks(): Promise<Task[]> {
-  return apiFetch<PaginatedResponse<Task>>(`/tasks/`).then((data) => data.results);
+export async function fetchTasks(): Promise<Task[]> {
+  const results: Task[] = [];
+  let path: string | null = `/tasks/`;
+
+  while (path) {
+    const data: PaginatedResponse<Task> = await apiFetch<PaginatedResponse<Task>>(path);
+    results.push(...data.results);
+    path = data.next ? `/tasks/?${new URL(data.next).searchParams.toString()}` : null;
+  }
+
+  return results;
 }
 
 export function fetchTask(id: number): Promise<Task> {

--- a/frontend/src/components/ModeSwitcher/ModeSwitcher.module.scss
+++ b/frontend/src/components/ModeSwitcher/ModeSwitcher.module.scss
@@ -1,0 +1,27 @@
+@use '../../styles/utilities/mixins' as m;
+@use '../../styles/semantic/typography' as t;
+@use '../../styles/semantic/colors' as c;
+@use '../../styles/semantic/spacing' as sp;
+@use 'sass:map';
+
+.radiogroup {
+  display: flex;
+  gap: map.get(sp.$gap, xs);
+  flex-wrap: wrap;
+}
+
+.chip {
+  border: 1px solid rgba(c.$color-border-primary, 0.35);
+  border-radius: sp.$button-radius;
+  padding: sp.$spacing-xs sp.$spacing-sm;
+  cursor: pointer;
+  @include c.apply-button-variant(secondary);
+  @include t.apply-text-style(t.$text-button);
+
+  &.active {
+    @include c.apply-button-variant(primary);
+    border-color: transparent;
+  }
+
+  @include m.focus-outline(c.$color-border-accent);
+}

--- a/frontend/src/components/ModeSwitcher/ModeSwitcher.test.tsx
+++ b/frontend/src/components/ModeSwitcher/ModeSwitcher.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import ModeSwitcher from './ModeSwitcher';
+
+const twoModes = [
+  { key: 'doing', label: 'Doing' },
+  { key: 'planning', label: 'Planning' },
+];
+
+const threeModes = [
+  ...twoModes,
+  { key: 'reviewing', label: 'Reviewing' },
+];
+
+describe('ModeSwitcher', () => {
+  it('renders one chip per mode with the active one checked', () => {
+    render(<ModeSwitcher modes={twoModes} activeKey="doing" onSelect={vi.fn()} />);
+
+    const doing = screen.getByRole('radio', { name: 'Doing' });
+    const planning = screen.getByRole('radio', { name: 'Planning' });
+
+    expect(doing).toHaveAttribute('aria-checked', 'true');
+    expect(doing).toHaveAttribute('tabIndex', '0');
+    expect(planning).toHaveAttribute('aria-checked', 'false');
+    expect(planning).toHaveAttribute('tabIndex', '-1');
+  });
+
+  it('renders correctly for 3+ modes', () => {
+    render(<ModeSwitcher modes={threeModes} activeKey="reviewing" onSelect={vi.fn()} />);
+
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(screen.getByRole('radio', { name: 'Reviewing' })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('calls onSelect with the clicked chip key', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<ModeSwitcher modes={twoModes} activeKey="doing" onSelect={onSelect} />);
+
+    await user.click(screen.getByRole('radio', { name: 'Planning' }));
+
+    expect(onSelect).toHaveBeenCalledWith('planning');
+  });
+
+  it('ArrowRight moves selection to the next chip and wraps at the end', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<ModeSwitcher modes={twoModes} activeKey="planning" onSelect={onSelect} />);
+
+    screen.getByRole('radio', { name: 'Planning' }).focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(onSelect).toHaveBeenCalledWith('doing');
+  });
+
+  it('ArrowLeft moves selection to the previous chip and wraps at the start', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<ModeSwitcher modes={twoModes} activeKey="doing" onSelect={onSelect} />);
+
+    screen.getByRole('radio', { name: 'Doing' }).focus();
+    await user.keyboard('{ArrowLeft}');
+
+    expect(onSelect).toHaveBeenCalledWith('planning');
+  });
+
+  it('Home and End jump to the first and last chip', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<ModeSwitcher modes={threeModes} activeKey="planning" onSelect={onSelect} />);
+
+    screen.getByRole('radio', { name: 'Planning' }).focus();
+    await user.keyboard('{End}');
+    expect(onSelect).toHaveBeenLastCalledWith('reviewing');
+
+    onSelect.mockClear();
+    screen.getByRole('radio', { name: 'Planning' }).focus();
+    await user.keyboard('{Home}');
+    expect(onSelect).toHaveBeenLastCalledWith('doing');
+  });
+});

--- a/frontend/src/components/ModeSwitcher/ModeSwitcher.tsx
+++ b/frontend/src/components/ModeSwitcher/ModeSwitcher.tsx
@@ -1,0 +1,83 @@
+import React, { useRef } from "react";
+import classNames from "classnames";
+import styles from "./ModeSwitcher.module.scss";
+
+export interface ModeOption {
+  key: string;
+  label: string;
+}
+
+interface ModeSwitcherProps {
+  modes: ModeOption[];
+  activeKey: string;
+  onSelect: (key: string) => void;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export default function ModeSwitcher({
+  modes,
+  activeKey,
+  onSelect,
+  ariaLabel = "Mode",
+  className,
+}: ModeSwitcherProps): React.ReactElement {
+  const chipRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const focusAndSelect = (index: number) => {
+    const wrapped = (index + modes.length) % modes.length;
+    const target = modes[wrapped];
+    chipRefs.current[wrapped]?.focus();
+    onSelect(target.key);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        focusAndSelect(index + 1);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        focusAndSelect(index - 1);
+        break;
+      case "Home":
+        event.preventDefault();
+        focusAndSelect(0);
+        break;
+      case "End":
+        event.preventDefault();
+        focusAndSelect(modes.length - 1);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className={classNames(styles.radiogroup, className)} role="radiogroup" aria-label={ariaLabel}>
+      {modes.map((mode, index) => {
+        const isActive = mode.key === activeKey;
+        return (
+          <button
+            key={mode.key}
+            ref={(el) => {
+              chipRefs.current[index] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            tabIndex={isActive ? 0 : -1}
+            className={classNames(styles.chip, { [styles.active]: isActive })}
+            onClick={() => onSelect(mode.key)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+          >
+            {mode.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/PlayerItemList/PlayerItemList.module.scss
+++ b/frontend/src/components/PlayerItemList/PlayerItemList.module.scss
@@ -156,6 +156,21 @@
   }
 }
 
+.childList {
+  list-style: none;
+  margin: sp.$spacing-xs 0 0;
+  padding: 0 0 0 sp.$spacing-lg;
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-xs;
+}
+
+.childItem {
+  background: transparent;
+  border-color: rgba(c.$color-border-primary, 0.12);
+  opacity: 0.9;
+}
+
 .itemCompleted {
   background: rgba(c.$color-border-primary, 0.03);
   border-color: rgba(c.$color-border-primary, 0.3);

--- a/frontend/src/components/PlayerItemList/PlayerItemList.test.tsx
+++ b/frontend/src/components/PlayerItemList/PlayerItemList.test.tsx
@@ -148,4 +148,34 @@ describe("PlayerItemList", () => {
       expect(screen.queryByText("Apple")).not.toBeInTheDocument();
     });
   });
+
+  describe("getChildren nested rendering", () => {
+    const parent = { id: 10, name: "Parent task" };
+    const child = { id: 11, name: "Child task" };
+    const flatItems = [parent, child];
+
+    it("renders children nested under their parent without a top-level row", () => {
+      render(
+        <PlayerItemList
+          items={flatItems}
+          itemLabel="task"
+          getChildren={(item) => (item.id === 10 ? [child] : undefined)}
+        />,
+      );
+
+      expect(screen.getByRole("button", { name: "Open task Parent task" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Open task Child task" })).toBeInTheDocument();
+      // The child is not rendered as its own top-level list item.
+      expect(screen.getAllByRole("button", { name: /^Open task / })).toHaveLength(2);
+    });
+
+    it("is unaffected when getChildren is not passed (ProjectsPanel-style usage)", () => {
+      render(<PlayerItemList items={flatItems} itemLabel="task" />);
+
+      // Without getChildren both items render as independent top-level rows.
+      expect(screen.getAllByRole("button", { name: /^Open task / })).toHaveLength(2);
+      expect(screen.getByRole("button", { name: "Open task Parent task" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Open task Child task" })).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/PlayerItemList/PlayerItemList.tsx
+++ b/frontend/src/components/PlayerItemList/PlayerItemList.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useMemo } from "react";
 import classNames from "classnames";
 
 import Button from "../Button/Button";
 import List from "../List/List";
+import Li from "../List/Li";
 import Modal from "../Modal/Modal";
 import { usePlayerItemListControls } from "./usePlayerItemListControls";
 import { usePlayerItemModal } from "./usePlayerItemModal";
@@ -39,6 +40,7 @@ interface PlayerItemListProps<T extends { id?: string | number; name?: string }>
   sortOptions?: SortOption<T>[];
   filterOptions?: FilterOption<T>[];
   controls?: React.ReactNode;
+  getChildren?: (item: T) => T[] | undefined;
 }
 
 export default function PlayerItemList<T extends { id?: string | number; name?: string }>({
@@ -60,6 +62,7 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
   sortOptions,
   filterOptions,
   controls,
+  getChildren,
 }: PlayerItemListProps<T>) {
   const {
     activeFilterKey,
@@ -105,6 +108,91 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
   const canEdit = typeof onEdit === "function";
   const canDelete = typeof onDelete === "function";
 
+  const childIds = useMemo(() => {
+    const ids = new Set<string | number>();
+    if (!getChildren) return ids;
+    items.forEach((item) => {
+      getChildren(item)?.forEach((child) => {
+        if (child.id !== undefined) ids.add(child.id);
+      });
+    });
+    return ids;
+  }, [items, getChildren]);
+
+  const topLevelDisplayItems = useMemo(() => {
+    if (!getChildren) return displayItems;
+    return displayItems.filter(
+      (item) => item.id === undefined || !childIds.has(item.id)
+    );
+  }, [displayItems, getChildren, childIds]);
+
+  const renderRow = (item: T): React.ReactNode => (
+    <>
+      {canToggleComplete ? (
+        <label className={styles.completeCheckboxLabel}>
+          <input
+            className={styles.completeCheckbox}
+            type="checkbox"
+            checked={Boolean(isItemComplete?.(item))}
+            onChange={() => onToggleComplete!(item)}
+            aria-label={`Mark ${getItemName(item) || itemLabelLower} as complete`}
+          />
+        </label>
+      ) : null}
+      {hoverEdit ? (
+        <div className={styles.itemContent}>
+          {canEdit ? (
+            <button
+              type="button"
+              className={classNames(styles.itemDetails, styles.itemDetailsButton)}
+              aria-label={`Edit ${itemLabelLower} ${getItemName(item)}`}
+              onClick={() => handleOpenItem(item)}
+            >
+              <div className={styles.itemName}>{getItemName(item)}</div>
+              {renderItemMeta ? (
+                <div className={styles.itemMeta}>{renderItemMeta(item)}</div>
+              ) : null}
+            </button>
+          ) : (
+            <div className={styles.itemDetails}>
+              <div className={styles.itemName}>{getItemName(item)}</div>
+              {renderItemMeta ? (
+                <div className={styles.itemMeta}>{renderItemMeta(item)}</div>
+              ) : null}
+            </div>
+          )}
+          <div className={styles.rowActions}>
+            {renderRowActions?.(item)}
+            {canEdit ? (
+              <button
+                type="button"
+                className={styles.editHoverButton}
+                aria-label={`Edit ${itemLabelLower} ${getItemName(item)}`}
+                onClick={() => handleOpenItem(item)}
+              >
+                📝
+              </button>
+            ) : null}
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className={styles.itemButton}
+          aria-label={`Open ${itemLabelLower} ${getItemName(item)}`}
+          onClick={() => handleOpenItem(item)}
+        >
+          <div className={styles.itemDetails}>
+            <div className={styles.itemName}>{getItemName(item)}</div>
+            {renderItemMeta ? (
+              <div className={styles.itemMeta}>{renderItemMeta(item)}</div>
+            ) : null}
+          </div>
+        </button>
+      )}
+    </>
+  );
+
   return (
     <div className={styles.wrapper}>
       {hasControls ? (
@@ -146,7 +234,7 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
       ) : null}
       <div className={styles.listScroll}>
       <List
-        items={displayItems}
+        items={topLevelDisplayItems}
         ariaLabel={ariaLabel}
         canHover
         className={classNames(styles.list, listClassName)}
@@ -157,72 +245,28 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
             [styles.itemCompleted]: isItemComplete?.(item),
           })
         }
-        renderItem={(item) => (
-          <>
-            {canToggleComplete ? (
-              <label className={styles.completeCheckboxLabel}>
-                <input
-                  className={styles.completeCheckbox}
-                  type="checkbox"
-                  checked={Boolean(isItemComplete?.(item))}
-                  onChange={() => onToggleComplete!(item)}
-                  aria-label={`Mark ${getItemName(item) || itemLabelLower} as complete`}
-                />
-              </label>
-            ) : null}
-            {hoverEdit ? (
-              <div className={styles.itemContent}>
-                {canEdit ? (
-                  <button
-                    type="button"
-                    className={classNames(styles.itemDetails, styles.itemDetailsButton)}
-                    aria-label={`Edit ${itemLabelLower} ${getItemName(item)}`}
-                    onClick={() => handleOpenItem(item)}
-                  >
-                    <div className={styles.itemName}>{getItemName(item)}</div>
-                    {renderItemMeta ? (
-                      <div className={styles.itemMeta}>{renderItemMeta(item)}</div>
-                    ) : null}
-                  </button>
-                ) : (
-                  <div className={styles.itemDetails}>
-                    <div className={styles.itemName}>{getItemName(item)}</div>
-                    {renderItemMeta ? (
-                      <div className={styles.itemMeta}>{renderItemMeta(item)}</div>
-                    ) : null}
-                  </div>
-                )}
-                <div className={styles.rowActions}>
-                  {renderRowActions?.(item)}
-                  {canEdit ? (
-                    <button
-                      type="button"
-                      className={styles.editHoverButton}
-                      aria-label={`Edit ${itemLabelLower} ${getItemName(item)}`}
-                      onClick={() => handleOpenItem(item)}
+        renderItem={(item) => {
+          const children = getChildren?.(item);
+          return (
+            <>
+              {renderRow(item)}
+              {children?.length ? (
+                <ul className={styles.childList}>
+                  {children.map((child, index) => (
+                    <Li
+                      key={(child.id as string | number | undefined) ?? index}
+                      className={classNames(styles.item, styles.childItem, {
+                        [styles.itemCompleted]: isItemComplete?.(child),
+                      })}
                     >
-                      📝
-                    </button>
-                  ) : null}
-                </div>
-              </div>
-            ) : (
-              <button
-                type="button"
-                className={styles.itemButton}
-                aria-label={`Open ${itemLabelLower} ${getItemName(item)}`}
-                onClick={() => handleOpenItem(item)}
-              >
-                <div className={styles.itemDetails}>
-                  <div className={styles.itemName}>{getItemName(item)}</div>
-                  {renderItemMeta ? (
-                    <div className={styles.itemMeta}>{renderItemMeta(item)}</div>
-                  ) : null}
-                </div>
-              </button>
-            )}
-          </>
-        )}
+                      {renderRow(child)}
+                    </Li>
+                  ))}
+                </ul>
+              ) : null}
+            </>
+          );
+        }}
       />
       </div>
 

--- a/frontend/src/components/TasksPanel/TasksPanel.module.scss
+++ b/frontend/src/components/TasksPanel/TasksPanel.module.scss
@@ -134,6 +134,69 @@
   }
 }
 
+.taskSubtaskButton {
+  border: none;
+  background: transparent;
+  color: c.$color-border-primary;
+  border-radius: sp.$border-radius;
+  width: 1.75rem;
+  height: 1.75rem;
+  font-size: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+
+  &:hover {
+    background: rgba(c.$color-border-primary, 0.1);
+  }
+}
+
+.overdue {
+  color: c.$color-error;
+  font-weight: 600;
+}
+
+.parentChip {
+  display: inline-flex;
+  align-items: center;
+  gap: sp.$spacing-xs;
+  padding: sp.$spacing-xs sp.$spacing-sm;
+  border-radius: sp.$border-radius;
+  background: rgba(c.$color-border-primary, 0.12);
+  font-size: 0.85em;
+}
+
+.parentChipClear {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: inherit;
+  font-size: 1em;
+  line-height: 1;
+  padding: 0;
+}
+
+.dueDateRow,
+.parentRow {
+  display: flex;
+  align-items: center;
+  gap: sp.$spacing-sm;
+  flex-wrap: wrap;
+}
+
+.dueDateInput,
+.parentSelect {
+  padding: sp.$spacing-xs sp.$spacing-sm;
+  border: 1px solid rgba(c.$color-border-primary, 0.35);
+  border-radius: sp.$border-radius;
+  background: transparent;
+  font-size: 0.875em;
+  font-family: inherit;
+  color: inherit;
+}
+
 .addButtonIcon {
   display: none;
 }

--- a/frontend/src/components/TasksPanel/TasksPanel.test.tsx
+++ b/frontend/src/components/TasksPanel/TasksPanel.test.tsx
@@ -71,6 +71,9 @@ const incompleteTask = {
   created_at: "2026-05-01T08:00:00.000Z",
   last_updated: "2026-05-01T08:00:00.000Z",
   last_worked_on: null,
+  due_at: null,
+  parent: null,
+  subtask_count: 0,
   total_time: 1800,
   total_records: 3,
 };
@@ -83,6 +86,9 @@ const completeTask = {
   created_at: "2026-04-01T08:00:00.000Z",
   last_updated: "2026-05-03T12:00:00.000Z",
   last_worked_on: "2026-05-03T12:00:00.000Z",
+  due_at: null,
+  parent: null,
+  subtask_count: 0,
   total_time: 600,
   total_records: 1,
 };
@@ -201,6 +207,125 @@ describe("TasksPanel", () => {
       expect(updateMutate).toHaveBeenCalledWith({
         id: 1,
         data: { name: "Evening routine" },
+      });
+    });
+  });
+
+  describe("subtasks", () => {
+    const parentTask = {
+      id: 3,
+      name: "Parent project task",
+      is_complete: false,
+      completed_at: null,
+      created_at: "2026-05-01T08:00:00.000Z",
+      last_updated: "2026-05-01T08:00:00.000Z",
+      last_worked_on: null,
+      due_at: null,
+      parent: null,
+      subtask_count: 1,
+      total_time: 0,
+      total_records: 0,
+    };
+
+    const childTask = {
+      id: 4,
+      name: "Child subtask",
+      is_complete: false,
+      completed_at: null,
+      created_at: "2026-05-01T08:05:00.000Z",
+      last_updated: "2026-05-01T08:05:00.000Z",
+      last_worked_on: null,
+      due_at: null,
+      parent: 3,
+      subtask_count: 0,
+      total_time: 0,
+      total_records: 0,
+    };
+
+    it("renders a subtask nested under its parent", () => {
+      mockUseTasks.mockReturnValue({
+        isLoading: false,
+        data: [parentTask, childTask],
+      });
+      renderTasksPanel();
+
+      const parentButton = screen.getAllByRole("button", { name: "Edit task Parent project task" })[0];
+      const childButton = screen.getAllByRole("button", { name: "Edit task Child subtask" })[0];
+      expect(parentButton).toBeInTheDocument();
+      expect(childButton).toBeInTheDocument();
+      // The subtask is nested inside the parent's <li>, not a sibling top-level row.
+      const parentListItem = parentButton.closest("li");
+      expect(parentListItem).toContainElement(childButton);
+    });
+
+    it("hides a completed parent and its subtasks together", () => {
+      const completedParent = { ...parentTask, id: 5, is_complete: true, completed_at: "2026-05-02T00:00:00.000Z" };
+      const childOfCompletedParent = { ...childTask, id: 6, parent: 5 };
+      mockUseTasks.mockReturnValue({
+        isLoading: false,
+        data: [completedParent, childOfCompletedParent],
+      });
+      renderTasksPanel();
+
+      expect(screen.queryByText("Parent project task")).not.toBeInTheDocument();
+      expect(screen.queryByText("Child subtask")).not.toBeInTheDocument();
+    });
+
+    it("pre-fills the add-task form with a parent chip via the add-subtask row action", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      mockUseTasks.mockReturnValue({
+        isLoading: false,
+        data: [parentTask],
+      });
+      renderTasksPanel();
+
+      await user.click(screen.getByRole("button", { name: "Add subtask to Parent project task" }));
+
+      expect(screen.getByText(/Subtask of Parent project task/)).toBeInTheDocument();
+
+      const input = screen.getByLabelText("new task");
+      await user.type(input, "Buy groceries");
+      await user.click(screen.getByRole("button", { name: "Add subtask" }));
+
+      await waitFor(() => {
+        expect(createMutate).toHaveBeenCalledWith({ name: "Buy groceries", parent: 3 });
+      });
+    });
+
+    it("disables the parent picker for a task that already has subtasks", async () => {
+      const user = userEvent.setup();
+      mockUseTasks.mockReturnValue({
+        isLoading: false,
+        data: [parentTask, childTask],
+      });
+      renderTasksPanel();
+
+      await user.click(
+        screen.getAllByRole("button", { name: "Edit task Parent project task" })[0],
+      );
+
+      expect(screen.getByLabelText("Parent task")).toBeDisabled();
+    });
+  });
+
+  describe("due date", () => {
+    it("commits a due date edit immediately on blur", async () => {
+      const user = userEvent.setup();
+      renderTasksPanel();
+
+      await user.click(
+        screen.getAllByRole("button", { name: "Edit task Morning routine" })[0],
+      );
+
+      const dueDateInput = screen.getByLabelText("Due date");
+      await user.type(dueDateInput, "2026-06-01T09:00");
+      await user.tab();
+
+      await waitFor(() => {
+        expect(updateMutate).toHaveBeenCalledWith({
+          id: 1,
+          data: { due_at: expect.any(String) },
+        });
       });
     });
   });

--- a/frontend/src/components/TasksPanel/TasksPanel.tsx
+++ b/frontend/src/components/TasksPanel/TasksPanel.tsx
@@ -1,11 +1,12 @@
 import React from "react";
+import classNames from "classnames";
 
 import EntitySearchInput from "../EntitySearchInput/EntitySearchInput";
 import Button from "../Button/Button";
 import PlayerItemList from "../PlayerItemList/PlayerItemList";
 import Tooltip from "../Tooltip/Tooltip";
-import { isTaskComplete, taskSortOptions, useTasksPanel } from "./useTasksPanel";
-import type { Task } from "../../types";
+import { isTaskComplete, taskSortOptions, useTasksPanel, type ItemRecord } from "./useTasksPanel";
+import { toDatetimeLocalValue, fromDatetimeLocalValue } from "../../utils/formatUtils";
 import styles from "./TasksPanel.module.scss";
 
 export default function TasksPanel(): React.ReactElement | null {
@@ -15,6 +16,11 @@ export default function TasksPanel(): React.ReactElement | null {
     setNewName,
     hideCompleted,
     visibleTasks,
+    getChildren,
+    topLevelTasks,
+    addSubtaskParent,
+    startAddSubtask,
+    clearAddSubtaskParent,
     handleCreateTask,
     handleSubmitForm,
     handleEdit,
@@ -24,6 +30,7 @@ export default function TasksPanel(): React.ReactElement | null {
     toggleHideCompleted,
     getTaskMeta,
     getTaskEditSummary,
+    updateTask,
   } = useTasksPanel();
 
   if (isLoading) return <p>Loading tasks...</p>;
@@ -32,23 +39,37 @@ export default function TasksPanel(): React.ReactElement | null {
     <div className={styles.page}>
       <div className={styles.content}>
       <form className={styles.addTaskForm} onSubmit={handleSubmitForm}>
+        {addSubtaskParent && (
+          <span className={styles.parentChip}>
+            Subtask of {addSubtaskParent.name}
+            <button
+              type="button"
+              className={styles.parentChipClear}
+              aria-label="Clear subtask parent"
+              onClick={clearAddSubtaskParent}
+            >
+              ×
+            </button>
+          </span>
+        )}
         <EntitySearchInput
           type="task"
           value={newName}
           onChange={(v) => setNewName(v)}
-          onCreate={handleCreateTask}
-          placeholder="New task name"
+          onCreate={(name) => handleCreateTask(name, { parent: addSubtaskParent?.id ?? undefined })}
+          placeholder={addSubtaskParent ? "New subtask name" : "New task name"}
           className={styles.addTaskInput}
         />
         <Button type="submit">
-          <span className={styles.addButtonText}>Add task</span>
+          <span className={styles.addButtonText}>{addSubtaskParent ? "Add subtask" : "Add task"}</span>
           <span className={styles.addButtonIcon} aria-hidden="true">✓</span>
         </Button>
       </form>
 
       <div className={styles.tasksList}>
-        <PlayerItemList<Task>
-          items={visibleTasks}
+        <PlayerItemList<ItemRecord>
+          items={visibleTasks as ItemRecord[]}
+          getChildren={getChildren}
           itemLabel="task"
           ariaLabel="Tasks"
           isItemComplete={isTaskComplete}
@@ -59,11 +80,23 @@ export default function TasksPanel(): React.ReactElement | null {
               <>
                 {meta.lastWorkedOn}
                 {meta.completionXp ? <> • +{meta.completionXp} XP</> : null}
+                {task.due_at ? (
+                  <>
+                    {" "}
+                    •{" "}
+                    <span className={classNames({ [styles.overdue]: meta.isOverdue })}>
+                      Due {meta.dueAt}
+                    </span>
+                  </>
+                ) : null}
               </>
             );
           }}
           renderEditSummary={(taskItem) => {
             const summary = getTaskEditSummary(taskItem);
+            const hasSubtasks = (taskItem.subtask_count ?? 0) > 0;
+            const parentOptions = topLevelTasks.filter((t) => t.id !== taskItem.id);
+
             return (
               <>
                 <div className={styles.taskTimestamps}>
@@ -84,24 +117,102 @@ export default function TasksPanel(): React.ReactElement | null {
                 <div>
                   Total time: {summary.totalTime}
                 </div>
+                <div className={styles.dueDateRow}>
+                  <label className={styles.timestampLabel} htmlFor="task-due-at">
+                    Due date
+                  </label>
+                  <input
+                    id="task-due-at"
+                    type="datetime-local"
+                    className={styles.dueDateInput}
+                    defaultValue={toDatetimeLocalValue(taskItem.due_at)}
+                    onBlur={(event) =>
+                      updateTask.mutate({
+                        id: taskItem.id,
+                        data: { due_at: fromDatetimeLocalValue(event.target.value) },
+                      })
+                    }
+                  />
+                  {taskItem.due_at && (
+                    <Button
+                      variant="secondary"
+                      onClick={() =>
+                        updateTask.mutate({ id: taskItem.id, data: { due_at: null } })
+                      }
+                    >
+                      Clear
+                    </Button>
+                  )}
+                </div>
+                {taskItem.parent == null && (
+                  <div className={styles.parentRow}>
+                    <label className={styles.timestampLabel} htmlFor="task-parent">
+                      Parent task
+                    </label>
+                    <Tooltip
+                      content={
+                        hasSubtasks
+                          ? "This task already has subtasks and can't be nested under another task."
+                          : undefined
+                      }
+                    >
+                      <select
+                        id="task-parent"
+                        className={styles.parentSelect}
+                        disabled={hasSubtasks}
+                        defaultValue={taskItem.parent ?? ""}
+                        onChange={(event) =>
+                          updateTask.mutate({
+                            id: taskItem.id,
+                            data: { parent: event.target.value ? Number(event.target.value) : null },
+                          })
+                        }
+                      >
+                        <option value="">No parent</option>
+                        {parentOptions.map((option) => (
+                          <option key={option.id} value={option.id}>
+                            {option.name}
+                          </option>
+                        ))}
+                      </select>
+                    </Tooltip>
+                  </div>
+                )}
               </>
             );
           }}
           hoverEdit
           renderRowActions={(task) => (
-            <Tooltip content="Start working on this task">
-              <button
-                type="button"
-                className={styles.taskPlayButton}
-                aria-label={`Start working on ${task.name}`}
-                onClick={async (event) => {
-                  event.currentTarget.blur();
-                  await handleStartTask(task);
-                }}
-              >
-                ▷
-              </button>
-            </Tooltip>
+            <>
+              {task.parent == null && (
+                <Tooltip content="Add a subtask">
+                  <button
+                    type="button"
+                    className={styles.taskSubtaskButton}
+                    aria-label={`Add subtask to ${task.name}`}
+                    onClick={(event) => {
+                      event.currentTarget.blur();
+                      startAddSubtask(task);
+                    }}
+                  >
+                    +
+                  </button>
+                </Tooltip>
+              )}
+              <Tooltip content="Start working on this task">
+                <button
+                  type="button"
+                  className={styles.taskPlayButton}
+                  aria-label={`Start working on ${task.name}`}
+                  onClick={async (event) => {
+                    event.currentTarget.blur();
+                    await handleStartTask(task);
+                  }}
+                >
+                  ▷
+                </button>
+              </Tooltip>
+            </>
           )}
           onEdit={handleEdit}
           onDelete={handleDelete}

--- a/frontend/src/components/TasksPanel/useTasksPanel.tsx
+++ b/frontend/src/components/TasksPanel/useTasksPanel.tsx
@@ -7,8 +7,10 @@ import type { Task } from "../../types";
 import type { SortOption } from "../PlayerItemList/PlayerItemList";
 import { asArray } from "../../utils/arrayUtils";
 import { isCompletable } from "../../utils/completable";
-import { formatRewardDuration } from "../../utils/formatUtils";
+import { formatRewardDuration, formatDueAt, isOverdue } from "../../utils/formatUtils";
 import { TASKS_HIDE_COMPLETED_KEY } from "../../utils/userPreferences";
+
+export type ItemRecord = Task & { [key: string]: unknown };
 
 export interface TaskEditSummary {
   created: string;
@@ -17,9 +19,14 @@ export interface TaskEditSummary {
   totalTime: string;
 }
 
+export interface ParentGroup {
+  parent: ItemRecord;
+  children: ItemRecord[];
+}
+
 export const isTaskComplete = isCompletable;
 
-export const taskSortOptions: SortOption<Task>[] = [
+export const taskSortOptions: SortOption<ItemRecord>[] = [
   {
     key: "last-worked",
     label: "Last worked",
@@ -38,6 +45,15 @@ export const taskSortOptions: SortOption<Task>[] = [
     key: "created",
     label: "Created",
     compareFn: (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  },
+  {
+    key: "due-date",
+    label: "Due date",
+    compareFn: (a, b) => {
+      const da = a.due_at ? new Date(a.due_at).getTime() : Infinity;
+      const db = b.due_at ? new Date(b.due_at).getTime() : Infinity;
+      return da - db;
+    },
   },
 ];
 
@@ -104,11 +120,64 @@ export function useTasksPanel() {
     return () => clearTimeout(timer);
   }, [completionReward]);
 
-  const safeTasks = useMemo(() => asArray(tasks), [tasks]);
+  const [addSubtaskParent, setAddSubtaskParent] = useState<ItemRecord | null>(null);
+
+  const safeTasks = useMemo(() => asArray(tasks) as ItemRecord[], [tasks]);
+
+  const topLevelTasks = useMemo(
+    () => safeTasks.filter((task) => task.parent == null),
+    [safeTasks]
+  );
+
+  const groupedTasks = useMemo<ParentGroup[]>(() => {
+    const byId = new Map<number, ItemRecord>();
+    safeTasks.forEach((task) => byId.set(task.id, task));
+
+    const childrenByParentId = new Map<number, ItemRecord[]>();
+    const topLevel: ItemRecord[] = [];
+
+    safeTasks.forEach((task) => {
+      const parentId = task.parent;
+      const parentTask = parentId != null ? byId.get(parentId) : undefined;
+      // Defensive: a task whose parent is missing or itself a subtask
+      // (grandparent nesting) renders as top-level rather than vanishing.
+      if (parentId == null || !parentTask || parentTask.parent != null) {
+        topLevel.push(task);
+      } else {
+        const siblings = childrenByParentId.get(parentId) ?? [];
+        siblings.push(task);
+        childrenByParentId.set(parentId, siblings);
+      }
+    });
+
+    const visibleTopLevel = hideCompleted
+      ? topLevel.filter((task) => !isTaskComplete(task))
+      : topLevel;
+
+    const groups: ParentGroup[] = visibleTopLevel.map((parent) => {
+      const children = childrenByParentId.get(parent.id) ?? [];
+      return {
+        parent,
+        children: hideCompleted ? children.filter((child) => !isTaskComplete(child)) : children,
+      };
+    });
+
+    return groups;
+  }, [safeTasks, hideCompleted]);
 
   const visibleTasks = useMemo(
-    () => (hideCompleted ? safeTasks.filter((task) => !isTaskComplete(task)) : safeTasks),
-    [hideCompleted, safeTasks]
+    () => groupedTasks.flatMap((group) => [group.parent, ...group.children]),
+    [groupedTasks]
+  );
+
+  const childrenByGroupParentId = useMemo(
+    () => new Map(groupedTasks.map((group) => [group.parent.id, group.children])),
+    [groupedTasks]
+  );
+
+  const getChildren = useCallback(
+    (task: ItemRecord): ItemRecord[] => childrenByGroupParentId.get(task.id) ?? [],
+    [childrenByGroupParentId]
   );
 
   const toggleHideCompleted = useCallback(() => {
@@ -124,11 +193,16 @@ export function useTasksPanel() {
   }, []);
 
   const handleCreateTask = useCallback(
-    (name: string) => {
+    (name: string, options?: { parent?: number | null; due_at?: string | null }) => {
       const trimmed = name.trim();
       if (!trimmed) return;
-      createTask.mutate({ name: trimmed });
+      createTask.mutate({
+        name: trimmed,
+        ...(options?.parent !== undefined ? { parent: options.parent } : {}),
+        ...(options?.due_at !== undefined ? { due_at: options.due_at } : {}),
+      });
       setNewName("");
+      setAddSubtaskParent(null);
     },
     [createTask]
   );
@@ -136,14 +210,29 @@ export function useTasksPanel() {
   const handleSubmitForm = useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      handleCreateTask(newName);
+      handleCreateTask(newName, { parent: addSubtaskParent?.id ?? undefined });
     },
-    [handleCreateTask, newName]
+    [handleCreateTask, newName, addSubtaskParent]
   );
 
+  const startAddSubtask = useCallback((task: ItemRecord) => {
+    setAddSubtaskParent(task);
+  }, []);
+
+  const clearAddSubtaskParent = useCallback(() => {
+    setAddSubtaskParent(null);
+  }, []);
+
   const handleEdit = useCallback(
-    (task: Task, name: string) => {
-      updateTask.mutate({ id: task.id, data: { name } });
+    (task: ItemRecord, name: string, options?: { parent?: number | null; due_at?: string | null }) => {
+      updateTask.mutate({
+        id: task.id,
+        data: {
+          name,
+          ...(options?.parent !== undefined ? { parent: options.parent } : {}),
+          ...(options?.due_at !== undefined ? { due_at: options.due_at } : {}),
+        },
+      });
     },
     [updateTask]
   );
@@ -198,6 +287,8 @@ export function useTasksPanel() {
     (task: Task) => ({
       lastWorkedOn: formatLastWorkedOn(task),
       completionXp: completionReward?.taskId === task.id ? completionReward.xp : null,
+      dueAt: formatDueAt(task.due_at),
+      isOverdue: isOverdue(task.due_at, isTaskComplete(task)),
     }),
     [completionReward]
   );
@@ -223,6 +314,12 @@ export function useTasksPanel() {
     setNewName,
     hideCompleted,
     visibleTasks,
+    groupedTasks,
+    getChildren,
+    topLevelTasks,
+    addSubtaskParent,
+    startAddSubtask,
+    clearAddSubtaskParent,
     handleCreateTask,
     handleSubmitForm,
     handleEdit,
@@ -232,5 +329,6 @@ export function useTasksPanel() {
     toggleHideCompleted,
     getTaskMeta,
     getTaskEditSummary,
+    updateTask,
   };
 }

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.module.scss
@@ -121,6 +121,15 @@ $row-control-height: 44px;
   align-items: center;
 }
 
+.modeSwitcher {
+  margin-top: sp.$spacing-md;
+  justify-content: center;
+}
+
+.planningPanel {
+  margin-top: sp.$spacing-sm;
+}
+
 .limitWarning {
   margin: sp.$spacing-sm 0 0;
   text-align: left;

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx
@@ -174,7 +174,7 @@ describe('UnifiedTimerHome', () => {
     expect(screen.getByRole('button', { name: 'Start' })).toBeEnabled();
   });
 
-  it('Start with an empty input starts a blank timer and moves to the running-unlabelled state', async () => {
+  it('Start with an empty input labels the timer "Planning" and switches to Planning mode', async () => {
     const user = userEvent.setup();
     startActivity.mockResolvedValue(null);
 
@@ -182,14 +182,16 @@ describe('UnifiedTimerHome', () => {
 
     await user.click(screen.getByRole('button', { name: 'Start' }));
 
-    expect(startActivity).toHaveBeenCalledWith({ text: '', allowBlank: true, limitSeconds: 15 });
+    expect(startActivity).toHaveBeenCalledWith({ text: 'Planning', limitSeconds: 15 });
 
-    // Reflect the timer now being active with a blank name.
-    mockGame({ status: 'active', currentActivity: { name: '' } });
+    // Reflect the timer now being active, labelled "Planning".
+    mockGame({ status: 'active', currentActivity: { name: 'Planning' } });
     rerender(<UnifiedTimerHome />);
 
-    expect(screen.getByRole('combobox', { name: 'Activity name' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Planning/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Planning' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByPlaceholderText('New task name')).toBeInTheDocument();
   });
 
   it('Start/Stop is the same persistent button element, not a swap', async () => {
@@ -200,7 +202,7 @@ describe('UnifiedTimerHome', () => {
     const startButton = screen.getByRole('button', { name: 'Start' });
 
     await user.click(startButton);
-    mockGame({ status: 'active', currentActivity: { name: '' } });
+    mockGame({ status: 'active', currentActivity: { name: 'Planning' } });
     rerender(<UnifiedTimerHome />);
 
     expect(screen.getByRole('button', { name: 'Stop' })).toBe(startButton);

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.test.tsx
@@ -18,8 +18,25 @@ const startActivity = vi.fn();
 const labelActivity = vi.fn();
 const addEntityToCache = vi.fn();
 
+const mockUseTasks = vi.fn();
+const mockUseCreateTask = vi.fn();
+const mockUseUpdateTask = vi.fn();
+const mockUseDeleteTask = vi.fn();
+const navigate = vi.fn();
+
 vi.mock('../../hooks/useGame', () => ({
   useGame: () => mockUseGame(),
+}));
+
+vi.mock('../../hooks/useTasks', () => ({
+  useTasks: () => mockUseTasks(),
+  useCreateTask: () => mockUseCreateTask(),
+  useUpdateTask: () => mockUseUpdateTask(),
+  useDeleteTask: () => mockUseDeleteTask(),
+}));
+
+vi.mock('react-router', () => ({
+  useNavigate: () => navigate,
 }));
 
 vi.mock('../../hooks/useSupportFlow', () => ({
@@ -125,6 +142,12 @@ describe('UnifiedTimerHome', () => {
     startActivity.mockReset();
     labelActivity.mockReset();
     addEntityToCache.mockReset();
+    navigate.mockReset();
+
+    mockUseTasks.mockReset().mockReturnValue({ isLoading: false, data: [] });
+    mockUseCreateTask.mockReset().mockReturnValue({ mutate: vi.fn() });
+    mockUseUpdateTask.mockReset().mockReturnValue({ mutate: vi.fn() });
+    mockUseDeleteTask.mockReset().mockReturnValue({ mutate: vi.fn() });
 
     mockUseSupportFlow.mockReturnValue({
       openWelcomeMessage: vi.fn(),
@@ -266,5 +289,108 @@ describe('UnifiedTimerHome', () => {
     expect(
       screen.getByText('This timer will stop automatically when it reaches 0:30.')
     ).toBeInTheDocument();
+  });
+
+  describe('mode switching', () => {
+    it('hides the mode switcher and tasks panel while the timer is idle', () => {
+      render(<UnifiedTimerHome />);
+
+      expect(screen.queryByRole('radiogroup', { name: 'Timer view' })).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('New task name')).not.toBeInTheDocument();
+    });
+
+    it('shows the mode switcher, defaulted to Doing, once the timer is running', () => {
+      mockGame({ status: 'active', currentActivity: { name: '' } });
+      render(<UnifiedTimerHome />);
+
+      expect(screen.getByRole('radio', { name: 'Doing' })).toHaveAttribute('aria-checked', 'true');
+      expect(screen.queryByPlaceholderText('New task name')).not.toBeInTheDocument();
+    });
+
+    it('auto-selects Planning when the activity name contains "plan"', async () => {
+      const user = userEvent.setup();
+      mockGame({ status: 'active', currentActivity: { name: '' } });
+      render(<UnifiedTimerHome />);
+
+      await user.type(screen.getByRole('combobox', { name: 'Activity name' }), 'Plan my week');
+
+      expect(screen.getByRole('radio', { name: 'Planning' })).toHaveAttribute('aria-checked', 'true');
+      expect(screen.getByPlaceholderText('New task name')).toBeInTheDocument();
+    });
+
+    it('matches "plan" case-insensitively and as a substring (e.g. "Planning")', async () => {
+      const user = userEvent.setup();
+      mockGame({ status: 'active', currentActivity: { name: '' } });
+      render(<UnifiedTimerHome />);
+
+      await user.type(screen.getByRole('combobox', { name: 'Activity name' }), 'PLANNING session');
+
+      expect(screen.getByRole('radio', { name: 'Planning' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('does not auto-select Planning for names without "plan"', async () => {
+      const user = userEvent.setup();
+      mockGame({ status: 'active', currentActivity: { name: '' } });
+      render(<UnifiedTimerHome />);
+
+      await user.type(screen.getByRole('combobox', { name: 'Activity name' }), 'Deep work');
+
+      expect(screen.getByRole('radio', { name: 'Doing' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('clicking the Planning chip renders TasksPanel and keeps timer controls visible', async () => {
+      const user = userEvent.setup();
+      mockGame({ status: 'active', currentActivity: { name: '' } });
+      render(<UnifiedTimerHome />);
+
+      await user.click(screen.getByRole('radio', { name: 'Planning' }));
+
+      expect(screen.getByRole('radio', { name: 'Planning' })).toHaveAttribute('aria-checked', 'true');
+      expect(screen.getByPlaceholderText('New task name')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+    });
+
+    it('switching back to Doing unmounts TasksPanel', async () => {
+      const user = userEvent.setup();
+      mockGame({ status: 'active', currentActivity: { name: '' } });
+      render(<UnifiedTimerHome />);
+
+      await user.click(screen.getByRole('radio', { name: 'Planning' }));
+      expect(screen.getByPlaceholderText('New task name')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('radio', { name: 'Doing' }));
+      expect(screen.queryByPlaceholderText('New task name')).not.toBeInTheDocument();
+    });
+
+    it('timer controls stay functional while in Planning mode', async () => {
+      const user = userEvent.setup();
+      mockGame({ status: 'active', currentActivity: { name: '' } });
+      render(<UnifiedTimerHome />);
+
+      await user.click(screen.getByRole('radio', { name: 'Planning' }));
+      expect(screen.getByPlaceholderText('New task name')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Stop' }));
+      expect(stop).toHaveBeenCalled();
+    });
+
+    it('switching mode does not itself reset an in-progress label edit beyond the blur it naturally causes', async () => {
+      // Clicking the Planning chip blurs the focused edit input, which
+      // `handleWrapperBlur` already commits (same as clicking anywhere else
+      // outside the card) — the mode switch itself doesn't add any extra
+      // reset logic on top of that pre-existing behaviour.
+      const user = userEvent.setup();
+      mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+      render(<UnifiedTimerHome />);
+
+      await user.click(screen.getByRole('button', { name: /Deep work/ }));
+      expect(screen.getByRole('combobox', { name: 'Activity name' })).toHaveValue('Deep work');
+
+      await user.click(screen.getByRole('radio', { name: 'Planning' }));
+      await user.click(screen.getByRole('radio', { name: 'Doing' }));
+
+      expect(screen.getByRole('button', { name: /Deep work/ })).toBeInTheDocument();
+      expect(labelActivity).toHaveBeenCalledWith('Deep work', null);
+    });
   });
 });

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
@@ -6,9 +6,18 @@ import Button from "../Button/Button";
 import AlertDialog from "../AlertDialog/AlertDialog";
 import EntitySearchInput from "../EntitySearchInput/EntitySearchInput";
 import SupportFlowModal from "../SupportFlow/SupportFlowModal";
+import ModeSwitcher from "../ModeSwitcher/ModeSwitcher";
+import TasksPanel from "../TasksPanel/TasksPanel";
 import { useActivityInput } from "../ActivityInput/useActivityInput";
 import { useDefaultActivityEntries } from "../../hooks/useDefaultActivityEntries";
 import styles from "./UnifiedTimerHome.module.scss";
+
+type TimerMode = "doing" | "planning";
+
+const TIMER_MODES = [
+  { key: "doing", label: "Doing" },
+  { key: "planning", label: "Planning" },
+];
 
 const fadeTransition = { duration: 0.18 };
 const fadeProps = {
@@ -47,6 +56,7 @@ export default function UnifiedTimerHome() {
 
   const defaultResults = useDefaultActivityEntries();
   const [submitConfirmOpen, setSubmitConfirmOpen] = useState(false);
+  const [mode, setMode] = useState<TimerMode>("doing");
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Label display (clickable name) only shows for a labelled, non-editing
@@ -66,6 +76,22 @@ export default function UnifiedTimerHome() {
     if (!isEditingLabel) return;
     containerRef.current?.querySelector("input")?.focus();
   }, [isEditingLabel]);
+
+  // Naming an activity around planning ("plan my week", "Planning session")
+  // is a strong-enough signal to drop the user straight into Planning mode
+  // without an extra click. One-directional: removing "plan" later doesn't
+  // switch back to Doing, since the user may have since interacted with the
+  // tasks panel and an automatic yank back out would be more surprising than
+  // helpful. Adjusted during render (not an effect) per React's "adjusting
+  // state when a prop changes" pattern — state, not a ref, tracks the last
+  // seen value so this only fires once per actual inputValue change.
+  const [lastCheckedInputValue, setLastCheckedInputValue] = useState<string | null>(null);
+  if (lastCheckedInputValue !== inputValue) {
+    setLastCheckedInputValue(inputValue);
+    if (mode !== "planning" && inputValue.toLowerCase().includes("plan")) {
+      setMode("planning");
+    }
+  }
 
   // Single Start button: starts blank if the input is empty, otherwise
   // starts (or labels) with whatever's typed — same distinction as before,
@@ -184,6 +210,24 @@ export default function UnifiedTimerHome() {
             </AnimatePresence>
           </motion.div>
         </motion.div>
+
+        {isActive && (
+          <>
+            <ModeSwitcher
+              modes={TIMER_MODES}
+              activeKey={mode}
+              onSelect={(key) => setMode(key as TimerMode)}
+              ariaLabel="Timer view"
+              className={styles.modeSwitcher}
+            />
+
+            {mode === "planning" && (
+              <div className={styles.planningPanel}>
+                <TasksPanel />
+              </div>
+            )}
+          </>
+        )}
 
         {showAutoStopWarning && (
           <p className={styles.limitWarning}>

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
@@ -43,7 +43,7 @@ export default function UnifiedTimerHome() {
     flowDispatch,
     handleConfirmActivity,
     handleToggle,
-    handleBlankStart,
+    handleCreateActivity,
     handleUnifiedSelect,
     handleUnifiedSubmit,
     startEditingLabel,
@@ -93,17 +93,19 @@ export default function UnifiedTimerHome() {
     }
   }
 
-  // Single Start button: starts blank if the input is empty, otherwise
-  // starts (or labels) with whatever's typed — same distinction as before,
-  // just collapsed into one action instead of two buttons.
+  // Single Start button: starting with a typed name labels the timer with
+  // it. Starting with nothing typed reads as "I don't have a specific
+  // activity yet" — rather than leaving the timer unlabelled, it's labelled
+  // "Planning" and Planning mode opens immediately so the task list is right
+  // there instead of an empty search box.
   const handleStartClick = async () => {
     if (name.trim()) {
       await handleToggle();
       return;
     }
 
-    await handleBlankStart();
-    containerRef.current?.querySelector("input")?.focus();
+    await handleCreateActivity("Planning");
+    setMode("planning");
   };
 
   const handleWrapperKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {

--- a/frontend/src/types/domain.ts
+++ b/frontend/src/types/domain.ts
@@ -213,6 +213,9 @@ export interface Task {
   is_complete: boolean;
   completed_at: string | null;
   first_completed_at: string | null;
+  due_at: string | null;
+  parent: number | null;
+  subtask_count: number;
   total_time: number;
   total_records: number;
   last_worked_on: string | null;

--- a/frontend/src/utils/formatUtils.test.ts
+++ b/frontend/src/utils/formatUtils.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  formatDueAt,
+  toDatetimeLocalValue,
+  fromDatetimeLocalValue,
+  isOverdue,
+} from "./formatUtils";
+
+describe("formatDueAt", () => {
+  // Anchor "today" to a fixed, mid-week local date so day-diff buckets are deterministic.
+  const today = new Date(2026, 6, 15, 12, 0, 0); // Wed 15 Jul 2026, local time
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(today);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const atLocalMidnight = (daysFromToday: number) => {
+    const d = new Date(today);
+    d.setDate(d.getDate() + daysFromToday);
+    d.setHours(9, 0, 0, 0);
+    return d.toISOString();
+  };
+
+  it("returns '-' when null", () => {
+    expect(formatDueAt(null)).toBe("-");
+  });
+
+  it("labels the current day as Today", () => {
+    expect(formatDueAt(atLocalMidnight(0))).toBe("Today");
+  });
+
+  it("labels the next day as Tomorrow", () => {
+    expect(formatDueAt(atLocalMidnight(1))).toBe("Tomorrow");
+  });
+
+  it("labels the previous day as Yesterday", () => {
+    expect(formatDueAt(atLocalMidnight(-1))).toBe("Yesterday");
+  });
+
+  it("labels a few days out as 'in N days'", () => {
+    expect(formatDueAt(atLocalMidnight(3))).toBe("in 3 days");
+  });
+
+  it("labels a few days back as 'N days ago'", () => {
+    expect(formatDueAt(atLocalMidnight(-3))).toBe("3 days ago");
+  });
+
+  it("labels a further-back date in weeks", () => {
+    expect(formatDueAt(atLocalMidnight(-14))).toBe("2 weeks ago");
+  });
+
+  it("labels a further-out date as an absolute weekday/day/month", () => {
+    // 9 days out from Wed 15 Jul 2026 is Fri 24 Jul 2026.
+    expect(formatDueAt(atLocalMidnight(9))).toBe("Fri 24th Jul");
+  });
+});
+
+describe("toDatetimeLocalValue", () => {
+  it("returns an empty string when null", () => {
+    expect(toDatetimeLocalValue(null)).toBe("");
+  });
+
+  it("formats a valid ISO string as YYYY-MM-DDTHH:mm", () => {
+    const value = toDatetimeLocalValue("2026-05-01T08:30:00.000Z");
+    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+  });
+});
+
+describe("fromDatetimeLocalValue", () => {
+  it("returns null for an empty string", () => {
+    expect(fromDatetimeLocalValue("")).toBeNull();
+  });
+
+  it("converts a datetime-local value to an ISO string", () => {
+    const iso = fromDatetimeLocalValue("2026-05-01T08:30");
+    expect(iso).not.toBeNull();
+    expect(new Date(iso as string).getFullYear()).toBe(2026);
+  });
+
+  it("round-trips through toDatetimeLocalValue", () => {
+    const original = "2026-05-01T08:30:00.000Z";
+    const localValue = toDatetimeLocalValue(original);
+    const roundTripped = fromDatetimeLocalValue(localValue);
+    expect(toDatetimeLocalValue(roundTripped)).toBe(localValue);
+  });
+});
+
+describe("isOverdue", () => {
+  it("is false when due_at is null", () => {
+    expect(isOverdue(null, false)).toBe(false);
+  });
+
+  it("is false when the task is complete, even if due_at is in the past", () => {
+    expect(isOverdue("2020-01-01T00:00:00.000Z", true)).toBe(false);
+  });
+
+  it("is true when due_at is in the past and the task is incomplete", () => {
+    expect(isOverdue("2020-01-01T00:00:00.000Z", false)).toBe(true);
+  });
+
+  it("is false when due_at is in the future", () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+    expect(isOverdue(future, false)).toBe(false);
+  });
+});

--- a/frontend/src/utils/formatUtils.ts
+++ b/frontend/src/utils/formatUtils.ts
@@ -55,3 +55,79 @@ export function formatRewardDuration(durationSeconds: number): string {
 
   return `${seconds} second${seconds === 1 ? "" : "s"}`;
 }
+
+function ordinalSuffix(day: number): string {
+  const remainder100 = day % 100;
+  if (remainder100 >= 11 && remainder100 <= 13) return "th";
+  switch (day % 10) {
+    case 1:
+      return "st";
+    case 2:
+      return "nd";
+    case 3:
+      return "rd";
+    default:
+      return "th";
+  }
+}
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function formatDueAt(dueAt: string | null): string {
+  if (!dueAt) return "-";
+  const date = new Date(dueAt);
+  if (Number.isNaN(date.getTime())) return "-";
+
+  const diffDays = Math.round(
+    (startOfDay(date).getTime() - startOfDay(new Date()).getTime()) / (24 * 60 * 60 * 1000)
+  );
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Tomorrow";
+  if (diffDays === -1) return "Yesterday";
+
+  if (diffDays > 1 && diffDays <= 6) return `in ${diffDays} days`;
+  if (diffDays < -1 && diffDays >= -6) return `${-diffDays} days ago`;
+
+  if (diffDays < -6) {
+    const weeks = Math.round(-diffDays / 7);
+    return `${weeks} week${weeks === 1 ? "" : "s"} ago`;
+  }
+
+  // diffDays > 6: further out than a week, show an absolute date.
+  const weekday = date.toLocaleDateString(undefined, { weekday: "short" });
+  const month = date.toLocaleDateString(undefined, { month: "short" });
+  const day = date.getDate();
+  return `${weekday} ${day}${ordinalSuffix(day)} ${month}`;
+}
+
+export function toDatetimeLocalValue(dueAt: string | null): string {
+  if (!dueAt) return "";
+  const date = new Date(dueAt);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const year = date.getFullYear();
+  const month = pad(date.getMonth() + 1);
+  const day = pad(date.getDate());
+  const hours = pad(date.getHours());
+  const minutes = pad(date.getMinutes());
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+export function fromDatetimeLocalValue(value: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+export function isOverdue(dueAt: string | null, isComplete: boolean): boolean {
+  if (!dueAt || isComplete) return false;
+  const date = new Date(dueAt);
+  if (Number.isNaN(date.getTime())) return false;
+  return date.getTime() < Date.now();
+}

--- a/frontend/tests/flows/unified-timer-home.spec.ts
+++ b/frontend/tests/flows/unified-timer-home.spec.ts
@@ -22,14 +22,23 @@ test.describe('Unified timer homepage (flag on)', () => {
       // Legacy "Recent activities" feed is not rendered under the flag.
       await expect(page.getByRole('heading', { name: 'Recent activities' })).toHaveCount(0);
 
-      // A single Start button, always enabled — starts blank when the input is empty.
+      // A single Start button, always enabled — starting with nothing typed
+      // auto-labels the timer "Planning" and opens Planning mode.
       const startButton = section.getByRole('button', { name: 'Start' });
       await expect(startButton).toBeEnabled();
       await startButton.click();
       await expect(section.getByRole('button', { name: 'Stop' })).toBeVisible();
 
+      const planningLabel = section.getByRole('button', { name: /Planning/ });
+      await expect(planningLabel).toBeVisible();
+      await expect(page.getByRole('radio', { name: 'Planning' })).toHaveAttribute('aria-checked', 'true');
+      await expect(page.getByPlaceholder('New task name')).toBeVisible();
+
+      // Click-to-edit: re-opens the input pre-filled with the current label,
+      // so it can be renamed to whatever the user is actually doing.
+      await planningLabel.click();
       const input = section.getByRole('combobox', { name: 'Activity name' });
-      await expect(input).toBeVisible();
+      await expect(input).toHaveValue('Planning');
       await input.fill('Flow test activity');
       await input.press('Enter');
 
@@ -76,10 +85,11 @@ test.describe('Unified timer homepage (flag on)', () => {
         has: page.getByRole('heading', { name: 'Activity timer' }),
       });
 
+      // Blank start auto-labels "Planning" and opens Planning mode already —
+      // no extra click needed to get there.
       await section.getByRole('button', { name: 'Start' }).click();
       await expect(section.getByRole('button', { name: 'Stop' })).toBeVisible();
-
-      await page.getByRole('radio', { name: 'Planning' }).click();
+      await expect(page.getByRole('radio', { name: 'Planning' })).toHaveAttribute('aria-checked', 'true');
 
       // The timer stays visible/controllable while planning.
       await expect(section.getByRole('button', { name: 'Stop' })).toBeVisible();

--- a/frontend/tests/flows/unified-timer-home.spec.ts
+++ b/frontend/tests/flows/unified-timer-home.spec.ts
@@ -66,6 +66,67 @@ test.describe('Unified timer homepage (flag on)', () => {
     }
   });
 
+  test('switching to Planning mode manages tasks without interfering with a running timer', async ({ page }) => {
+    await stabilizeTimerPage(page, { unifiedHomepage: true });
+    const taskName = `Planning mode task ${Date.now()}`;
+
+    try {
+      await page.goto('/timer');
+      const section = page.locator('section').filter({
+        has: page.getByRole('heading', { name: 'Activity timer' }),
+      });
+
+      await section.getByRole('button', { name: 'Start' }).click();
+      await expect(section.getByRole('button', { name: 'Stop' })).toBeVisible();
+
+      await page.getByRole('radio', { name: 'Planning' }).click();
+
+      // The timer stays visible/controllable while planning.
+      await expect(section.getByRole('button', { name: 'Stop' })).toBeVisible();
+
+      await page.getByPlaceholder('New task name').fill(taskName);
+      const [postResponse] = await Promise.all([
+        page.waitForResponse(
+          (r) => r.url().includes('/tasks/') && r.request().method() === 'POST',
+        ),
+        page.getByRole('button', { name: /add task/i }).click(),
+      ]);
+      expect(postResponse.status()).toBeLessThan(300);
+      await page.waitForResponse(
+        (r) => r.url().includes('/tasks/') && r.request().method() === 'GET',
+      );
+
+      const checkbox = page.getByRole('checkbox', { name: `Mark ${taskName} as complete` });
+      await expect(checkbox).toBeVisible({ timeout: 10000 });
+      await Promise.all([
+        page.waitForResponse(
+          (r) => r.url().includes('/tasks/') && r.request().method() === 'PATCH',
+        ),
+        checkbox.click(),
+      ]);
+      await expect(
+        page.getByRole('checkbox', { name: `Mark ${taskName} as complete` }),
+      ).toHaveCount(0);
+
+      // Clean up so repeated runs stay deterministic.
+      await page.getByRole('button', { name: 'Show complete' }).click();
+      await page.getByRole('button', { name: `Edit task ${taskName}` }).first().click();
+      const dialog = page.getByRole('dialog');
+      await dialog.getByRole('button', { name: 'Delete' }).click();
+      await dialog.getByRole('button', { name: 'Delete' }).click();
+      await expect(page.getByText(taskName)).not.toBeVisible();
+
+      await page.getByRole('radio', { name: 'Doing' }).click();
+      await expect(page.getByPlaceholder('New task name')).not.toBeVisible();
+
+      await section.getByRole('button', { name: 'Stop' }).click();
+      await page.getByRole('button', { name: 'Back to timer' }).click();
+      await expect(section.getByRole('button', { name: 'Start' })).toBeVisible();
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
+  });
+
   test('the reward dialog opened from Stop is never covered by the persistent list', async ({ page }) => {
     await stabilizeTimerPage(page, { unifiedHomepage: true });
 

--- a/progression/filters.py
+++ b/progression/filters.py
@@ -96,6 +96,11 @@ class TaskFilter(django_filters.FilterSet):
     project = django_filters.NumberFilter(field_name="project_id")
     created_at = django_filters.DateFromToRangeFilter(field_name="created_at")
     last_updated = django_filters.DateFromToRangeFilter(field_name="last_updated")
+    due_at = django_filters.DateFromToRangeFilter(field_name="due_at")
+    parent = django_filters.NumberFilter(field_name="parent_id")
+    parent__isnull = django_filters.BooleanFilter(
+        field_name="parent", lookup_expr="isnull"
+    )
 
     class Meta:
         model = Task
@@ -107,4 +112,6 @@ class TaskFilter(django_filters.FilterSet):
             "last_updated",
             "is_complete",
             "completed_at",
+            "due_at",
+            "parent",
         ]

--- a/progression/migrations/0006_task_due_at_parent.py
+++ b/progression/migrations/0006_task_due_at_parent.py
@@ -1,0 +1,30 @@
+# Generated manually to match 0005_task_first_completed_at pattern
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("progression", "0005_task_first_completed_at"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="task",
+            name="due_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="task",
+            name="parent",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="subtasks",
+                to="progression.task",
+            ),
+        ),
+    ]

--- a/progression/models.py
+++ b/progression/models.py
@@ -2,6 +2,7 @@
 from decimal import Decimal
 from datetime import datetime, timedelta
 from django.apps import apps
+from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import CheckConstraint, Q, Sum
 from django.utils import timezone
@@ -677,15 +678,42 @@ class Task(PlayerOwnedMixin):
     is_complete = models.BooleanField(default=False)
     completed_at = models.DateTimeField(null=True, blank=True)
     first_completed_at = models.DateTimeField(null=True, blank=True)
+    due_at = models.DateTimeField(null=True, blank=True)
+    parent = models.ForeignKey(
+        "self",
+        on_delete=models.CASCADE,
+        related_name="subtasks",
+        null=True,
+        blank=True,
+    )
+
+    def clean(self):
+        super().clean()
+        if self.parent_id is None:
+            return
+        if self.parent_id == self.id:
+            raise ValidationError({"parent": "A task cannot be its own parent."})
+        if self.parent.parent_id is not None:
+            raise ValidationError({"parent": "Cannot nest more than one level deep."})
+        if self.parent.player_id != self.player_id:
+            raise ValidationError(
+                {"parent": "Parent task must belong to the same player."}
+            )
+        if self.pk and self.subtasks.exists():
+            raise ValidationError(
+                {"parent": "A task with subtasks cannot itself have a parent."}
+            )
 
     @property
     def total_time(self):
-        return (
+        own_total = (
             self.records.filter(is_complete=True).aggregate(total=Sum("duration"))[
                 "total"
             ]
             or 0
         )
+        children_total = sum(child.total_time for child in self.subtasks.all())
+        return own_total + children_total
 
     @property
     def total_records(self):

--- a/progression/serializers.py
+++ b/progression/serializers.py
@@ -1,5 +1,6 @@
 # progression/serializers.py
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
 from rest_framework import serializers
 
@@ -221,6 +222,7 @@ class TaskSerializer(serializers.ModelSerializer):
     total_time = serializers.IntegerField(read_only=True)
     total_records = serializers.IntegerField(read_only=True)
     last_worked_on = serializers.DateTimeField(read_only=True)
+    subtask_count = serializers.IntegerField(source="subtasks.count", read_only=True)
 
     class Meta:
         model = Task
@@ -235,8 +237,36 @@ class TaskSerializer(serializers.ModelSerializer):
             "is_complete",
             "completed_at",
             "first_completed_at",
+            "due_at",
+            "parent",
+            "subtask_count",
             "total_time",
             "total_records",
             "last_worked_on",
         ]
         read_only_fields = ["player", "first_completed_at"]
+
+    def validate(self, attrs):
+        instance = self.instance
+        parent = attrs.get("parent", instance.parent if instance else None)
+
+        if instance:
+            player_id = instance.player_id
+        else:
+            request = self.context.get("request")
+            player_id = (
+                request.user.player.id
+                if request and getattr(request.user, "is_authenticated", False)
+                else None
+            )
+
+        candidate = Task(
+            id=instance.id if instance else None,
+            player_id=player_id,
+            parent=parent,
+        )
+        try:
+            candidate.clean()
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.message_dict)
+        return attrs

--- a/progression/tests/test_task_api.py
+++ b/progression/tests/test_task_api.py
@@ -6,8 +6,11 @@ Covers:
 - The first-completion bonus awarded by ``TaskViewSet.partial_update``
 """
 
+from datetime import timedelta
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -108,6 +111,117 @@ class TaskViewSetTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         names = [t["name"] for t in response.data["results"]]
         self.assertEqual(names, ["Done"])
+
+    def test_create_with_due_at(self):
+        due_at = timezone.now() + timedelta(days=2)
+        response = self.client.post(
+            reverse("tasks-list"), {"name": "Due task", "due_at": due_at.isoformat()}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        task = Task.objects.get(pk=response.data["id"])
+        self.assertIsNotNone(task.due_at)
+
+    def test_create_subtask_via_parent(self):
+        parent = Task.objects.create(player=self.player, name="Parent")
+
+        response = self.client.post(
+            reverse("tasks-list"), {"name": "Child", "parent": parent.id}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        task = Task.objects.get(pk=response.data["id"])
+        self.assertEqual(task.parent_id, parent.id)
+        self.assertEqual(response.data["subtask_count"], 0)
+
+    def test_reject_subtask_of_subtask(self):
+        parent = Task.objects.create(player=self.player, name="Parent")
+        child = Task.objects.create(player=self.player, name="Child", parent=parent)
+
+        response = self.client.post(
+            reverse("tasks-list"), {"name": "Grandchild", "parent": child.id}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_reject_giving_parent_to_task_with_existing_subtasks(self):
+        parent = Task.objects.create(player=self.player, name="Parent")
+        Task.objects.create(player=self.player, name="Child", parent=parent)
+        other = Task.objects.create(player=self.player, name="Other")
+
+        response = self.client.patch(
+            reverse("tasks-detail", args=[parent.id]), {"parent": other.id}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_filter_by_parent(self):
+        parent = Task.objects.create(player=self.player, name="Parent")
+        child = Task.objects.create(player=self.player, name="Child", parent=parent)
+        Task.objects.create(player=self.player, name="Unrelated")
+
+        response = self.client.get(reverse("tasks-list"), {"parent": parent.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [t["id"] for t in response.data["results"]]
+        self.assertEqual(ids, [child.id])
+
+    def test_filter_by_parent_isnull(self):
+        parent = Task.objects.create(player=self.player, name="Parent")
+        Task.objects.create(player=self.player, name="Child", parent=parent)
+
+        response = self.client.get(reverse("tasks-list"), {"parent__isnull": "true"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = [t["name"] for t in response.data["results"]]
+        self.assertEqual(names, ["Parent"])
+
+    def test_filter_by_due_at_range(self):
+        in_range = Task.objects.create(
+            player=self.player,
+            name="In range",
+            due_at=timezone.now() + timedelta(days=1),
+        )
+        Task.objects.create(
+            player=self.player,
+            name="Out of range",
+            due_at=timezone.now() + timedelta(days=10),
+        )
+
+        response = self.client.get(
+            reverse("tasks-list"),
+            {
+                "due_at_after": timezone.now().isoformat(),
+                "due_at_before": (timezone.now() + timedelta(days=3)).isoformat(),
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [t["id"] for t in response.data["results"]]
+        self.assertEqual(ids, [in_range.id])
+
+    def test_delete_parent_cascades_via_api(self):
+        parent = Task.objects.create(player=self.player, name="Parent")
+        child = Task.objects.create(player=self.player, name="Child", parent=parent)
+
+        response = self.client.delete(reverse("tasks-detail", args=[parent.id]))
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Task.objects.filter(pk=child.id).exists())
+
+    def test_subtask_count_accuracy(self):
+        parent = Task.objects.create(player=self.player, name="Parent")
+        Task.objects.create(player=self.player, name="Child 1", parent=parent)
+        Task.objects.create(player=self.player, name="Child 2", parent=parent)
+
+        list_response = self.client.get(reverse("tasks-list"))
+        detail_response = self.client.get(reverse("tasks-detail", args=[parent.id]))
+
+        parent_in_list = next(
+            t for t in list_response.data["results"] if t["id"] == parent.id
+        )
+        self.assertEqual(parent_in_list["subtask_count"], 2)
+        self.assertEqual(detail_response.data["subtask_count"], 2)
 
 
 class TaskCompletionBonusTests(APITestCase):

--- a/progression/tests/test_task_models.py
+++ b/progression/tests/test_task_models.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
@@ -51,3 +52,97 @@ class TaskModelTests(TestCase):
         )
 
         self.assertEqual(self.task.last_worked_on, newer_completed_at)
+
+    def test_due_at_is_optional(self):
+        task = Task.objects.create(player=self.player, name="No due date")
+        self.assertIsNone(task.due_at)
+
+        due_at = timezone.now() + timedelta(days=1)
+        task.due_at = due_at
+        task.full_clean()
+        task.save()
+        task.refresh_from_db()
+        self.assertEqual(task.due_at, due_at)
+
+    def test_valid_parent_subtask_assignment(self):
+        subtask = Task(player=self.player, name="Subtask", parent=self.task)
+        subtask.full_clean()
+        subtask.save()
+
+        self.assertEqual(subtask.parent, self.task)
+        self.assertIn(subtask, self.task.subtasks.all())
+
+    def test_self_parent_rejected(self):
+        self.task.parent = self.task
+        with self.assertRaises(ValidationError):
+            self.task.clean()
+
+    def test_grandparent_nesting_rejected(self):
+        subtask = Task.objects.create(
+            player=self.player, name="Subtask", parent=self.task
+        )
+        grandchild = Task(player=self.player, name="Grandchild", parent=subtask)
+
+        with self.assertRaises(ValidationError):
+            grandchild.clean()
+
+    def test_parent_with_subtasks_cannot_get_a_parent(self):
+        Task.objects.create(player=self.player, name="Subtask", parent=self.task)
+        other = Task.objects.create(player=self.player, name="Other task")
+
+        self.task.parent = other
+        with self.assertRaises(ValidationError):
+            self.task.clean()
+
+    def test_cross_player_parent_rejected(self):
+        other_user = get_user_model().objects.create_user(
+            email="other-player@example.com", password="pass"
+        )
+        other_task = Task.objects.create(player=other_user.player, name="Theirs")
+
+        subtask = Task(player=self.player, name="Subtask", parent=other_task)
+        with self.assertRaises(ValidationError):
+            subtask.clean()
+
+    def test_cascade_delete_removes_subtasks(self):
+        subtask = Task.objects.create(
+            player=self.player, name="Subtask", parent=self.task
+        )
+        subtask_id = subtask.id
+
+        self.task.delete()
+
+        self.assertFalse(Task.objects.filter(pk=subtask_id).exists())
+
+    def test_total_time_rolls_up_subtask_time(self):
+        PlayerActivity.objects.create(
+            player=self.player,
+            name="Parent work",
+            task=self.task,
+            duration=50,
+            is_complete=True,
+        )
+        subtask = Task.objects.create(
+            player=self.player, name="Subtask", parent=self.task
+        )
+        PlayerActivity.objects.create(
+            player=self.player,
+            name="Subtask work",
+            task=subtask,
+            duration=30,
+            is_complete=True,
+        )
+
+        self.assertEqual(subtask.total_time, 30)
+        self.assertEqual(self.task.total_time, 80)
+
+    def test_total_time_with_no_subtasks_unchanged(self):
+        PlayerActivity.objects.create(
+            player=self.player,
+            name="Solo work",
+            task=self.task,
+            duration=40,
+            is_complete=True,
+        )
+
+        self.assertEqual(self.task.total_time, 40)


### PR DESCRIPTION
## Summary

Rebases `feat/unified-timer-task-mode-plan` onto current `development`.

- feat(frontend): add Doing/Planning mode switch to `UnifiedTimerHome`
- feat: add task due dates (`Task.due_at`) and single-level subtasks (`Task.parent`), including model validation, serializer/filter support, and `PlayerItemList` `getChildren` rendering for nested subtasks
- feat(frontend): blank Start now auto-labels the timer "Planning" and opens Planning mode immediately, instead of starting a genuinely unlabelled timer (plan addendum, `.claude/plans/unified-timer-task-mode-plan.md` §9)
- plan/docs: implementation plan notes for all of the above, plus a documentation-only addendum (§10) recording two behaviors Phase 2 shipped that deviated from the original plan without a recorded design decision — the mode switcher only rendering while a timer is active, and an undocumented "activity name contains 'plan'" auto-switch

## Rebase conflict resolution

`development` had independently refactored `TasksPanel`/`useTasksPanel` (extracting `isTaskComplete` to a shared `isCompletable` util and `safeTasks` to a shared `asArray` util) while this branch extended the same functions with the `ItemRecord`/`ParentGroup` subtask model and due-date handling. Conflicts in `TasksPanel.tsx` and `useTasksPanel.tsx` were resolved by combining both: kept `development`'s shared `asArray`/`isCompletable` utils while layering the subtask grouping, `ItemRecord` type, and due-date logic from this branch on top.

While verifying the rebase against the full test suite, found and fixed two classes of bugs the merge introduced silently (no conflict markers, since they were "clean" auto-merges of non-overlapping lines):

1. **Stale Sass namespace**: `development` renamed the `base/variables` spacing alias (`v`) to `semantic/spacing` (`sp`). `PlayerItemList.module.scss`, `TasksPanel.module.scss`, `ModeSwitcher.module.scss`, and `UnifiedTimerHome.module.scss` all had new rules from this branch still referencing the old `v.` alias — compiled fine at rebase time (no conflict) but broke every test that renders those components. Updated to `sp.`.
2. **Stale router mock**: `development`'s react-router v8 migration moved `useNavigate` from `react-router-dom` to `react-router`. `UnifiedTimerHome.test.tsx` still mocked `react-router-dom`, which silently stopped intercepting the hook once `TasksPanel` (which now imports from `react-router`) got rendered inside `UnifiedTimerHome` via Planning mode.

Both fixes are folded into the commits that introduced the breakage (not tacked on as a separate "fixup" commit) so `git bisect` stays meaningful.

## Blank-start behavior change

Clicking Start with nothing typed used to start a genuinely unlabelled timer (`handleBlankStart`). It now labels the timer `"Planning"` (via the same `handleCreateActivity` path any typed name goes through) and switches `mode` to `"planning"` immediately. Starting with a typed name is unchanged. `handleBlankStart`/`isUnlabelled` are untouched in `useActivityInput` — unlabelled-while-running is still reachable via other paths (e.g. clearing a running timer's label through click-to-edit) — only `UnifiedTimerHome`'s Start-button branch stops calling it.

## Plan deviations (documentation only, no behavior changed)

Two things Phase 2 shipped with that don't match the original plan, neither with a recorded design decision, now written up in §10 of the plan doc:
1. The mode switcher/planning panel only render while `isActive` — the plan's Assumption 2 said it should be visible regardless.
2. An auto-switch to Planning when the activity name contains "plan" (tested, working as designed) that was never mentioned anywhere in the plan.

Both are left as shipped; reversing #1 is a separate product decision, not part of this PR.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on all touched component directories — clean (pre-existing unrelated lint errors elsewhere on `development` untouched)
- `npx vitest run` — 448/448 tests passed (2 unrelated pre-existing browser-mode test files fail in this sandbox due to a missing Playwright browser binary, unrelated to this change)
- Playwright E2E flow spec updated to match the new blank-start behavior (not run in this sandbox — no browser binary available)
- Python files affected by the rebase parsed and the new migration (`0006_task_due_at_parent`) chains correctly off `0005_task_first_completed_at`; Django/Docker weren't available in this sandbox to run the backend test suite

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01En4PsTNk4yzvbt1EuKZgaJ