### PR TITLE
fix: align celery/celery-beat autoDeployTrigger with web (commit)

### DIFF
--- a/render-staging.yaml
+++ b/render-staging.yaml
@@ -34,7 +34,7 @@ projects:
             dockerCommand: celery -A progress_rpg worker --loglevel=info --concurrency=1 --prefetch-multiplier=1 --max-tasks-per-child=1000
             dockerContext: .
             dockerfilePath: ./Dockerfile
-            autoDeployTrigger: checksPass
+            autoDeployTrigger: commit
             buildFilter:
               ignoredPaths:
               - frontend/**
@@ -51,7 +51,7 @@ projects:
             dockerCommand: celery -A progress_rpg beat --loglevel=info --scheduler django_celery_beat.schedulers:DatabaseScheduler --max-interval=30
             dockerContext: .
             dockerfilePath: ./Dockerfile
-            autoDeployTrigger: checksPass
+            autoDeployTrigger: commit
             buildFilter:
               ignoredPaths:
               - frontend/**

--- a/render.yaml
+++ b/render.yaml
@@ -34,7 +34,7 @@ projects:
             dockerCommand: celery -A progress_rpg worker --loglevel=info --concurrency=1 --prefetch-multiplier=1 --max-tasks-per-child=1000
             dockerContext: .
             dockerfilePath: ./Dockerfile
-            autoDeployTrigger: checksPass
+            autoDeployTrigger: commit
             buildFilter:
               ignoredPaths:
               - frontend/*
@@ -51,7 +51,7 @@ projects:
             dockerCommand: celery -A progress_rpg beat --loglevel=info --scheduler django_celery_beat.schedulers:DatabaseScheduler --max-interval=30
             dockerContext: .
             dockerfilePath: ./Dockerfile
-            autoDeployTrigger: checksPass
+            autoDeployTrigger: commit
             buildFilter:
               ignoredPaths:
               - frontend/*


### PR DESCRIPTION
## Summary

Investigated a Sentry error from a staging promotion:

```
ProgrammingError: column progression_activity.xp_gained does not exist
```
raised from `gameplay/tasks.py::auto_complete_timers_for_stale_players`.

Root cause was not a bug in the `xp_gained` → `reward_breakdown` rework itself — that model change and its migrations (`0017_add_reward_breakdown` → `0019_remove_xp_gained`) are correct on `staging`. It was a deploy race:

- `web-staging` uses `autoDeployTrigger: commit` and runs `manage.py migrate` via `pre-deploy.sh` on every commit.
- `celery-staging` / `celery-beat-staging` used `autoDeployTrigger: checksPass`, a different, slower trigger.

During the promotion, `web-staging` deployed and ran the migration that dropped the `xp_gained` column before the Celery worker had redeployed. The still-running old worker code (which still declared `xp_gained` as a real model field) then issued a `SELECT` against a column that no longer existed. This is self-healing once the worker catches up, but the identical mismatch exists in `render.yaml` (production), so any future migration that drops/renames a column a worker still references would hit the same race.

## Change

Changed `celery` and `celery-beat` (both production and staging) from `autoDeployTrigger: checksPass` to `commit`, matching the `web` service. Workers now redeploy in lockstep with the service that runs migrations, closing the schema/code mismatch window for future migrations.

## Files changed

- `render.yaml`
- `render-staging.yaml`


---
_Generated by [Claude Code](https://claude.ai/code/session_01JbNGb7EAoDbLi7hJ3ai6ja)_