### PR TITLE
Restrict write access on authored/curated catalog viewsets to admins

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -253,6 +253,19 @@ class IsOwnerCharacter(permissions.BasePermission):
         return False
 
 
+class IsAdminOrReadOnly(permissions.BasePermission):
+    """
+    For authored/curated catalogs (roles, skill taxonomy, activity
+    definitions, suggested activities) - any authenticated player can read,
+    only staff can create/update/delete.
+    """
+
+    def has_permission(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return bool(request.user and request.user.is_staff)
+
+
 class CustomTokenObtainPairView(TokenObtainPairView):
     serializer_class = CustomTokenObtainPairSerializer
 

--- a/progression/views.py
+++ b/progression/views.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 else:
     _RequestMixinBase = object
 
-from api.views import IsOwnerPlayer
+from api.views import IsAdminOrReadOnly, IsOwnerPlayer
 from .models import (
     Category,
     Role,
@@ -113,7 +113,7 @@ class CategoryViewSet(PlayerScopedQuerysetMixin, viewsets.ModelViewSet):
 class RoleViewSet(viewsets.ModelViewSet):
     queryset = Role.objects.all()
     serializer_class = RoleSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsAdminOrReadOnly]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ["name", "description"]
     ordering_fields = ["created_at", "last_updated"]
@@ -122,7 +122,7 @@ class RoleViewSet(viewsets.ModelViewSet):
 class SkillGroupViewSet(viewsets.ModelViewSet):
     queryset = SkillGroup.objects.all()
     serializer_class = SkillGroupSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsAdminOrReadOnly]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ["name", "description", "role__name"]
     ordering_fields = ["created_at", "last_updated"]
@@ -131,7 +131,7 @@ class SkillGroupViewSet(viewsets.ModelViewSet):
 class SkillDefinitionViewSet(viewsets.ModelViewSet):
     queryset = SkillDefinition.objects.all()
     serializer_class = SkillDefinitionSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsAdminOrReadOnly]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ["name", "description", "role__name"]
     ordering_fields = ["created_at", "last_updated"]
@@ -191,7 +191,7 @@ class ActivityViewSet(PlayerScopedQuerysetMixin, viewsets.ModelViewSet):
 class SuggestedActivityViewSet(viewsets.ModelViewSet):
     queryset = SuggestedActivity.objects.all()
     serializer_class = SuggestedActivitySerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsAdminOrReadOnly]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ["name", "description"]
     ordering_fields = ["name", "created_at", "last_updated"]
@@ -350,7 +350,7 @@ class CurrentCharacterScopedQuerysetMixin(_RequestMixinBase):
 class ActivityDefinitionViewSet(viewsets.ModelViewSet):
     queryset = ActivityDefinition.objects.all()
     serializer_class = ActivityDefinitionSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsAdminOrReadOnly]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ["name", "description", "kind"]
     ordering_fields = ["created_at", "last_updated"]


### PR DESCRIPTION
`RoleViewSet`, `SkillGroupViewSet`, `SkillDefinitionViewSet`, `SuggestedActivityViewSet`, and `ActivityDefinitionViewSet` were only gated by `IsAuthenticated`, letting any authenticated player create, update, or delete these authored/global game-content catalogs. Adds an `IsAdminOrReadOnly` permission (read for any authenticated user, writes require staff) and applies it alongside `IsAuthenticated` on those five viewsets.

`CharacterRoleViewSet` and `CharacterSkillViewSet` are left unchanged — they hold per-character assignment records with a different, still-undecided write-access model.

Note: none of the five affected viewsets are currently wired into `api/urls.py`'s router (pre-existing, unrelated to this change) — this closes the gap ahead of them being exposed.

Split out of #696, deferred until #705/#706/#707 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)