### PR TITLE
Add PlayerActivity catalog: Activity/SuggestedActivity (#689)

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -13,7 +13,7 @@ from unittest.mock import patch, MagicMock
 from character.models import Character, PlayerCharacterLink
 from core.models import Announcement, PlayerAnnouncementState
 from gameplay.models import Quest
-from progression.models import CharacterQuest, PlayerActivity
+from progression.models import Activity, CharacterQuest, PlayerActivity
 from server_management.models import FeatureFlag
 from users.models import CustomUserManager, Player
 
@@ -430,7 +430,7 @@ class AppConfigViewTests(APITestCase):
         )
 
 
-class PlayerActivityGroupKeyAPITests(APITestCase):
+class PlayerActivityActivityLinkAPITests(APITestCase):
     def setUp(self):
         self.user = create_test_user(
             email="activity-groups@example.com",
@@ -439,16 +439,10 @@ class PlayerActivityGroupKeyAPITests(APITestCase):
         self.client.force_authenticate(user=self.user)
         self.url = reverse("playeractivity-list")
 
-    def test_create_reuses_dominant_exact_match_group_key(self):
-        PlayerActivity.objects.create(
+    def test_create_reuses_case_insensitive_matching_activity(self):
+        existing = PlayerActivity.objects.create(
             player=player_for(self.user),
             name="Morning planning",
-            group_key="morning-planning",
-        )
-        PlayerActivity.objects.create(
-            player=player_for(self.user),
-            name="morning planning",
-            group_key="morning-planning",
         )
 
         response = self.client.post(
@@ -459,6 +453,9 @@ class PlayerActivityGroupKeyAPITests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(
-            response.data["activity"]["group_key"],
-            "morning-planning",
+            response.data["activity"]["activity"],
+            existing.activity_id,
+        )
+        self.assertEqual(
+            Activity.objects.filter(player=player_for(self.user)).count(), 1
         )

--- a/progression/admin.py
+++ b/progression/admin.py
@@ -7,6 +7,8 @@ from .models import (
     Role,
     PlayerSkill,
     CharacterSkill,
+    Activity,
+    SuggestedActivity,
     PlayerActivity,
     CharacterActivity,
     CharacterQuest,
@@ -93,6 +95,24 @@ class CharacterSkillAdmin(admin.ModelAdmin):
 
 
 #########################################
+#####      Activity admins
+#########################################
+
+
+# @admin.register(Activity)
+class ActivityAdmin(admin.ModelAdmin):
+    list_display = ("id", "name", "player", "created_at")
+    search_fields = ("name", "description", "player__name")
+    list_filter = ("player",)
+
+
+# @admin.register(SuggestedActivity)
+class SuggestedActivityAdmin(admin.ModelAdmin):
+    list_display = ("id", "name", "created_at")
+    search_fields = ("name", "description")
+
+
+#########################################
 #####      TimeRecord admins
 #########################################
 
@@ -102,7 +122,7 @@ class PlayerActivityAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "name",
-        "group_key",
+        "activity",
         "player",
         "origin",
         "duration",
@@ -111,7 +131,7 @@ class PlayerActivityAdmin(admin.ModelAdmin):
         "started_at",
         "completed_at",
     )
-    search_fields = ("name", "group_key", "description", "player__name")
+    search_fields = ("name", "activity__name", "description", "player__name")
     list_filter = (
         "player",
         "origin",

--- a/progression/migrations/0010_activity_catalog.py
+++ b/progression/migrations/0010_activity_catalog.py
@@ -1,0 +1,77 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("progression", "0009_merge_20260806_1433"),
+        ("users", "0012_waitlist_nudge_fields"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SuggestedActivity",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                ("description", models.TextField(blank=True, max_length=2000)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("last_updated", models.DateTimeField(auto_now=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="Activity",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                ("description", models.TextField(blank=True, max_length=2000)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("last_updated", models.DateTimeField(auto_now=True)),
+                (
+                    "player",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="activity_catalog",
+                        to="users.player",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "progression_activity_catalog",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="activity",
+            constraint=models.UniqueConstraint(
+                fields=("player", "name"), name="unique_player_activity_name"
+            ),
+        ),
+        migrations.AddField(
+            model_name="playeractivity",
+            name="activity",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="sessions",
+                to="progression.activity",
+            ),
+        ),
+    ]

--- a/progression/migrations/0011_backfill_playeractivity_activity.py
+++ b/progression/migrations/0011_backfill_playeractivity_activity.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+
+def backfill_activity(apps, schema_editor):
+    PlayerActivity = apps.get_model("progression", "PlayerActivity")
+    Activity = apps.get_model("progression", "Activity")
+
+    activity_cache = {}  # (player_id, normalized_name.casefold()) -> Activity.id
+
+    for session in (
+        PlayerActivity.objects.filter(activity__isnull=True)
+        .exclude(name="")
+        .order_by("id")
+    ):
+        normalized_name = session.name.strip()
+        if not normalized_name:
+            continue
+
+        cache_key = (session.player_id, normalized_name.casefold())
+        activity_id = activity_cache.get(cache_key)
+        if activity_id is None:
+            activity = Activity.objects.filter(
+                player_id=session.player_id, name__iexact=normalized_name
+            ).first()
+            if activity is None:
+                activity = Activity.objects.create(
+                    player_id=session.player_id, name=normalized_name
+                )
+            activity_id = activity.id
+            activity_cache[cache_key] = activity_id
+
+        session.activity_id = activity_id
+        session.save(update_fields=["activity"])
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("progression", "0010_activity_catalog"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_activity, noop_reverse),
+    ]

--- a/progression/migrations/0012_remove_playeractivity_group_key.py
+++ b/progression/migrations/0012_remove_playeractivity_group_key.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("progression", "0011_backfill_playeractivity_activity"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="playeractivity",
+            name="group_key",
+        ),
+    ]

--- a/progression/models.py
+++ b/progression/models.py
@@ -1,6 +1,6 @@
 # progression/models.py
 from decimal import Decimal
-from datetime import datetime, timedelta
+from datetime import datetime
 from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
@@ -231,12 +231,67 @@ class TimeRecord(models.Model):
         abstract = True
 
 
+class Activity(PlayerOwnedMixin):
+    """
+    A player's reusable activity "type" (e.g. "Write tests"). PlayerActivity
+    sessions FK this explicitly rather than each owning a free-standing
+    name, replacing the old fuzzy name-matching (group_key/infer_group_key).
+    """
+
+    player = models.ForeignKey(
+        "users.Player", on_delete=models.CASCADE, related_name="activity_catalog"
+    )
+    name = models.CharField(max_length=255)
+    description = models.TextField(max_length=2000, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    last_updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        # progression_activity is already claimed by PlayerActivity's legacy
+        # explicit db_table.
+        db_table = "progression_activity_catalog"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["player", "name"], name="unique_player_activity_name"
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.name} ({self.player.name})"
+
+    @classmethod
+    def get_or_create_for_player(cls, player, name: str) -> "Activity":
+        normalized_name = name.strip()
+        existing = cls.objects.filter(
+            player=player, name__iexact=normalized_name
+        ).first()
+        if existing:
+            return existing
+        return cls.objects.create(player=player, name=normalized_name)
+
+
+class SuggestedActivity(models.Model):
+    """
+    Authored, curated catalog for activity-name autocomplete - no FK to any
+    player's data, so player-typed activity names (see Activity) stay
+    private.
+    """
+
+    name = models.CharField(max_length=255)
+    description = models.TextField(max_length=2000, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    last_updated = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.name
+
+
 class PlayerActivity(TimeRecord, PlayerOwnedMixin):
     """
-    Represents an activity tracked by a user.
+    Represents an activity session tracked by a user.
 
     Inherits common time tracking fields and behaviour from ``TimeRecord``.
-    Activities may be linked to a skill or project, and can be private.
+    Sessions may be linked to a skill or project, and can be private.
     """
 
     class Origin(models.TextChoices):
@@ -246,7 +301,13 @@ class PlayerActivity(TimeRecord, PlayerOwnedMixin):
     player = models.ForeignKey(
         "users.Player", on_delete=models.CASCADE, related_name="activities"
     )
-    group_key = models.CharField(max_length=255, null=True, blank=True, db_index=True)
+    activity = models.ForeignKey(
+        Activity,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="sessions",
+    )
     is_private = models.BooleanField(default=False)
     origin = models.CharField(
         max_length=10, choices=Origin.choices, default=Origin.TIMER
@@ -289,139 +350,22 @@ class PlayerActivity(TimeRecord, PlayerOwnedMixin):
         """
         return "Private activity" if self.is_private else f"activity {self.name}"
 
-    @staticmethod
-    def _normalized_grouping_name(name: str | None) -> str:
-        return (name or "").strip().casefold()
-
-    @staticmethod
-    def _history_last_seen(activity: "PlayerActivity"):
-        return activity.completed_at or activity.last_updated or activity.created_at
-
-    def _grouped_history(self):
-        if not self.player_id:
-            return []
-
-        queryset = (
-            self.__class__.objects.filter(player_id=self.player_id)
-            .exclude(group_key__isnull=True)
-            .exclude(group_key="")
-            .only(
-                "id", "name", "group_key", "completed_at", "last_updated", "created_at"
-            )
-        )
-
-        if self.pk:
-            queryset = queryset.exclude(pk=self.pk)
-
-        return list(queryset)
-
-    def infer_group_key(self) -> str | None:
-        normalized_name = self._normalized_grouping_name(self.name)
-        if not normalized_name:
-            return None
-
-        history = self._grouped_history()
-        if not history:
-            return None
-
-        overall_stats: dict[str, dict[str, Any]] = {}
-        exact_stats: dict[str, dict[str, Any]] = {}
-        similar_stats: dict[str, dict[str, Any]] = {}
-
-        for activity in history:
-            if not activity.group_key:
-                continue
-
-            last_seen = self._history_last_seen(activity)
-            group_key = activity.group_key
-            existing_name = self._normalized_grouping_name(activity.name)
-
-            overall_entry = overall_stats.setdefault(
-                group_key,
-                {"count": 0, "last_seen": last_seen},
-            )
-            overall_entry["count"] += 1
-            if last_seen > overall_entry["last_seen"]:
-                overall_entry["last_seen"] = last_seen
-
-            if existing_name == normalized_name:
-                exact_entry = exact_stats.setdefault(
-                    group_key,
-                    {"count": 0, "last_seen": last_seen},
-                )
-                exact_entry["count"] += 1
-                if last_seen > exact_entry["last_seen"]:
-                    exact_entry["last_seen"] = last_seen
-                continue
-
-            if existing_name and (
-                normalized_name in existing_name or existing_name in normalized_name
-            ):
-                similar_entry = similar_stats.setdefault(
-                    group_key,
-                    {"count": 0, "last_seen": last_seen},
-                )
-                similar_entry["count"] += 1
-                if last_seen > similar_entry["last_seen"]:
-                    similar_entry["last_seen"] = last_seen
-
-        def ranked_candidates(stats: dict[str, dict[str, Any]]):
-            return sorted(
-                (
-                    {
-                        "group_key": group_key,
-                        "count": values["count"],
-                        "overall_count": overall_stats[group_key]["count"],
-                        "last_seen": values["last_seen"],
-                    }
-                    for group_key, values in stats.items()
-                ),
-                key=lambda candidate: (
-                    -candidate["count"],
-                    -candidate["overall_count"],
-                    -candidate["last_seen"].timestamp(),
-                ),
-            )
-
-        exact_candidates = ranked_candidates(exact_stats)
-        if exact_candidates:
-            return cast(str, exact_candidates[0]["group_key"])
-
-        similar_candidates = ranked_candidates(similar_stats)
-        if not similar_candidates:
-            return None
-
-        top_candidate = similar_candidates[0]
-        top_last_seen = cast(datetime, top_candidate["last_seen"])
-        if top_candidate["count"] < 3 or timezone.now() - top_last_seen > timedelta(
-            days=120
-        ):
-            return None
-
-        if len(similar_candidates) > 1:
-            second_candidate = similar_candidates[1]
-            if (
-                top_candidate["count"] < second_candidate["count"] * 2
-                or top_candidate["count"] - second_candidate["count"] < 2
-            ):
-                return None
-
-        return cast(str, top_candidate["group_key"])
-
     def save(self, *args, **kwargs):
-        if not self.group_key:
-            inferred_group_key = self.infer_group_key()
-            if inferred_group_key:
-                self.group_key = inferred_group_key
-                update_fields = kwargs.get("update_fields")
-                if update_fields is not None:
-                    kwargs["update_fields"] = set(update_fields) | {"group_key"}
+        if not self.activity_id and self.player_id and self.name.strip():
+            self.activity = Activity.get_or_create_for_player(self.player, self.name)
+            update_fields = kwargs.get("update_fields")
+            if update_fields is not None:
+                kwargs["update_fields"] = set(update_fields) | {"activity"}
 
         super().save(*args, **kwargs)
 
     def rename(self, newName):
         self.name = newName
-        self.save(update_fields=["name"])
+        update_fields = ["name"]
+        if newName.strip() and self.player_id:
+            self.activity = Activity.get_or_create_for_player(self.player, newName)
+            update_fields.append("activity")
+        self.save(update_fields=update_fields)
 
     def calculate_base_xp(self, duration: int) -> int:
         from core.models import GameSettings

--- a/progression/serializers.py
+++ b/progression/serializers.py
@@ -12,6 +12,8 @@ from .models import (
     Role,
     PlayerSkill,
     CharacterSkill,
+    Activity,
+    SuggestedActivity,
     PlayerActivity,
     CharacterActivity,
     CharacterQuest,
@@ -130,24 +132,47 @@ class CharacterSkillSerializer(SkillBaseSerializer):
 #########################################
 
 
+class ActivitySerializer(serializers.ModelSerializer):
+    player: serializers.PrimaryKeyRelatedField[Player] = (
+        serializers.PrimaryKeyRelatedField(read_only=True)
+    )
+
+    class Meta:
+        model = Activity
+        fields = [
+            "id",
+            "player",
+            "name",
+            "description",
+            "created_at",
+            "last_updated",
+        ]
+        read_only_fields = ["player"]
+
+
+class SuggestedActivitySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SuggestedActivity
+        fields = ["id", "name", "description", "created_at", "last_updated"]
+
+
 class PlayerActivitySerializer(TimeRecordBaseSerializer):
     player: serializers.PrimaryKeyRelatedField[Player] = (
         serializers.PrimaryKeyRelatedField(read_only=True)
     )
-    group_key = serializers.CharField(read_only=True)
 
     class Meta(TimeRecordBaseSerializer.Meta):
         model = PlayerActivity
         fields = TimeRecordBaseSerializer.Meta.fields + [
             "player",
-            "group_key",
+            "activity",
             "is_private",
             "origin",
             "skill",
             "project",
             "task",
         ]
-        read_only_fields = ["player", "origin"]
+        read_only_fields = ["player", "origin", "activity"]
 
 
 class OfflineActivityLogSerializer(serializers.Serializer):

--- a/progression/tests/test_activities.py
+++ b/progression/tests/test_activities.py
@@ -1,9 +1,10 @@
-from datetime import timedelta
+from django.contrib.auth import get_user_model
 
-from django.utils import timezone
-
-from progression.models import Category, PlayerActivity, PlayerSkill
+from progression.models import Activity, Category, PlayerActivity, PlayerSkill
+from users.models import Player
 from .base import BaseTestCase
+
+User = get_user_model()
 
 
 class ActivityModelTests(BaseTestCase):
@@ -47,77 +48,42 @@ class ActivityModelTests(BaseTestCase):
         self.assertEqual(self.skill.total_time, 30)
         self.assertEqual(self.skill.records.count(), 1)
 
-    def test_activity_infers_group_key_from_exact_case_insensitive_match(self):
-        PlayerActivity.objects.create(
-            player=self.player,
-            name="Deep Work",
-            group_key="deep-work-session",
-        )
-        PlayerActivity.objects.create(
-            player=self.player,
-            name="deep work",
-            group_key="deep-work-session",
-        )
-        PlayerActivity.objects.create(
-            player=self.player,
-            name="Deep Work",
-            group_key="other-group",
-        )
+    def test_creating_a_session_resolves_a_case_insensitive_match(self):
+        first = PlayerActivity.objects.create(player=self.player, name="Deep Work")
+        second = PlayerActivity.objects.create(player=self.player, name="deep work")
+        third = PlayerActivity.objects.create(player=self.player, name="DEEP WORK")
 
-        activity = PlayerActivity.objects.create(
-            player=self.player,
-            name="DEEP WORK",
-        )
+        self.assertEqual(Activity.objects.filter(player=self.player).count(), 1)
+        self.assertEqual(first.activity_id, second.activity_id)
+        self.assertEqual(first.activity_id, third.activity_id)
+        self.assertEqual(first.activity.name, "Deep Work")
 
-        self.assertEqual(activity.group_key, "deep-work-session")
+    def test_creating_a_session_with_a_new_name_creates_a_new_activity(self):
+        PlayerActivity.objects.create(player=self.player, name="Deep Work")
+        activity = PlayerActivity.objects.create(player=self.player, name="Admin")
 
-    def test_activity_infers_group_key_from_dominant_similar_titles(self):
-        recent_time = timezone.now() - timedelta(days=5)
-        for name in [
-            "Write docs",
-            "Write documentation",
-            "Write docs sprint",
-        ]:
-            activity = PlayerActivity.objects.create(
-                player=self.player,
-                name=name,
-                group_key="docs-writing",
-            )
-            PlayerActivity.objects.filter(pk=activity.pk).update(
-                last_updated=recent_time
-            )
+        self.assertEqual(Activity.objects.filter(player=self.player).count(), 2)
+        self.assertEqual(activity.activity.name, "Admin")
 
-        older_activity = PlayerActivity.objects.create(
-            player=self.player,
-            name="Write document",
-            group_key="other-group",
-        )
-        PlayerActivity.objects.filter(pk=older_activity.pk).update(
-            last_updated=timezone.now() - timedelta(days=180)
-        )
+    def test_blank_named_session_leaves_activity_unset(self):
+        activity = PlayerActivity.objects.create(player=self.player, name="")
 
-        activity = PlayerActivity.objects.create(
-            player=self.player,
-            name="Write doc",
-        )
+        self.assertIsNone(activity.activity)
 
-        self.assertEqual(activity.group_key, "docs-writing")
+    def test_renaming_a_session_re_resolves_its_activity(self):
+        first = PlayerActivity.objects.create(player=self.player, name="Deep Work")
+        session = PlayerActivity.objects.create(player=self.player, name="")
 
-    def test_activity_leaves_group_key_null_when_similar_signal_is_weak(self):
-        PlayerActivity.objects.create(
-            player=self.player,
-            name="Write docs",
-            group_key="docs-writing",
-        )
-        PlayerActivity.objects.create(
-            player=self.player,
-            name="Write document",
-            group_key="document-work",
-        )
+        session.rename("deep work")
 
-        activity = PlayerActivity.objects.create(
-            player=self.player,
-            name="Write doc",
-        )
+        self.assertEqual(session.activity_id, first.activity_id)
 
-        self.assertIsNone(activity.group_key)
+    def test_activities_are_not_shared_across_players(self):
+        other_user = User.objects.create_user(email="other@test.com", password="pass")
+        other_player, _ = Player.objects.get_or_create(user=other_user)
+
+        mine = PlayerActivity.objects.create(player=self.player, name="Deep Work")
+        theirs = PlayerActivity.objects.create(player=other_player, name="Deep Work")
+
+        self.assertNotEqual(mine.activity_id, theirs.activity_id)
+        self.assertEqual(Activity.objects.filter(name__iexact="deep work").count(), 2)

--- a/progression/views.py
+++ b/progression/views.py
@@ -21,6 +21,8 @@ from .models import (
     Role,
     PlayerSkill,
     CharacterSkill,
+    Activity,
+    SuggestedActivity,
     PlayerActivity,
     CharacterActivity,
     CharacterQuest,
@@ -33,6 +35,8 @@ from .serializers import (
     RoleSerializer,
     PlayerSkillSerializer,
     CharacterSkillSerializer,
+    ActivitySerializer,
+    SuggestedActivitySerializer,
     PlayerActivitySerializer,
     OfflineActivityLogSerializer,
     CharacterActivitySerializer,
@@ -135,6 +139,29 @@ class CharacterSkillViewSet(viewsets.ModelViewSet):
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ["name", "description", "character__name"]
     ordering_fields = ["level", "created_at", "last_updated"]
+
+
+#########################################
+#####      Activity viewsets
+#########################################
+
+
+class ActivityViewSet(PlayerScopedQuerysetMixin, viewsets.ModelViewSet):
+    model = Activity
+    serializer_class = ActivitySerializer
+    permission_classes = [IsAuthenticated, IsOwnerPlayer]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ["name", "description"]
+    ordering_fields = ["name", "created_at", "last_updated"]
+
+
+class SuggestedActivityViewSet(viewsets.ModelViewSet):
+    queryset = SuggestedActivity.objects.all()
+    serializer_class = SuggestedActivitySerializer
+    permission_classes = [IsAuthenticated]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ["name", "description"]
+    ordering_fields = ["name", "created_at", "last_updated"]
 
 
 #########################################


### PR DESCRIPTION
Part of #696 split. Introduces the player-side activity catalog (Activity, SuggestedActivity) feeding PlayerActivity suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)