### PR TITLE
Feed player skill XP into the AP mastery multiplier

### DIFF
--- a/.claude/plans/progression-track-abstraction.md
+++ b/.claude/plans/progression-track-abstraction.md
@@ -160,20 +160,16 @@ does for characters (`PlayerActivity.get_xp_reward_summary` hardcodes
 `xp_mastery_multiplier(0)`).
 
 Because `PlayerSkill`/`CharacterSkill` are already one row per (owner,
-skill) — the exact granularity a skill-XP ledger needs — Phase 2 is likely
-**not** "introduce a new `ProgressionTrack`-shaped table," but "add a
-persisted `total_earned` field + a credit method directly onto the existing
-`PlayerSkill`/`CharacterSkill` models," reusing what's already there instead
-of inventing a new abstraction for it. `Role.proficiency_for`/
-`SkillGroup.proficiency_for`/`SkillDefinition.is_unlocked_for` (character
-side) switch from live duration aggregation to reading the credited total;
-a `player_total_skill_xp()` aggregate can then be added for the player-side
-mastery multiplier gap. Needs a proper pass at Phase-2 planning time rather
-than deciding the final shape here.
+skill) — the exact granularity a skill-XP ledger needs — the natural next
+question was whether Phase 2 needs a persisted `total_earned` on those models
+at all. **Finalized design: see §9 — it doesn't.** The live-aggregation
+pattern already in production for `CharacterSkill` is sufficient for
+`PlayerSkill` too; Phase 2 turns out to be a two-function change with no
+schema migration.
 
-Also worth cleaning up in the same pass: `Skill.level` (inherited by
-`PlayerSkill`) is a stored field that's never written anywhere in
-non-migration code — dead, same class of issue as `Person.xp_modifier`.
+`Skill.level` (inherited by `PlayerSkill`) is a stored field that's never
+written anywhere in non-migration code — dead, same class of issue as
+`Person.xp_modifier`. Deliberately **not** bundled into Phase 2 — see §9.5.
 
 **Phase 3 — migrate AP itself, if still justified.**
 Once Phase 2 is proven, decide whether `Person.xp`/`level` should also move
@@ -465,5 +461,130 @@ This also reframes Phase 2's likely shape: since `PlayerSkill`/
 `CharacterSkill` are already one row per (owner, skill) — the granularity a
 skill-XP ledger needs — Phase 2 is more likely to be "persist a total on the
 existing skill models" than "introduce a new `ProgressionTrack` table." §3's
-Phase 2 description above has been corrected accordingly; the final shape
-still needs a proper look at Phase-2 planning time.
+Phase 2 description above has been corrected accordingly. Finalized design
+below in §9 — it goes a step further: no persistence needed at all.
+
+---
+
+## 9. Phase 2 — finalized design
+
+### 9.1 Scope decision: no schema change
+
+The one concrete gap identified in §8 is narrow: `PlayerActivity.
+get_xp_reward_summary` hardcodes `xp_mastery_multiplier(0)` instead of
+reading a real total, because no `player_total_skill_xp()` aggregate exists
+(the character-side equivalent, `character_total_skill_xp`, already does).
+Closing that gap doesn't require persisting anything — `character_total_skill_xp`
+itself is a live aggregation (`Sum("duration")` over completed
+`CharacterActivity` + `CharacterActivityArchive`), not a ledger read, and it's
+already proven in production. `player_total_skill_xp` can be the same shape,
+one query, no new model.
+
+The performance concern that would justify persistence — unbounded row
+growth — was already solved character-side by #299's compaction
+(`CharacterActivityArchive`), and doesn't apply symmetrically to players:
+`CharacterActivity` rows are generated autonomously every day for every
+character, `PlayerActivity` rows are created one at a time by a human
+manually running a timer, so volume is bounded very differently. If player
+activity volume ever becomes a real aggregation cost, that's the point to
+revisit — not now, speculatively. Building a ledger today would be
+persistence with no observed problem to justify it, the same
+"unnecessary abstraction" risk flagged against Approach B in §7.5.
+
+**Net result: Phase 2 needs no migration.** The 3-step
+add-table/backfill/drop-column template used twice already in this branch
+(§7.3) doesn't get exercised a third time here.
+
+### 9.2 The change
+
+Add `player_total_skill_xp`, mirroring `character_total_skill_xp` but
+without the `**skill_definition_filter` machinery `_character_skill_duration`
+carries for Role/SkillGroup scoping — player skills (`PlayerSkill`) aren't
+authored/gated content, there's no equivalent scoping to filter by, so this
+is the flat form only:
+
+```python
+def player_total_skill_xp(player) -> int:
+    """
+    A player's total skill XP across every skill - the "total XP" input to
+    the AP mastery multiplier (see progression.points.xp_mastery_multiplier).
+    Mirrors character_total_skill_xp; player skills have no Role/SkillGroup
+    gating to scope by, so this is always the flat, unfiltered total.
+    """
+    from .points import xp_for_duration
+
+    total_duration = (
+        PlayerActivity.objects.filter(
+            player=player, is_complete=True, skill__isnull=False
+        ).aggregate(total=Sum("duration"))["total"]
+        or 0
+    )
+    return xp_for_duration(total_duration)
+```
+
+Place it in `progression/models.py` next to `character_total_skill_xp` for
+discoverability (forward-referencing `PlayerActivity`, defined later in the
+file, is fine — same as `character_total_skill_xp` forward-referencing
+`CharacterActivity`/`CharacterActivityArchive` today).
+
+Then in `PlayerActivity.get_xp_reward_summary`, replace:
+
+```python
+        # Players have no skill XP source yet (see progression.points), so
+        # this always evaluates to 1.0 - kept explicit here rather than
+        # hardcoded so it picks up a real total once player skills exist.
+        mastery_multiplier = xp_mastery_multiplier(0)
+```
+
+with:
+
+```python
+        mastery_multiplier = xp_mastery_multiplier(player_total_skill_xp(player))
+```
+
+matching `CharacterActivity.get_xp_reward_summary`'s
+`xp_mastery_multiplier(character_total_skill_xp(self.character))` call
+exactly. Also drop the now-inaccurate "Players have no skill XP source yet"
+line from `xp_mastery_multiplier`'s docstring in `progression/points.py`.
+
+### 9.3 Self-reference safety
+
+The record currently being completed must not count toward its own mastery
+multiplier. `CharacterActivity` already relies on this and it holds for the
+same reason `PlayerActivity` will: `get_xp_reward_summary()` runs *before*
+`self.save()` persists `is_complete = True` to the database (in both
+`PlayerActivity.complete()` and `CharacterActivity.complete_now()`/
+`complete_past()`, `is_complete` is flipped on the in-memory instance first,
+but the aggregate queries hit the DB, which still shows the row as
+incomplete until `save()` runs afterward). No new code needed to preserve
+this — just confirmed it holds symmetrically before relying on it.
+
+### 9.4 Tests
+
+Mirror `progression/tests/test_activity_archive.py`'s
+`character_total_skill_xp` coverage:
+
+- `player_total_skill_xp` sums completed, skill-linked `PlayerActivity`
+  duration and ignores incomplete/unlinked rows.
+- `assertNumQueries` guard (1 aggregate query) so it can't silently regress
+  into an N+1 later.
+- Extend `progression/tests/test_premium_activity_rewards.py`'s pattern with
+  a case that has prior completed skill-linked activity and asserts
+  `mastery_multiplier > 1` in `get_xp_reward_summary()`. The two existing
+  cases in that file have no skill-linked activity in `setUp`, so
+  `player_total_skill_xp` returns 0 and `mastery_multiplier` stays `1` for
+  them — unaffected by this change, confirmed by reading their `setUp`.
+
+### 9.5 Deliberately out of scope: `Skill.level`
+
+`Skill.level` (inherited by `PlayerSkill`) is stored, default `0`,
+client-writable via `SkillBaseSerializer` (not `read_only`), listed in
+`PlayerSkillAdmin`, and rendered in the frontend
+(`SkillsPanel.tsx`: `Level {skill.level}`) — but nothing ever computes or
+writes it outside migrations, so it always renders `Level 0`. Real, but not
+a progression-abstraction problem: fixing it means picking one of two product
+decisions (compute a real skill level from `total_xp` via some curve, or
+remove the field and the UI text that implies it means something), either of
+which touches the API contract and frontend, independent of anything else in
+Phase 2. Recommend filing it as its own follow-up issue rather than folding
+it into this change.

--- a/.claude/plans/progression-track-abstraction.md
+++ b/.claude/plans/progression-track-abstraction.md
@@ -147,15 +147,33 @@ without touching every call site simultaneously. Also formalizes "AP" as the
 name in code (rename internal helpers away from generic `xp` where they mean
 AP specifically), addressing conflation #1 without a data migration.
 
-**Phase 2 — give skill XP an actual ledger.**
-Introduce `ProgressionTrackDefinition` + `CharacterProgressionTrack` (Player
-doesn't need this yet — players have no skill XP source, per
-`progression.points`'s own comment) and start crediting skill XP to it
-instead of re-summing `CharacterActivity.duration` on every read. This is the
-one place a genuinely new model earns its keep today: skill XP currently has
-*zero* persistence, not "persistence conflated with something else."
-`Role.proficiency_for`/`SkillGroup.proficiency_for`/`SkillDefinition.
-is_unlocked_for` switch from live duration aggregation to reading the ledger.
+**Phase 2 — give skill XP an actual ledger.** *(corrected — see §8)*
+Both owners already have a live-derived skill XP source that's never
+persisted: `CharacterSkill.total_xp` (via `SkillDefinition`, summing
+`CharacterActivity`/`CharacterActivityArchive` duration) and
+`PlayerSkill.total_xp` (inherited from the abstract `Skill.total_xp`, summing
+linked `PlayerActivity` duration) — `PlayerSkill` is a real, user-facing
+model (own viewset/serializer, displayed in the frontend `SkillsPanel`), not
+a stub. The narrower true gap is that no `player_total_skill_xp()` aggregate
+feeds a player's own AP mastery multiplier the way `character_total_skill_xp`
+does for characters (`PlayerActivity.get_xp_reward_summary` hardcodes
+`xp_mastery_multiplier(0)`).
+
+Because `PlayerSkill`/`CharacterSkill` are already one row per (owner,
+skill) — the exact granularity a skill-XP ledger needs — Phase 2 is likely
+**not** "introduce a new `ProgressionTrack`-shaped table," but "add a
+persisted `total_earned` field + a credit method directly onto the existing
+`PlayerSkill`/`CharacterSkill` models," reusing what's already there instead
+of inventing a new abstraction for it. `Role.proficiency_for`/
+`SkillGroup.proficiency_for`/`SkillDefinition.is_unlocked_for` (character
+side) switch from live duration aggregation to reading the credited total;
+a `player_total_skill_xp()` aggregate can then be added for the player-side
+mastery multiplier gap. Needs a proper pass at Phase-2 planning time rather
+than deciding the final shape here.
+
+Also worth cleaning up in the same pass: `Skill.level` (inherited by
+`PlayerSkill`) is a stored field that's never written anywhere in
+non-migration code — dead, same class of issue as `Person.xp_modifier`.
 
 **Phase 3 — migrate AP itself, if still justified.**
 Once Phase 2 is proven, decide whether `Person.xp`/`level` should also move
@@ -426,3 +444,26 @@ middle of an already 118-file epic, designed against a single known track
 exact "unnecessary abstraction" / "architectural drift" risk the planning
 template flags. B is worth doing once skill XP is ready to move onto the same
 mechanism; it is not worth doing to unblock F specifically.
+
+---
+
+## 8. Correction — players already have a skill XP source
+
+An earlier version of §3 claimed "Player doesn't need [a ledger] yet -
+players have no skill XP source", citing a comment in `progression.points`.
+That was wrong. `PlayerSkill` (a real, user-facing model — own viewset/
+serializer, `total_xp` displayed in the frontend `SkillsPanel`) inherits
+`total_xp` from the abstract `Skill` base, live-derived from linked
+`PlayerActivity` duration via `xp_for_duration` — the same mechanism
+`CharacterSkill.total_xp` uses for characters. The `progression.points`
+comment actually being referenced is narrower: no `player_total_skill_xp()`
+aggregate feeds a player's *own AP mastery multiplier* the way
+`character_total_skill_xp` does for characters — a real gap, but not "no
+skill XP."
+
+This also reframes Phase 2's likely shape: since `PlayerSkill`/
+`CharacterSkill` are already one row per (owner, skill) — the granularity a
+skill-XP ledger needs — Phase 2 is more likely to be "persist a total on the
+existing skill models" than "introduce a new `ProgressionTrack` table." §3's
+Phase 2 description above has been corrected accordingly; the final shape
+still needs a proper look at Phase-2 planning time.

--- a/progression/models.py
+++ b/progression/models.py
@@ -127,6 +127,25 @@ def character_total_skill_xp(character) -> int:
     return xp_for_duration(_character_skill_duration(character))
 
 
+def player_total_skill_xp(player) -> int:
+    """
+    A player's total skill XP across every skill - the "total XP" input to
+    the AP mastery multiplier (see progression.points.xp_mastery_multiplier).
+    Mirrors character_total_skill_xp; player skills (PlayerSkill) have no
+    Role/SkillGroup gating to scope by, so this is always the flat,
+    unfiltered total.
+    """
+    from .points import xp_for_duration
+
+    total_duration = (
+        PlayerActivity.objects.filter(
+            player=player, is_complete=True, skill__isnull=False
+        ).aggregate(total=Sum("duration"))["total"]
+        or 0
+    )
+    return xp_for_duration(total_duration)
+
+
 class Role(models.Model):
     """
     Authored role definition (e.g. "Farmer", "Guard") - not owned by any one
@@ -652,10 +671,7 @@ class PlayerActivity(TimeRecord, PlayerOwnedMixin):
 
             task_xp_multiplier = GameSettings.current().task_activity_xp_multiplier
             multiplier *= task_xp_multiplier
-        # Players have no skill XP source yet (see progression.points), so
-        # this always evaluates to 1.0 - kept explicit here rather than
-        # hardcoded so it picks up a real total once player skills exist.
-        mastery_multiplier = xp_mastery_multiplier(0)
+        mastery_multiplier = xp_mastery_multiplier(player_total_skill_xp(player))
         multiplier *= mastery_multiplier
 
         def _fmt(d: Decimal) -> int | float:

--- a/progression/points.py
+++ b/progression/points.py
@@ -31,10 +31,10 @@ def xp_for_duration(duration_seconds) -> int:
 def xp_mastery_multiplier(total_xp) -> Decimal:
     """
     AP-earning multiplier driven by accumulated skill XP - the more skilled
-    a character has become overall, the faster they earn AP on anything.
-    Linear growth up to a configurable cap, both GameSettings-tunable.
-    Players have no skill XP source yet, so `total_xp=0` here always
-    resolves to 1.0 (no boost) until a player-side skill system exists.
+    a character or player has become overall, the faster they earn AP on
+    anything. Linear growth up to a configurable cap, both GameSettings-
+    tunable. See progression.models.character_total_skill_xp/
+    player_total_skill_xp for how `total_xp` is computed for each owner.
     """
     from core.models import GameSettings
 

--- a/progression/tests/test_player_skill_xp.py
+++ b/progression/tests/test_player_skill_xp.py
@@ -1,0 +1,54 @@
+from core.models import GameSettings
+from progression.models import PlayerActivity, PlayerSkill, player_total_skill_xp
+
+from .base import BaseTestCase
+
+
+class PlayerTotalSkillXpTests(BaseTestCase):
+    """
+    Mirrors progression.tests.test_activity_archive's coverage of
+    character_total_skill_xp - see .claude/plans/progression-track-abstraction.md
+    §9 for why player_total_skill_xp is a flat live aggregate, not a ledger.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.skill = PlayerSkill.objects.create(player=self.player, name="Coding")
+        GameSettings.current()
+
+    def test_sums_completed_skill_linked_activity_duration(self):
+        PlayerActivity.objects.create(
+            player=self.player,
+            name="Write tests",
+            skill=self.skill,
+            duration=600,
+            is_complete=True,
+        )
+
+        # An incomplete activity - excluded.
+        PlayerActivity.objects.create(
+            player=self.player,
+            name="In progress",
+            skill=self.skill,
+            duration=999,
+        )
+
+        # A completed activity with no skill linked - excluded.
+        PlayerActivity.objects.create(
+            player=self.player,
+            name="Unlinked",
+            duration=999,
+            is_complete=True,
+        )
+
+        # 600 seconds at the default 1.0 xp/sec rate.
+        self.assertEqual(player_total_skill_xp(self.player), 600)
+
+    def test_no_completed_skill_activity_returns_zero(self):
+        self.assertEqual(player_total_skill_xp(self.player), 0)
+
+    def test_query_count_stays_bounded(self):
+        # One aggregate against PlayerActivity, one GameSettings lookup for
+        # the XP rate - guards against this silently growing an N+1 later.
+        with self.assertNumQueries(2):
+            player_total_skill_xp(self.player)

--- a/progression/tests/test_premium_activity_rewards.py
+++ b/progression/tests/test_premium_activity_rewards.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from payments.models import SubscriptionPlan, UserSubscription
-from progression.models import PlayerActivity
+from progression.models import PlayerActivity, PlayerSkill
 
 
 class PlayerActivityPremiumRewardTests(TestCase):
@@ -75,3 +75,38 @@ class PlayerActivityPremiumRewardTests(TestCase):
             },
         )
         self.assertEqual(activity.complete(), 120)
+
+    def test_prior_skill_xp_boosts_mastery_multiplier(self):
+        # See .claude/plans/progression-track-abstraction.md §9 -
+        # player_total_skill_xp feeds this the same way character_total_skill_xp
+        # feeds CharacterActivity's mastery_multiplier.
+        skill = PlayerSkill.objects.create(player=self.player, name="Coding")
+        PlayerActivity.objects.create(
+            player=self.player,
+            name="Prior work",
+            skill=skill,
+            duration=500,
+            is_complete=True,
+        )
+
+        activity = PlayerActivity.objects.create(
+            player=self.player,
+            name="Write tests",
+            duration=60,
+        )
+
+        reward_summary = activity.get_xp_reward_summary()
+
+        # 500s of prior skill XP at the default 1000/1.0x mastery scale -> +0.5x.
+        self.assertEqual(
+            reward_summary,
+            {
+                "duration_seconds": 60,
+                "base_xp": 60,
+                "xp_multiplier": 1.5,
+                "task_xp_multiplier": 1,
+                "mastery_multiplier": 1.5,
+                "xp_gained": 90,
+                "skill_xp_gained": 0,
+            },
+        )


### PR DESCRIPTION
Part of #696 split. Stacked on #711 (feat/ap-curve-extraction). Phase 2 of the ProgressionTrack groundwork: player_total_skill_xp() mirrors character_total_skill_xp(), wired into PlayerActivity.get_xp_reward_summary's mastery multiplier (previously hardcoded to 0). No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)