### PR TITLE
Register catalog viewsets in api router

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -32,6 +32,11 @@ from progression.views import (
     ProjectViewSet,
     TaskViewSet,
     NoteViewSet,
+    RoleViewSet,
+    SkillGroupViewSet,
+    SkillDefinitionViewSet,
+    SuggestedActivityViewSet,
+    ActivityDefinitionViewSet,
 )
 from server_management.views import maintenance_status
 from users.views import PlayerViewSet
@@ -73,6 +78,17 @@ router.register(
     r"population-centres", PopulationCentreViewSet, basename="populationcentre"
 )
 router.register(r"activity_timers", ActivityTimerViewSet, basename="activitytimer")
+router.register(r"roles", RoleViewSet, basename="role")
+router.register(r"skill-groups", SkillGroupViewSet, basename="skillgroup")
+router.register(
+    r"skill-definitions", SkillDefinitionViewSet, basename="skilldefinition"
+)
+router.register(
+    r"suggested-activities", SuggestedActivityViewSet, basename="suggestedactivity"
+)
+router.register(
+    r"activity-definitions", ActivityDefinitionViewSet, basename="activitydefinition"
+)
 
 urlpatterns = [
     # General urls


### PR DESCRIPTION
`RoleViewSet`, `SkillGroupViewSet`, `SkillDefinitionViewSet`, `SuggestedActivityViewSet`, and `ActivityDefinitionViewSet` existed in `progression/views.py` but were never wired into a URL, so their `IsAdminOrReadOnly` permission (#714) had nothing to guard. Registers them at `/roles/`, `/skill-groups/`, `/skill-definitions/`, `/suggested-activities/`, and `/activity-definitions/`, following the router's existing no-dash basename convention (`role`, `skillgroup`, `skilldefinition`, `suggestedactivity`, `activitydefinition`).

`CharacterRoleViewSet` and `CharacterSkillViewSet` stay unregistered — their write-access model is still undecided (see #714).

Verified `reverse()` resolves all five list routes to the expected paths, `manage.py check` clean, full `progression`/`api` test suites pass (117 tests, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)