### PR TITLE
map: add entity detail card for characters and buildings

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -41,7 +41,12 @@ from progression.views import (
 from server_management.views import maintenance_status
 from users.views import PlayerViewSet
 
-from locations.views import PopulationCentreMapView, MapViewportView, MapWorldBoundsView
+from locations.views import (
+    PopulationCentreMapView,
+    MapCharacterDetailView,
+    MapViewportView,
+    MapWorldBoundsView,
+)
 
 
 class KeyConverter:
@@ -139,5 +144,10 @@ urlpatterns = [
         "map/world-bounds/",
         MapWorldBoundsView.as_view(),
         name="map-world-bounds",
+    ),
+    path(
+        "map/characters/<int:pk>/",
+        MapCharacterDetailView.as_view(),
+        name="map-character-detail",
     ),
 ]

--- a/character/services/relationship_services.py
+++ b/character/services/relationship_services.py
@@ -106,6 +106,79 @@ def relationship_get_relationships_of_type(character, relationship_type):
     ).distinct()
 
 
+def relationship_get_household_members(character):
+    """
+    `character`'s MARRIAGE/PARENT_CHILD relationship partners (the types
+    household_services.create_household_relationships creates - see
+    locations/management/commands/generate_characters.py), each as a dict
+    with the other character, the relationship's type, and *their* role in
+    it - `household_relationship_label` needs their role (not `character`'s
+    own) to know whether e.g. a PARENT_CHILD relationship makes them a
+    parent or a child of `character`.
+    """
+    from character.models import CharacterRelationship, RelationshipType
+
+    relationships = (
+        CharacterRelationship.objects.filter(
+            relationship_type__in=[
+                RelationshipType.MARRIAGE,
+                RelationshipType.PARENT_CHILD,
+            ],
+            characters=character,
+        )
+        .prefetch_related("characterrelationshipmembership_set__character")
+        .distinct()
+    )
+
+    members = []
+    for relationship in relationships:
+        memberships = list(relationship.characterrelationshipmembership_set.all())
+        if not any(m.character_id == character.id for m in memberships):
+            continue
+        for membership in memberships:
+            if membership.character_id == character.id:
+                continue
+            members.append(
+                {
+                    "character": membership.character,
+                    "relationship_type": relationship.relationship_type,
+                    "other_role": membership.role,
+                }
+            )
+    return members
+
+
+# Gendered labels for the two relationship types household generation
+# actually produces - keyed by the *other* character's sex (Character.
+# SexChoices), since "husband"/"son" etc. describe them, not `character`.
+_MARRIAGE_LABELS = {"Male": "husband", "Female": "wife"}
+_PARENT_LABELS = {"Male": "father", "Female": "mother"}
+_CHILD_LABELS = {"Male": "son", "Female": "daughter"}
+
+
+def household_relationship_label(relationship_type, other_role, other_sex) -> str:
+    """
+    Human-readable label for the *other* member of one of `character`'s
+    household relationships (relationship_get_household_members above),
+    e.g. "husband"/"mother"/"daughter" - falls back to a generic word for a
+    sex of "Other" or any relationship_type/role combination not covered
+    (defensive only; the two types this is actually called for are always
+    MARRIAGE/SPOUSE or PARENT_CHILD/PARENT|CHILD).
+    """
+    from character.models import RelationshipRole, RelationshipType
+
+    if relationship_type == RelationshipType.MARRIAGE:
+        return _MARRIAGE_LABELS.get(other_sex, "spouse")
+
+    if relationship_type == RelationshipType.PARENT_CHILD:
+        if other_role == RelationshipRole.PARENT:
+            return _PARENT_LABELS.get(other_sex, "parent")
+        if other_role == RelationshipRole.CHILD:
+            return _CHILD_LABELS.get(other_sex, "child")
+
+    return str(relationship_type).replace("_", " ")
+
+
 def relationship_get_family_groups(characters):
     """
     Map each character's id to a group key such that characters connected via

--- a/character/tests/test_relationship_services.py
+++ b/character/tests/test_relationship_services.py
@@ -1,0 +1,117 @@
+"""
+Tests for relationship_services.relationship_get_household_members and
+household_relationship_label - the "Thomas — husband" style summary used by
+the map's character detail card (see locations.serializers.
+CharacterDetailSerializer).
+"""
+
+from django.test import SimpleTestCase, TestCase
+
+from character.models import Character, RelationshipRole, RelationshipType
+from character.services import relationship_services
+
+
+class RelationshipGetHouseholdMembersTests(TestCase):
+    def _make_character(self, name, sex="Female"):
+        return Character.objects.create(given_name=name, sex=sex)
+
+    def test_marriage_partner_is_included(self):
+        alice = self._make_character("Alice", sex="Female")
+        bob = self._make_character("Bob", sex="Male")
+        relationship_services.relationship_create(
+            RelationshipType.MARRIAGE,
+            [
+                (alice, RelationshipRole.SPOUSE),
+                (bob, RelationshipRole.SPOUSE),
+            ],
+        )
+
+        members = relationship_services.relationship_get_household_members(alice)
+
+        self.assertEqual(len(members), 1)
+        self.assertEqual(members[0]["character"], bob)
+        self.assertEqual(members[0]["relationship_type"], RelationshipType.MARRIAGE)
+        self.assertEqual(members[0]["other_role"], RelationshipRole.SPOUSE)
+
+    def test_parent_and_child_see_each_other_with_the_right_role(self):
+        alice = self._make_character("Alice")
+        kid = self._make_character("Kid")
+        relationship_services.relationship_create(
+            RelationshipType.PARENT_CHILD,
+            [
+                (alice, RelationshipRole.PARENT),
+                (kid, RelationshipRole.CHILD),
+            ],
+        )
+
+        alice_members = relationship_services.relationship_get_household_members(alice)
+        kid_members = relationship_services.relationship_get_household_members(kid)
+
+        self.assertEqual(alice_members[0]["character"], kid)
+        self.assertEqual(alice_members[0]["other_role"], RelationshipRole.CHILD)
+        self.assertEqual(kid_members[0]["character"], alice)
+        self.assertEqual(kid_members[0]["other_role"], RelationshipRole.PARENT)
+
+    def test_only_marriage_and_parent_child_types_are_included(self):
+        alice = self._make_character("Alice")
+        rival = self._make_character("Rival")
+        relationship_services.relationship_create(
+            RelationshipType.RIVAL,
+            [
+                (alice, RelationshipRole.PARTICIPANT),
+                (rival, RelationshipRole.PARTICIPANT),
+            ],
+        )
+
+        self.assertEqual(
+            relationship_services.relationship_get_household_members(alice), []
+        )
+
+    def test_character_with_no_relationships_returns_empty_list(self):
+        alice = self._make_character("Alice")
+
+        self.assertEqual(
+            relationship_services.relationship_get_household_members(alice), []
+        )
+
+
+class HouseholdRelationshipLabelTests(SimpleTestCase):
+    def test_marriage_labels_by_sex(self):
+        self.assertEqual(
+            relationship_services.household_relationship_label(
+                RelationshipType.MARRIAGE, RelationshipRole.SPOUSE, "Male"
+            ),
+            "husband",
+        )
+        self.assertEqual(
+            relationship_services.household_relationship_label(
+                RelationshipType.MARRIAGE, RelationshipRole.SPOUSE, "Female"
+            ),
+            "wife",
+        )
+        self.assertEqual(
+            relationship_services.household_relationship_label(
+                RelationshipType.MARRIAGE, RelationshipRole.SPOUSE, "Other"
+            ),
+            "spouse",
+        )
+
+    def test_parent_child_labels_depend_on_the_others_role(self):
+        self.assertEqual(
+            relationship_services.household_relationship_label(
+                RelationshipType.PARENT_CHILD, RelationshipRole.PARENT, "Female"
+            ),
+            "mother",
+        )
+        self.assertEqual(
+            relationship_services.household_relationship_label(
+                RelationshipType.PARENT_CHILD, RelationshipRole.CHILD, "Male"
+            ),
+            "son",
+        )
+        self.assertEqual(
+            relationship_services.household_relationship_label(
+                RelationshipType.PARENT_CHILD, RelationshipRole.CHILD, "Female"
+            ),
+            "daughter",
+        )

--- a/frontend/src/api/map.ts
+++ b/frontend/src/api/map.ts
@@ -57,6 +57,35 @@ export function fetchMapViewport(bbox: string): Promise<any> {
   return apiFetch(`/map/viewport/?bbox=${encodeURIComponent(bbox)}`);
 }
 
+export interface MapCharacterRelationship {
+  character_id: number;
+  name: string;
+  // Human-readable ("husband", "daughter", ...) - see
+  // character.services.relationship_services.household_relationship_label.
+  label: string;
+}
+
+export interface MapCharacterDetail {
+  id: number;
+  name: string;
+  age: number;
+  sex: string;
+  home_type: string | null;
+  home_id: number | null;
+  work_type: string | null;
+  current_activity: string | null;
+  is_moving: boolean;
+  relationships: MapCharacterRelationship[];
+}
+
+// On-demand detail for one character's map detail card (MapCharacterDetailView,
+// locations/views.py) - deliberately separate from the bulk per-poll map
+// viewport features, which only carry cheap tooltip-level data (see that
+// view's own docstring).
+export function fetchMapCharacterDetail(characterId: number): Promise<MapCharacterDetail> {
+  return apiFetch(`/map/characters/${characterId}/`);
+}
+
 interface MapWorldBoundsResponse {
   bbox: [number, number, number, number] | null;
 }

--- a/frontend/src/components/BuildingDetail/BuildingDetail.module.scss
+++ b/frontend/src/components/BuildingDetail/BuildingDetail.module.scss
@@ -1,0 +1,59 @@
+@use 'sass:map';
+@use '../../styles/semantic/spacing' as sp;
+@use '../../styles/semantic/colors' as c;
+@use '../../styles/semantic/typography' as t;
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-md;
+}
+
+.facts {
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-sm;
+  margin: 0;
+}
+
+.fact {
+  display: flex;
+  justify-content: space-between;
+  gap: sp.$spacing-gap;
+
+  dt {
+    @include c.apply-text-tone(map.get(c.$text-tone, muted));
+  }
+
+  dd {
+    margin: 0;
+    text-align: right;
+  }
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-sm;
+}
+
+.sectionHeading {
+  margin: 0;
+  font-size: 0.95rem;
+  @include c.apply-text-tone(map.get(c.$text-tone, muted));
+}
+
+.goodsList {
+  @include t.apply-text-style(t.$text-body);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-xs;
+}
+
+.residentsList {
+  max-height: 200px;
+  overflow-y: auto;
+}

--- a/frontend/src/components/BuildingDetail/BuildingDetail.stories.tsx
+++ b/frontend/src/components/BuildingDetail/BuildingDetail.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import BuildingDetail from './BuildingDetail';
+import DetailCard from '../DetailCard/DetailCard';
+
+/**
+ * `BuildingDetail` is the building-specific content shown inside
+ * `DetailCard`. Unlike `CharacterDetail`, it takes plain props rather than
+ * fetching its own data - residents/occupancy/goods are all already
+ * available from the map's own feature data (see Map.tsx, which derives
+ * these props from the building's own feature plus already-loaded
+ * character features matching its `home_id`).
+ */
+const meta: Meta<typeof BuildingDetail> = {
+  title: 'Map/BuildingDetail',
+  component: BuildingDetail,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      story: { inline: false, iframeHeight: 400 },
+    },
+  },
+  decorators: [
+    (Story, { args }) => (
+      <DetailCard open title={args.buildingType === 'residential' ? 'House' : 'Bakery'} onClose={fn()}>
+        <Story />
+      </DetailCard>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof BuildingDetail>;
+
+export const House: Story = {
+  args: {
+    buildingType: 'residential',
+    residentialCapacity: 6,
+    residents: [
+      { id: 1, name: 'Alice', currentActivity: 'idle' },
+      { id: 2, name: 'Thomas', currentActivity: 'delivering goods to neighbours' },
+      { id: 3, name: 'Emily', isMoving: true },
+    ],
+    onSelectResident: fn(),
+  },
+};
+
+export const Workplace: Story = {
+  args: {
+    buildingType: 'bakery',
+    residents: [],
+    workerCount: 2,
+    goods: [
+      { good_type: 'flour', display: '3 sacks' },
+      { good_type: 'bread', display: '18.0 loaves' },
+    ],
+  },
+};
+
+export const EmptyHouse: Story = {
+  args: {
+    buildingType: 'residential',
+    residents: [],
+    residentialCapacity: 4,
+  },
+};

--- a/frontend/src/components/BuildingDetail/BuildingDetail.test.tsx
+++ b/frontend/src/components/BuildingDetail/BuildingDetail.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import BuildingDetail from './BuildingDetail';
+
+describe('BuildingDetail', () => {
+  it('shows residents out of capacity for a residential building', () => {
+    render(
+      <BuildingDetail
+        buildingType="residential"
+        residents={[{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }]}
+        residentialCapacity={6}
+      />
+    );
+
+    expect(screen.getByText('2 / 6')).toBeInTheDocument();
+    expect(screen.queryByText(/Workers/)).not.toBeInTheDocument();
+  });
+
+  it('omits the capacity suffix when capacity is unknown', () => {
+    render(
+      <BuildingDetail
+        buildingType="residential"
+        residents={[{ id: 1, name: 'Alice' }]}
+        residentialCapacity={null}
+      />
+    );
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('shows a worker count instead of residents for a non-residential building', () => {
+    render(
+      <BuildingDetail buildingType="bakery" residents={[]} workerCount={2} />
+    );
+
+    expect(screen.getByText('Workers')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.queryByText('Residents')).not.toBeInTheDocument();
+  });
+
+  it('lists in-stock goods, skipping zero-quantity entries', () => {
+    render(
+      <BuildingDetail
+        buildingType="bakery"
+        residents={[]}
+        goods={[
+          { good_type: 'flour', display: '3 sacks' },
+          { good_type: 'wheat', display: '' },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Flour: 3 sacks')).toBeInTheDocument();
+    expect(screen.queryByText(/Wheat/)).not.toBeInTheDocument();
+  });
+
+  it('shows each resident, with "walking" overriding their scheduled activity', () => {
+    render(
+      <BuildingDetail
+        buildingType="residential"
+        residents={[
+          { id: 1, name: 'Alice', currentActivity: 'idle' },
+          { id: 2, name: 'Bob', currentActivity: 'sleeping', isMoving: true },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Alice — idle')).toBeInTheDocument();
+    expect(screen.getByText('Bob — walking')).toBeInTheDocument();
+  });
+
+  it('calls onSelectResident when a resident row is clicked', async () => {
+    const user = userEvent.setup();
+    const onSelectResident = vi.fn();
+    render(
+      <BuildingDetail
+        buildingType="residential"
+        residents={[{ id: 7, name: 'Alice' }]}
+        onSelectResident={onSelectResident}
+      />
+    );
+
+    await user.click(screen.getByText('Alice'));
+
+    expect(onSelectResident).toHaveBeenCalledWith(7);
+  });
+
+  it('renders residents as non-interactive when onSelectResident is omitted', () => {
+    render(
+      <BuildingDetail
+        buildingType="residential"
+        residents={[{ id: 7, name: 'Alice' }]}
+      />
+    );
+
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/BuildingDetail/BuildingDetail.tsx
+++ b/frontend/src/components/BuildingDetail/BuildingDetail.tsx
@@ -1,0 +1,98 @@
+import List from "../List/List";
+import styles from "./BuildingDetail.module.scss";
+
+interface BuildingDetailGood {
+  good_type?: string;
+  display?: string;
+}
+
+export interface BuildingDetailResident {
+  id: number;
+  name: string;
+  currentActivity?: string | null;
+  isMoving?: boolean | null;
+}
+
+interface BuildingDetailProps {
+  buildingType?: string;
+  residents: BuildingDetailResident[];
+  workerCount?: number | null;
+  residentialCapacity?: number | null;
+  goods?: BuildingDetailGood[] | null;
+  /** Omit to render residents as a plain, non-interactive list. */
+  onSelectResident?: (characterId: number) => void;
+}
+
+function capitalize(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+function residentLine(resident: BuildingDetailResident): string {
+  // "walking" overrides the scheduled activity while moving, same rule as
+  // a character's own map tooltip (CharacterTooltipContent).
+  const activity = resident.isMoving ? "walking" : resident.currentActivity;
+  return activity ? `${resident.name} — ${activity}` : resident.name;
+}
+
+export default function BuildingDetail({
+  buildingType,
+  residents,
+  workerCount,
+  residentialCapacity,
+  goods,
+  onSelectResident,
+}: BuildingDetailProps) {
+  const isResidential = buildingType === "residential";
+  const stockedGoods = (goods ?? []).filter((good) => good.display);
+
+  return (
+    <div className={styles.root}>
+      <dl className={styles.facts}>
+        {isResidential ? (
+          <div className={styles.fact}>
+            <dt>Residents</dt>
+            <dd>
+              {residents.length}
+              {residentialCapacity != null && residentialCapacity > 0
+                ? ` / ${residentialCapacity}`
+                : ""}
+            </dd>
+          </div>
+        ) : (
+          workerCount != null && (
+            <div className={styles.fact}>
+              <dt>Workers</dt>
+              <dd>{workerCount}</dd>
+            </div>
+          )
+        )}
+      </dl>
+
+      {stockedGoods.length > 0 && (
+        <section className={styles.section}>
+          <h3 className={styles.sectionHeading}>Inventory</h3>
+          <ul className={styles.goodsList}>
+            {stockedGoods.map((good, index) => (
+              <li key={good.good_type ?? index}>
+                {good.good_type ? capitalize(good.good_type) : ""}: {good.display}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {isResidential && residents.length > 0 && (
+        <section className={styles.section}>
+          <h3 className={styles.sectionHeading}>Residents</h3>
+          <List<BuildingDetailResident>
+            items={residents}
+            className={styles.residentsList}
+            canSelect={Boolean(onSelectResident)}
+            onSelect={(resident) => onSelectResident?.(resident.id)}
+            renderItem={(resident) => <span>{residentLine(resident)}</span>}
+          />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/CharacterDetail/CharacterDetail.module.scss
+++ b/frontend/src/components/CharacterDetail/CharacterDetail.module.scss
@@ -1,0 +1,54 @@
+@use 'sass:map';
+@use '../../styles/semantic/spacing' as sp;
+@use '../../styles/semantic/colors' as c;
+@use '../../styles/semantic/typography' as t;
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-md;
+}
+
+.status {
+  @include t.apply-text-style(t.$text-body);
+  @include c.apply-text-tone(map.get(c.$text-tone, muted));
+}
+
+.facts {
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-sm;
+  margin: 0;
+}
+
+.fact {
+  display: flex;
+  justify-content: space-between;
+  gap: sp.$spacing-gap;
+
+  dt {
+    @include c.apply-text-tone(map.get(c.$text-tone, muted));
+  }
+
+  dd {
+    margin: 0;
+    text-align: right;
+  }
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-sm;
+}
+
+.sectionHeading {
+  margin: 0;
+  font-size: 0.95rem;
+  @include c.apply-text-tone(map.get(c.$text-tone, muted));
+}
+
+.relationshipsList {
+  max-height: 200px;
+  overflow-y: auto;
+}

--- a/frontend/src/components/CharacterDetail/CharacterDetail.stories.tsx
+++ b/frontend/src/components/CharacterDetail/CharacterDetail.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import CharacterDetail from './CharacterDetail';
+import DetailCard from '../DetailCard/DetailCard';
+
+/**
+ * `CharacterDetail` is the character-specific content shown inside
+ * `DetailCard` on the map's second level of progressive disclosure
+ * (tooltip -> click -> detail card). It fetches its own data
+ * (`useMapCharacterDetail`) rather than receiving it as props, so this
+ * story wraps it in `DetailCard` for a realistic preview but can't drive
+ * real network data - see CharacterDetail.test.tsx for behaviour covered
+ * against mocked fetch states.
+ */
+const meta: Meta<typeof CharacterDetail> = {
+  title: 'Map/CharacterDetail',
+  component: CharacterDetail,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      story: { inline: false, iframeHeight: 360 },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <DetailCard open title="Alice" onClose={fn()}>
+        <Story />
+      </DetailCard>
+    ),
+  ],
+  args: {
+    characterId: 1,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CharacterDetail>;
+
+export const Default: Story = {};

--- a/frontend/src/components/CharacterDetail/CharacterDetail.test.tsx
+++ b/frontend/src/components/CharacterDetail/CharacterDetail.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import CharacterDetail from './CharacterDetail';
+import type { MapCharacterDetail } from '../../api/map';
+
+const mockUseMapCharacterDetail = vi.fn();
+
+vi.mock('../../hooks/useMap', () => ({
+  useMapCharacterDetail: (...args: unknown[]) => mockUseMapCharacterDetail(...args),
+}));
+
+function detail(overrides: Partial<MapCharacterDetail> = {}): MapCharacterDetail {
+  return {
+    id: 1,
+    name: 'Alice',
+    age: 32,
+    sex: 'Female',
+    home_type: 'residential',
+    home_id: 5,
+    work_type: 'bakery',
+    current_activity: 'delivering goods to neighbours',
+    is_moving: false,
+    relationships: [],
+    ...overrides,
+  };
+}
+
+describe('CharacterDetail', () => {
+  it('shows a loading state while the fetch is in flight', () => {
+    mockUseMapCharacterDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    render(<CharacterDetail characterId={1} />);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the fetch fails', () => {
+    mockUseMapCharacterDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<CharacterDetail characterId={1} />);
+
+    expect(screen.getByText(/couldn't load/i)).toBeInTheDocument();
+  });
+
+  it('shows age, sex, home, work, and current activity', () => {
+    mockUseMapCharacterDetail.mockReturnValue({
+      data: detail(),
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<CharacterDetail characterId={1} />);
+
+    expect(screen.getByText('32, Female')).toBeInTheDocument();
+    expect(screen.getByText('delivering goods to neighbours')).toBeInTheDocument();
+    expect(screen.getByText('House')).toBeInTheDocument();
+    expect(screen.getByText('Bakery')).toBeInTheDocument();
+  });
+
+  it('shows "walking" instead of the scheduled activity while moving', () => {
+    mockUseMapCharacterDetail.mockReturnValue({
+      data: detail({ is_moving: true, current_activity: 'delivering goods to neighbours' }),
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<CharacterDetail characterId={1} />);
+
+    expect(screen.getByText('walking')).toBeInTheDocument();
+    expect(screen.queryByText('delivering goods to neighbours')).not.toBeInTheDocument();
+  });
+
+  it('lists household relationships in "name — label" form', () => {
+    mockUseMapCharacterDetail.mockReturnValue({
+      data: detail({
+        relationships: [
+          { character_id: 2, name: 'Thomas', label: 'husband' },
+          { character_id: 3, name: 'Emily', label: 'daughter' },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<CharacterDetail characterId={1} />);
+
+    expect(screen.getByText('Relationships')).toBeInTheDocument();
+    expect(screen.getByText('Thomas — husband')).toBeInTheDocument();
+    expect(screen.getByText('Emily — daughter')).toBeInTheDocument();
+  });
+
+  it('omits the relationships section when there are none', () => {
+    mockUseMapCharacterDetail.mockReturnValue({
+      data: detail({ relationships: [] }),
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<CharacterDetail characterId={1} />);
+
+    expect(screen.queryByText('Relationships')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/CharacterDetail/CharacterDetail.tsx
+++ b/frontend/src/components/CharacterDetail/CharacterDetail.tsx
@@ -1,0 +1,81 @@
+import { useMapCharacterDetail } from "../../hooks/useMap";
+import { buildingTypeLabel } from "../Map/geojson";
+import List from "../List/List";
+import styles from "./CharacterDetail.module.scss";
+
+interface CharacterDetailProps {
+  characterId: number;
+}
+
+export default function CharacterDetail({ characterId }: CharacterDetailProps) {
+  const { data, isLoading, isError } = useMapCharacterDetail(characterId);
+
+  if (isLoading) {
+    return <p className={styles.status}>Loading...</p>;
+  }
+
+  if (isError || !data) {
+    return <p className={styles.status}>Couldn&apos;t load this character.</p>;
+  }
+
+  // "walking" overrides the scheduled activity while moving, same rule as
+  // the character's own map tooltip (CharacterTooltipContent).
+  const activityLabel = data.is_moving ? "walking" : data.current_activity;
+  const home = data.home_type ? buildingTypeLabel(data.home_type) : null;
+  const work = data.work_type ? buildingTypeLabel(data.work_type) : null;
+
+  // List's generic constraint needs an `id` field - reuse character_id
+  // rather than widen the item type with an index signature.
+  type RelationshipListItem = (typeof data.relationships)[number] & {
+    id: number;
+  };
+  const relationshipItems: RelationshipListItem[] = data.relationships.map(
+    (relationship) => ({ ...relationship, id: relationship.character_id })
+  );
+
+  return (
+    <div className={styles.root}>
+      <dl className={styles.facts}>
+        <div className={styles.fact}>
+          <dt>Age</dt>
+          <dd>
+            {data.age}, {data.sex}
+          </dd>
+        </div>
+        {activityLabel && (
+          <div className={styles.fact}>
+            <dt>Currently</dt>
+            <dd>{activityLabel}</dd>
+          </div>
+        )}
+        {home && (
+          <div className={styles.fact}>
+            <dt>Home</dt>
+            <dd>{home}</dd>
+          </div>
+        )}
+        {work && (
+          <div className={styles.fact}>
+            <dt>Work</dt>
+            <dd>{work}</dd>
+          </div>
+        )}
+      </dl>
+
+      {data.relationships.length > 0 && (
+        <section className={styles.section}>
+          <h3 className={styles.sectionHeading}>Relationships</h3>
+          <List<RelationshipListItem>
+            items={relationshipItems}
+            className={styles.relationshipsList}
+            renderItem={(relationship) => (
+              <span>
+                {relationship.name} — {relationship.label}
+              </span>
+            )}
+          />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/DetailCard/DetailCard.module.scss
+++ b/frontend/src/components/DetailCard/DetailCard.module.scss
@@ -1,0 +1,64 @@
+// components/DetailCard/DetailCard.module.scss
+@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
+@use '../../styles/semantic/colors' as c;
+@use '../../styles/utilities/mixins' as m;
+
+// Mobile-first: a bottom sheet spanning the full viewport width, capped at
+// a portion of the viewport height so long content (e.g. a big
+// relationships list) scrolls inside .content instead of the sheet
+// growing off-screen. At `sm` and up this switches to a centered floating
+// card, matching Modal's own layout.
+.card {
+  position: fixed;
+  z-index: v.$z-index-modal;
+  display: flex;
+  flex-direction: column;
+  background: c.$color-bg;
+  box-shadow: 0 sp.$spacing-sm sp.$spacing-md rgba(0, 0, 0, 0.2);
+
+  left: 0;
+  right: 0;
+  bottom: 0;
+  max-height: 80vh;
+  border-radius: sp.$border-radius sp.$border-radius 0 0;
+
+  @include m.respond-to(sm) {
+    left: 50%;
+    right: auto;
+    bottom: auto;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 90%;
+    max-width: min(95vw, 480px);
+    max-height: 85vh;
+    border-radius: sp.$border-radius;
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: sp.$spacing-gap;
+  padding: sp.$spacing-sm sp.$padding-base;
+  border-bottom: 1px solid rgba(c.$color-border-primary, 0.4);
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  line-height: 1.2;
+  font-size: 1.1rem;
+}
+
+.closeButton {
+  flex-shrink: 0;
+}
+
+.content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  min-height: 0;
+  padding: sp.$spacing-md sp.$padding-base;
+}

--- a/frontend/src/components/DetailCard/DetailCard.stories.tsx
+++ b/frontend/src/components/DetailCard/DetailCard.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import DetailCard from './DetailCard';
+
+/**
+ * `DetailCard` is the entity-agnostic shell for the map's second level of
+ * progressive disclosure (Map -> tooltip -> click -> DetailCard). It only
+ * provides layout (title/close/content area, responsive mobile sheet vs.
+ * desktop centered card) via `DetailSurface` - entity-specific content
+ * (`CharacterDetail`, `BuildingDetail`, ...) is passed as `children`.
+ */
+const meta: Meta<typeof DetailCard> = {
+  title: 'Shared/DetailCard',
+  component: DetailCard,
+  tags: ['autodocs'],
+  // Renders via a Radix Portal into document.body - escapes the story
+  // canvas with inline docs rendering, so use an iframe like AlertDialog.
+  parameters: {
+    docs: {
+      story: { inline: false, iframeHeight: 320 },
+    },
+  },
+  args: {
+    open: true,
+    title: 'Alice',
+    onClose: () => {},
+    children: <p>Entity-specific content goes here.</p>,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DetailCard>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    const dialog = await body.findByRole('dialog', { name: 'Alice' });
+    await expect(dialog).toBeVisible();
+    await expect(body.getByRole('button', { name: 'Close' })).toBeVisible();
+  },
+};
+
+export const WithLongerContent: Story = {
+  args: {
+    title: 'Rose Cottage',
+    children: (
+      <>
+        <p>House</p>
+        <p>Residents: 4</p>
+        <ul>
+          <li>Alice (idle)</li>
+          <li>Thomas (delivering goods to neighbours)</li>
+          <li>Emily (idle)</li>
+          <li>James (idle)</li>
+        </ul>
+      </>
+    ),
+  },
+};

--- a/frontend/src/components/DetailCard/DetailCard.test.tsx
+++ b/frontend/src/components/DetailCard/DetailCard.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DetailCard from './DetailCard';
+
+function renderCard(overrides: Partial<React.ComponentProps<typeof DetailCard>> = {}) {
+  const props = {
+    open: true,
+    title: 'Alice',
+    onClose: vi.fn(),
+    children: <p>Card content</p>,
+    ...overrides,
+  };
+  render(<DetailCard {...props} />);
+  return props;
+}
+
+describe('DetailCard', () => {
+  it('renders the title and content when open', () => {
+    renderCard();
+    expect(screen.getByRole('dialog', { name: 'Alice' })).toBeInTheDocument();
+    expect(screen.getAllByText('Alice').length).toBeGreaterThan(0);
+    expect(screen.getByText('Card content')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    renderCard({ open: false });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderCard();
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Escape is pressed', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderCard();
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/DetailCard/DetailCard.tsx
+++ b/frontend/src/components/DetailCard/DetailCard.tsx
@@ -1,0 +1,48 @@
+import type React from "react";
+import DetailSurface from "../DetailSurface/DetailSurface";
+import Button from "../Button/Button";
+import styles from "./DetailCard.module.scss";
+
+// Reusable, entity-agnostic detail-card shell (see Map's "click a tooltip to
+// open a richer detail card" flow) - provides the header/title/close/content
+// layout every entity type shares; CharacterDetail/BuildingDetail (and later
+// PopulationCentreDetail) supply the actual information as `children`.
+// Deliberately has no Radix/Tamagui import of its own - DetailSurface is the
+// only piece of this feature that talks to a UI library primitive, so
+// swapping it out later doesn't touch this file or its callers.
+interface DetailCardProps {
+  open: boolean;
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export default function DetailCard({ open, title, onClose, children }: DetailCardProps) {
+  return (
+    <DetailSurface
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+      title={title}
+    >
+      <div className={styles.card}>
+        <div className={styles.header}>
+          {/* Plain text, not a heading element - DetailSurface already
+              renders an sr-only <h2> with the same text as the dialog's
+              accessible name/heading; a second real heading here would
+              duplicate it for screen reader users navigating by heading. */}
+          <div className={styles.title}>{title}</div>
+          <Button
+            ariaLabel="Close"
+            className={styles.closeButton}
+            onClick={onClose}
+          >
+            &times;
+          </Button>
+        </div>
+        <div className={styles.content}>{children}</div>
+      </div>
+    </DetailSurface>
+  );
+}

--- a/frontend/src/components/DetailSurface/DetailSurface.module.scss
+++ b/frontend/src/components/DetailSurface/DetailSurface.module.scss
@@ -1,0 +1,24 @@
+// components/DetailSurface/DetailSurface.module.scss
+@use '../../styles/base/variables' as v;
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: v.$z-index-modal;
+}
+
+// display: contents - Radix still needs this element in the DOM (focus
+// trap, dismiss-on-outside-click), but it should generate no box of its
+// own. DetailCard (rendered as this component's children) does its own
+// fixed positioning independent of this element's layout, so the "sheet on
+// mobile, centered card on larger screens" behaviour lives entirely in
+// DetailCard.module.scss instead of leaking into this thin adapter.
+.content {
+  display: contents;
+}
+
+.content:focus,
+.content:focus-visible {
+  outline: none;
+}

--- a/frontend/src/components/DetailSurface/DetailSurface.test.tsx
+++ b/frontend/src/components/DetailSurface/DetailSurface.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DetailSurface from './DetailSurface';
+
+function renderSurface(overrides: Partial<React.ComponentProps<typeof DetailSurface>> = {}) {
+  const props = {
+    open: true,
+    title: 'Alice',
+    onOpenChange: vi.fn(),
+    children: <p>Card content</p>,
+    ...overrides,
+  };
+  render(<DetailSurface {...props} />);
+  return props;
+}
+
+describe('DetailSurface', () => {
+  it('renders its children when open', () => {
+    renderSurface();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Card content')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    renderSurface({ open: false });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('gives the dialog an accessible name from title', () => {
+    renderSurface({ title: 'Rose Cottage' });
+    expect(screen.getByRole('dialog', { name: 'Rose Cottage' })).toBeInTheDocument();
+  });
+
+  it('calls onOpenChange(false) when Escape is pressed', async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderSurface();
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/src/components/DetailSurface/DetailSurface.tsx
+++ b/frontend/src/components/DetailSurface/DetailSurface.tsx
@@ -1,0 +1,39 @@
+import type React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import styles from "./DetailSurface.module.scss";
+
+// The one file in the map entity detail card (DetailSurface -> DetailCard
+// -> CharacterDetail/BuildingDetail, see MapTooltips.tsx/Map.tsx) allowed
+// to import a UI library primitive directly - everything above it works
+// against this component's plain open/onOpenChange/title/children props,
+// so swapping the overlay/sheet/dialog primitive underneath (e.g. once the
+// project's in-progress Radix -> Tamagui migration reaches this component)
+// only touches this file.
+interface DetailSurfaceProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Accessible name for the surface - not rendered visually here (DetailCard
+   * renders its own visible title inside `children`); Radix requires every
+   * Dialog to have one for screen reader users. */
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function DetailSurface({
+  open,
+  onOpenChange,
+  title,
+  children,
+}: DetailSurfaceProps) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className={styles.overlay} />
+        <DialogPrimitive.Content className={styles.content}>
+          <DialogPrimitive.Title className="sr-only">{title}</DialogPrimitive.Title>
+          {children}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/frontend/src/components/Map/Map.module.scss
+++ b/frontend/src/components/Map/Map.module.scss
@@ -65,6 +65,11 @@
 }
 
 .floatingTooltip {
+  // .tooltipHost above is pointer-events: none so empty space around the
+  // tooltip doesn't block map drags/clicks - re-enable it here so its own
+  // content (e.g. the "View details" button opening the entity detail
+  // card) is actually clickable.
+  pointer-events: auto;
   transform: translate(-50%, calc(-100% - 12px));
   background: white;
   border: 1px solid #888;

--- a/frontend/src/components/Map/Map.test.tsx
+++ b/frontend/src/components/Map/Map.test.tsx
@@ -1,8 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ComponentProps } from 'react';
 import { fromLngLat, toLngLat } from './utils';
 import { colourForCharacter } from './characters/placement';
+
+const mockFetchMapCharacterDetail = vi.fn();
+vi.mock('../../api/map', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/map')>();
+  return {
+    ...actual,
+    fetchMapCharacterDetail: (...args: unknown[]) => mockFetchMapCharacterDetail(...args),
+  };
+});
 
 // MapLibre needs a real WebGL context, which jsdom doesn't provide - these
 // fakes stand in for just enough of the maplibre-gl API surface for Map.tsx
@@ -230,16 +241,34 @@ function positionAlongPathForTest(
 }
 
 function renderMap(props: ComponentProps<typeof PopulationCentreMap>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <TooltipProvider>
-      <PopulationCentreMap {...props} />
-    </TooltipProvider>
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <PopulationCentreMap {...props} />
+      </TooltipProvider>
+    </QueryClientProvider>
   );
 }
 
 beforeEach(() => {
   FakeMap.instances = [];
   FakeMarker.instances = [];
+  mockFetchMapCharacterDetail.mockReset();
+  mockFetchMapCharacterDetail.mockResolvedValue({
+    id: 1,
+    name: 'Alice',
+    age: 32,
+    sex: 'Female',
+    home_type: null,
+    home_id: null,
+    work_type: null,
+    current_activity: null,
+    is_moving: false,
+    relationships: [],
+  });
 });
 
 const baseGeojson = {
@@ -818,7 +847,7 @@ describe('PopulationCentreMap', () => {
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent('Alice');
-    expect(tooltip.textContent).toBe('Alice');
+    expect(tooltip).not.toHaveTextContent('Currently:');
   });
 
   it('shows the crop stage in a field tooltip instead of the literal word "Crops"', async () => {
@@ -967,6 +996,143 @@ describe('PopulationCentreMap', () => {
 
     const feature = villageSourceFeatures().find((f) => f.properties.feature_type === 'path');
     expect(feature).toBeDefined();
+  });
+});
+
+describe('PopulationCentreMap entity detail card', () => {
+  it('opens a character detail card when "View details" is clicked in its tooltip', async () => {
+    const user = userEvent.setup();
+    const geojsonWithCharacter = {
+      ...baseGeojson,
+      features: [
+        {
+          geometry: { type: 'Point', coordinates: [10, 10] },
+          properties: { feature_type: 'character', id: 1, name: 'Alice' },
+        },
+      ],
+    };
+    renderMap({ geojson: geojsonWithCharacter });
+    const feature = villageSourceFeatures().find((f) => f.properties.feature_type === 'character');
+
+    act(() => {
+      currentMap().trigger('click', { features: [feature], lngLat: { lng: 10, lat: 10 } }, 'characters');
+    });
+    await screen.findByRole('tooltip');
+
+    await user.click(screen.getByRole('button', { name: 'View details' }));
+
+    expect(await screen.findByRole('dialog', { name: 'Alice' })).toBeInTheDocument();
+    expect(mockFetchMapCharacterDetail).toHaveBeenCalledWith(1);
+    // The tooltip is obscured behind the detail card's overlay - closed
+    // rather than left lingering underneath it.
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('opens a building detail card showing its residents when "View details" is clicked', async () => {
+    const user = userEvent.setup();
+    const geojsonWithHouse = {
+      ...baseGeojson,
+      features: [
+        {
+          geometry: { type: 'Polygon', coordinates: [[[5, 5], [5, 10], [10, 10], [10, 5], [5, 5]]] },
+          properties: {
+            feature_type: 'building',
+            id: 42,
+            name: 'House 2 of (Driftmoor village)',
+            building_type: 'residential',
+            residents: 1,
+            residential_capacity: 4,
+          },
+        },
+        {
+          geometry: { type: 'Point', coordinates: [7, 7] },
+          properties: {
+            feature_type: 'character',
+            id: 1,
+            name: 'Alice',
+            home_id: 42,
+            current_activity: 'idle',
+          },
+        },
+      ],
+    };
+    renderMap({ geojson: geojsonWithHouse });
+    const feature = villageSourceFeatures().find((f) => f.properties.feature_type === 'building');
+
+    act(() => {
+      currentMap().trigger('click', { features: [feature], lngLat: { lng: 0, lat: 0 } }, 'buildings-fill');
+    });
+    await screen.findByRole('tooltip');
+
+    await user.click(screen.getByRole('button', { name: 'View details' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'House' });
+    expect(dialog).toHaveTextContent('1 / 4');
+    expect(dialog).toHaveTextContent('Alice');
+    expect(dialog).toHaveTextContent('idle');
+  });
+
+  it('switches to a resident\'s own detail card when clicked inside the building detail card', async () => {
+    const user = userEvent.setup();
+    const geojsonWithHouse = {
+      ...baseGeojson,
+      features: [
+        {
+          geometry: { type: 'Polygon', coordinates: [[[5, 5], [5, 10], [10, 10], [10, 5], [5, 5]]] },
+          properties: {
+            feature_type: 'building',
+            id: 42,
+            name: 'House 2 of (Driftmoor village)',
+            building_type: 'residential',
+            residents: 1,
+          },
+        },
+        {
+          geometry: { type: 'Point', coordinates: [7, 7] },
+          properties: { feature_type: 'character', id: 1, name: 'Alice', home_id: 42 },
+        },
+      ],
+    };
+    renderMap({ geojson: geojsonWithHouse });
+    const feature = villageSourceFeatures().find((f) => f.properties.feature_type === 'building');
+
+    act(() => {
+      currentMap().trigger('click', { features: [feature], lngLat: { lng: 0, lat: 0 } }, 'buildings-fill');
+    });
+    await screen.findByRole('tooltip');
+    await user.click(screen.getByRole('button', { name: 'View details' }));
+    await screen.findByRole('dialog', { name: 'House' });
+
+    await user.click(screen.getByText('Alice'));
+
+    expect(await screen.findByRole('dialog', { name: 'Alice' })).toBeInTheDocument();
+    expect(mockFetchMapCharacterDetail).toHaveBeenCalledWith(1);
+  });
+
+  it('closes the detail card via its close button', async () => {
+    const user = userEvent.setup();
+    const geojsonWithCharacter = {
+      ...baseGeojson,
+      features: [
+        {
+          geometry: { type: 'Point', coordinates: [10, 10] },
+          properties: { feature_type: 'character', id: 1, name: 'Alice' },
+        },
+      ],
+    };
+    renderMap({ geojson: geojsonWithCharacter });
+    const feature = villageSourceFeatures().find((f) => f.properties.feature_type === 'character');
+
+    act(() => {
+      currentMap().trigger('click', { features: [feature], lngLat: { lng: 10, lat: 10 } }, 'characters');
+    });
+    await screen.findByRole('tooltip');
+    await user.click(screen.getByRole('button', { name: 'View details' }));
+    await screen.findByRole('dialog', { name: 'Alice' });
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -35,6 +35,9 @@ import {
   VILLAGE_LABEL_LAYER,
 } from "./layers";
 import { buildVillageSourceData, type WalkerState } from "./sourceData";
+import DetailCard from "../DetailCard/DetailCard";
+import CharacterDetail from "../CharacterDetail/CharacterDetail";
+import BuildingDetail from "../BuildingDetail/BuildingDetail";
 import styles from "./Map.module.scss";
 
 // maplibre-gl loads its own tile-processing worker via a runtime
@@ -127,6 +130,14 @@ interface TooltipOverlayState {
   lngLat: [number, number];
 }
 
+// The map's second level of progressive disclosure (tooltip -> click "View
+// details" -> DetailCard). Only character/building are wired up yet
+// (population centres are a later follow-up - see the map entity detail
+// card issue).
+type DetailSelection =
+  | { type: "character"; id: number }
+  | { type: "building"; id: number };
+
 export default function PopulationCentreMap({
   geojson,
   onViewportChange,
@@ -163,6 +174,15 @@ export default function PopulationCentreMap({
   const [tooltip, setTooltip] = useState<TooltipOverlayState | null>(null);
   const tooltipRootRef = useRef<Root | null>(null);
   const tooltipHostRef = useRef<HTMLDivElement | null>(null);
+
+  const [detail, setDetail] = useState<DetailSelection | null>(null);
+  // Opening the richer detail card obscures the (unreachable, once the
+  // card's overlay covers it) floating tooltip behind it - close it rather
+  // than leave it lingering under the modal.
+  const openDetail = useCallback((selection: DetailSelection) => {
+    setTooltip(null);
+    setDetail(selection);
+  }, []);
 
   const buildingFootprints = useMemo(
     () => buildingFootprintRings(features),
@@ -287,6 +307,7 @@ export default function PopulationCentreMap({
         // via buildingTypeLabel.
         const homeType = feature.properties?.home_type as string | null | undefined;
         const workType = feature.properties?.work_type as string | null | undefined;
+        const characterId = Number(feature.properties?.id);
         setTooltip({
           key: `character-${feature.id ?? JSON.stringify(feature.properties)}`,
           content: (
@@ -296,6 +317,7 @@ export default function PopulationCentreMap({
               work={workType ? buildingTypeLabel(workType) : undefined}
               currentActivity={feature.properties?.current_activity as string | null | undefined}
               isMoving={feature.properties?.is_moving as boolean | null | undefined}
+              onViewDetails={() => openDetail({ type: "character", id: characterId })}
             />
           ),
           lngLat: [e.lngLat.lng, e.lngLat.lat],
@@ -370,8 +392,12 @@ export default function PopulationCentreMap({
             return;
           }
           e.originalEvent?.stopPropagation?.();
+          const buildingId = Number(feature.properties?.id);
           const content = polygonTooltipContent(
-            feature.properties as GeoJSONFeatureProperties
+            feature.properties as GeoJSONFeatureProperties,
+            feature.properties?.feature_type === "building"
+              ? () => openDetail({ type: "building", id: buildingId })
+              : undefined
           );
           if (!content) return;
           setTooltip({
@@ -419,7 +445,10 @@ export default function PopulationCentreMap({
       setMapReady(false);
       initialFitDoneRef.current = false;
     };
-  }, []);
+    // openDetail is a useCallback with its own `[]` deps, so it's
+    // referentially stable - listing it here satisfies exhaustive-deps
+    // without changing this effect's actual "run once on mount" behaviour.
+  }, [openDetail]);
 
   // Keeps the tooltip overlay anchored to its map-space point while panning,
   // and reprojects the initial position once opened.
@@ -569,11 +598,79 @@ export default function PopulationCentreMap({
     };
   }, []);
 
+  // Derived from data the map already has loaded (this village's features/
+  // characterFeatures) rather than a dedicated fetch - BuildingDetail's
+  // residents are every currently-loaded character feature whose home_id
+  // (see CharacterPointFeatureSerializer) matches the selected building.
+  const selectedBuildingFeature = useMemo(() => {
+    if (!detail || detail.type !== "building") return null;
+    return (
+      features.find(
+        (f) =>
+          f.properties?.feature_type === "building" &&
+          Number(f.properties?.id) === detail.id
+      ) ?? null
+    );
+  }, [detail, features]);
+
+  const selectedBuildingResidents = useMemo(() => {
+    if (!detail || detail.type !== "building") return [];
+    return characterFeatures
+      .filter((f) => f.properties?.home_id != null && Number(f.properties.home_id) === detail.id)
+      .map((f) => ({
+        id: Number(f.properties?.id),
+        name: (f.properties?.name as string | undefined) ?? "",
+        currentActivity: f.properties?.current_activity as string | null | undefined,
+        isMoving: f.properties?.is_moving as boolean | null | undefined,
+      }));
+  }, [detail, characterFeatures]);
+
+  const selectedCharacterName = useMemo(() => {
+    if (!detail || detail.type !== "character") return "Character";
+    const feature = characterFeatures.find(
+      (f) => Number(f.properties?.id) === detail.id
+    );
+    return (feature?.properties?.name as string | undefined) ?? "Character";
+  }, [detail, characterFeatures]);
+
   return (
     <div className={styles.mapWrapper}>
       <div ref={containerRef} className={styles.mapContainer} />
       <div ref={tooltipHostRef} className={styles.tooltipHost} />
       {children && <div className={styles.controlsOverlay}>{children}</div>}
+      {detail?.type === "character" && (
+        <DetailCard open title={selectedCharacterName} onClose={() => setDetail(null)}>
+          <CharacterDetail characterId={detail.id} />
+        </DetailCard>
+      )}
+      {detail?.type === "building" && selectedBuildingFeature && (
+        <DetailCard
+          open
+          title={buildingTypeLabel(
+            selectedBuildingFeature.properties?.building_type as string | undefined
+          )}
+          onClose={() => setDetail(null)}
+        >
+          <BuildingDetail
+            buildingType={selectedBuildingFeature.properties?.building_type as string | undefined}
+            residents={selectedBuildingResidents}
+            workerCount={selectedBuildingFeature.properties?.workers as number | null | undefined}
+            residentialCapacity={
+              selectedBuildingFeature.properties?.residential_capacity as
+                | number
+                | null
+                | undefined
+            }
+            goods={
+              selectedBuildingFeature.properties?.goods as
+                | { good_type?: string; display?: string }[]
+                | null
+                | undefined
+            }
+            onSelectResident={(characterId) => openDetail({ type: "character", id: characterId })}
+          />
+        </DetailCard>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Map/MapTooltips.tsx
+++ b/frontend/src/components/Map/MapTooltips.tsx
@@ -19,6 +19,9 @@ interface BuildingTooltipProps {
   workers?: number | null;
   residents?: number | null;
   goods?: GoodEntry[] | null;
+  /** Second level of progressive disclosure (issue: map entity detail card) -
+   * omit to render the tooltip with no "View details" affordance. */
+  onViewDetails?: () => void;
 }
 
 export function BuildingTooltipContent({
@@ -27,6 +30,7 @@ export function BuildingTooltipContent({
   workers,
   residents,
   goods,
+  onViewDetails,
 }: BuildingTooltipProps) {
   const stockedGoods = (goods ?? []).filter((g) => g.display);
   const isResidential = buildingType === "residential";
@@ -52,6 +56,11 @@ export function BuildingTooltipContent({
           </ul>
         </>
       )}
+      {onViewDetails && (
+        <button type="button" onClick={onViewDetails}>
+          View details
+        </button>
+      )}
     </div>
   );
 }
@@ -62,6 +71,9 @@ interface CharacterTooltipProps {
   work?: string | null;
   currentActivity?: string | null;
   isMoving?: boolean | null;
+  /** Second level of progressive disclosure (issue: map entity detail card) -
+   * omit to render the tooltip with no "View details" affordance. */
+  onViewDetails?: () => void;
 }
 
 export function CharacterTooltipContent({
@@ -70,6 +82,7 @@ export function CharacterTooltipContent({
   work,
   currentActivity,
   isMoving,
+  onViewDetails,
 }: CharacterTooltipProps) {
   const activityLabel = isMoving ? "walking" : currentActivity;
 
@@ -79,6 +92,11 @@ export function CharacterTooltipContent({
       {activityLabel && <div>Currently: {activityLabel}</div>}
       {home && <div>Lives at: {home}</div>}
       {work && <div>Works at: {work}</div>}
+      {onViewDetails && (
+        <button type="button" onClick={onViewDetails}>
+          View details
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Map/geojson.tsx
+++ b/frontend/src/components/Map/geojson.tsx
@@ -67,7 +67,8 @@ export function buildingTypeLabel(buildingType: string | null | undefined): stri
 }
 
 export function polygonTooltipContent(
-  properties: GeoJSONFeatureProperties | null | undefined
+  properties: GeoJSONFeatureProperties | null | undefined,
+  onViewDetails?: () => void
 ): React.ReactNode | undefined {
   if (properties?.feature_type === "building") {
     const buildingType = properties?.building_type as string | undefined;
@@ -79,6 +80,7 @@ export function polygonTooltipContent(
         workers={properties?.workers as number | null | undefined}
         residents={properties?.residents as number | null | undefined}
         goods={properties?.goods as { good_type?: string; display?: string }[] | null | undefined}
+        onViewDetails={onViewDetails}
       />
     );
   }

--- a/frontend/src/hooks/useMap.ts
+++ b/frontend/src/hooks/useMap.ts
@@ -2,6 +2,7 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   fetchFirstPopulationCentreId,
+  fetchMapCharacterDetail,
   fetchMapViewport,
   fetchMapWorldBounds,
   fetchPopulationCentreMap,
@@ -84,6 +85,20 @@ export function useMapWorldBounds() {
     queryFn: fetchMapWorldBounds,
     staleTime: 30 * 60 * 1000,
     gcTime: 60 * 60 * 1000,
+  });
+}
+
+// On-demand fetch for one character's map detail card (see DetailCard/
+// CharacterDetail) - only enabled while that character's card is actually
+// open, not polled like useMapViewport, since age/sex/relationships don't
+// need to track second-to-second the way position/activity do.
+export function useMapCharacterDetail(characterId: number | null) {
+  return useQuery({
+    queryKey: ["map", "character-detail", characterId],
+    queryFn: () => fetchMapCharacterDetail(characterId as number),
+    enabled: characterId != null,
+    staleTime: 15 * 1000,
+    gcTime: 5 * 60 * 1000,
   });
 }
 

--- a/locations/serializers.py
+++ b/locations/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from character.models import CharacterLocation
 from character.serializers import CharacterSerializer
+from character.services import relationship_services
 from economy.constants import format_quantity
 
 from locations.models import (
@@ -14,6 +15,7 @@ from locations.models import (
     Road,
     Journey,
 )
+from locations.services import population_estimation
 
 ##########################################################
 ##### LOCATION SERIALISERS
@@ -104,6 +106,18 @@ class CharacterPointFeatureSerializer(PointFeatureSerializer):
                 return location.location.building_type
         return None
 
+    def _primary_location_id(self, obj, role):
+        # The building's own pk, alongside _primary_location_type's plain
+        # type label - lets the frontend cross-reference a character back
+        # to its home Building (e.g. BuildingDetail's resident list, built
+        # client-side by matching already-loaded character features'
+        # home_id against the selected building's id - see the map entity
+        # detail card).
+        for location in obj.locations.all():
+            if location.role == role and location.is_primary:
+                return location.location_id
+        return None
+
     def _active_journey(self, obj):
         journeys = getattr(obj, "active_journey_list", None)
         if journeys is not None:
@@ -142,6 +156,7 @@ class CharacterPointFeatureSerializer(PointFeatureSerializer):
             "id": obj.id,
             "name": obj.name,
             "home_type": self._primary_location_type(obj, CharacterLocation.Role.HOME),
+            "home_id": self._primary_location_id(obj, CharacterLocation.Role.HOME),
             "work_type": self._primary_location_type(obj, CharacterLocation.Role.WORK),
             "hunger_label": needs.hunger_label() if needs else None,
             "current_activity": self._current_activity_name(obj),
@@ -149,6 +164,36 @@ class CharacterPointFeatureSerializer(PointFeatureSerializer):
             "effective_speed": obj.movement_speed,
             "path": path,
         }
+
+
+class CharacterDetailSerializer(serializers.Serializer):
+    """
+    Richer, on-demand character info for the map's detail card (see
+    MapCharacterDetailView) - starts from the same tooltip-level properties
+    CharacterPointFeatureSerializer already computes (home/work/activity/
+    is_moving), then adds age/sex/relationships. Those involve extra
+    queries per character, so they're deliberately kept out of the bulk
+    per-poll map feature every character on screen carries, and only
+    fetched once a player actually opens that one character's detail card.
+    """
+
+    def to_representation(self, obj):
+        properties = CharacterPointFeatureSerializer().get_properties(obj)
+        properties["age"] = int(obj.get_age() // 365)
+        properties["sex"] = obj.sex
+        properties["relationships"] = [
+            {
+                "character_id": member["character"].id,
+                "name": member["character"].name,
+                "label": relationship_services.household_relationship_label(
+                    member["relationship_type"],
+                    member["other_role"],
+                    member["character"].sex,
+                ),
+            }
+            for member in relationship_services.relationship_get_household_members(obj)
+        ]
+        return properties
 
 
 class LineStringFeatureSerializer(GeoJSONFeatureSerializer):
@@ -260,6 +305,10 @@ class BuildingFeatureSerializer(PolygonFeatureSerializer):
             "building_type": obj.building_type,
             "workers": self._primary_count(obj, CharacterLocation.Role.WORK),
             "residents": self._primary_count(obj, CharacterLocation.Role.HOME),
+            # 0 (never None) for a non-residential building - same "not
+            # applicable" shape residents/workers already use above, rather
+            # than the frontend needing to special-case null vs. zero.
+            "residential_capacity": population_estimation.residential_capacity(obj),
             "goods": goods,
         }
 

--- a/locations/tests/test_map_character_detail.py
+++ b/locations/tests/test_map_character_detail.py
@@ -1,0 +1,54 @@
+from django.contrib.auth import get_user_model
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from character.models import Character, RelationshipRole, RelationshipType
+from character.services import relationship_services
+
+
+class MapCharacterDetailViewTest(TestCase):
+    def setUp(self):
+        user = get_user_model().objects.create_user(
+            email="detail-viewer@example.com", password="testpassword123"
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=user)
+        self.character = Character.objects.create(
+            given_name="Alice", sex="Female", location=Point(0, 0, srid=3857)
+        )
+        self.url = reverse("map-character-detail", kwargs={"pk": self.character.id})
+
+    def test_unknown_character_returns_404(self):
+        response = self.client.get(
+            reverse("map-character-detail", kwargs={"pk": 999999})
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_name_age_sex_and_empty_relationships(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], self.character.id)
+        self.assertEqual(response.data["name"], self.character.name)
+        self.assertEqual(response.data["sex"], "Female")
+        self.assertIsInstance(response.data["age"], int)
+        self.assertEqual(response.data["relationships"], [])
+
+    def test_includes_household_relationships(self):
+        husband = Character.objects.create(given_name="Thomas", sex="Male")
+        relationship_services.relationship_create(
+            RelationshipType.MARRIAGE,
+            [
+                (self.character, RelationshipRole.SPOUSE),
+                (husband, RelationshipRole.SPOUSE),
+            ],
+        )
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(
+            response.data["relationships"],
+            [{"character_id": husband.id, "name": "Thomas", "label": "husband"}],
+        )

--- a/locations/tests/test_map_serializers.py
+++ b/locations/tests/test_map_serializers.py
@@ -9,10 +9,12 @@ from progression.models import ActivityDefinition, CharacterActivity
 from ..models import Building, LandArea, PopulationCentre, Subzone
 from ..serializers import (
     BuildingFeatureSerializer,
+    CharacterDetailSerializer,
     CharacterPointFeatureSerializer,
     PopulationCentreLabelFeatureSerializer,
     SubzoneFeatureSerializer,
 )
+from ..services import population_estimation
 
 SQUARE = Polygon(
     ((0, 0), (0, 10), (10, 10), (10, 0), (0, 0)),
@@ -67,6 +69,23 @@ class BuildingFeatureSerializerTest(TestCase):
         self.assertEqual(props["workers"], 1)
         self.assertEqual(props["residents"], 1)
 
+    def test_residential_capacity_is_zero_for_a_non_residential_building(self):
+        self.assertEqual(self.properties()["residential_capacity"], 0)
+
+    def test_residential_capacity_matches_the_service_for_a_residential_building(self):
+        house = Building.objects.create(
+            name="House", building_type="residential", footprint=SQUARE
+        )
+        house = Building.objects.prefetch_related(
+            "character_locations", "goods_stocks"
+        ).get(pk=house.pk)
+        props = BuildingFeatureSerializer(house).data["properties"]
+        self.assertEqual(
+            props["residential_capacity"],
+            population_estimation.residential_capacity(house),
+        )
+        self.assertGreater(props["residential_capacity"], 0)
+
     def test_goods_only_include_positive_stock_using_format_quantity(self):
         GoodsStock.objects.create(
             building=self.building, good_type="flour", quantity=21000
@@ -104,6 +123,17 @@ class CharacterPointFeatureSerializerTest(TestCase):
         props = self.properties()
         self.assertIsNone(props["home_type"])
         self.assertIsNone(props["work_type"])
+        self.assertIsNone(props["home_id"])
+
+    def test_home_id_matches_the_primary_home_building(self):
+        CharacterLocation.objects.create(
+            character=self.character,
+            location=self.home,
+            role=CharacterLocation.Role.HOME,
+            is_primary=True,
+        )
+
+        self.assertEqual(self.properties()["home_id"], self.home.id)
 
     def test_home_and_work_type_from_primary_locations_only(self):
         CharacterLocation.objects.create(
@@ -197,6 +227,65 @@ class CharacterPointFeatureSerializerTest(TestCase):
         self.character.needs.hunger = 50
         self.character.needs.save(update_fields=["hunger"])
         self.assertEqual(self.properties()["hunger_label"], "Hungry")
+
+
+class CharacterDetailSerializerTest(TestCase):
+    """
+    CharacterDetailSerializer builds on CharacterPointFeatureSerializer's
+    properties (home/work/activity - covered above), so these tests only
+    cover what it adds: age, sex, and relationships.
+    """
+
+    def setUp(self):
+        self.character = Character.objects.create(
+            given_name="Alice", sex="Female", location=Point(0, 0, srid=3857)
+        )
+
+    def properties(self):
+        character = (
+            Character.objects.select_related("needs")
+            .prefetch_related("locations__location")
+            .get(pk=self.character.pk)
+        )
+        return CharacterDetailSerializer(character).data
+
+    def test_includes_age_and_sex(self):
+        props = self.properties()
+        self.assertEqual(props["sex"], "Female")
+        self.assertIsInstance(props["age"], int)
+
+    def test_no_relationships_by_default(self):
+        self.assertEqual(self.properties()["relationships"], [])
+
+    def test_household_relationships_are_summarised(self):
+        from character.models import RelationshipRole, RelationshipType
+        from character.services import relationship_services
+
+        husband = Character.objects.create(given_name="Thomas", sex="Male")
+        relationship_services.relationship_create(
+            RelationshipType.MARRIAGE,
+            [
+                (self.character, RelationshipRole.SPOUSE),
+                (husband, RelationshipRole.SPOUSE),
+            ],
+        )
+        daughter = Character.objects.create(given_name="Emily", sex="Female")
+        relationship_services.relationship_create(
+            RelationshipType.PARENT_CHILD,
+            [
+                (self.character, RelationshipRole.PARENT),
+                (daughter, RelationshipRole.CHILD),
+            ],
+        )
+
+        relationships = self.properties()["relationships"]
+        self.assertCountEqual(
+            relationships,
+            [
+                {"character_id": husband.id, "name": "Thomas", "label": "husband"},
+                {"character_id": daughter.id, "name": "Emily", "label": "daughter"},
+            ],
+        )
 
 
 class SubzoneFeatureSerializerTest(TestCase):

--- a/locations/views.py
+++ b/locations/views.py
@@ -36,6 +36,7 @@ from .serializers import (
     BoundaryFeatureSerializer,
     FeatureCollectionSerializer,
     PopulationCentreLabelFeatureSerializer,
+    CharacterDetailSerializer,
     CharacterPointFeatureSerializer,
     BuildingFeatureSerializer,
     SubzoneFeatureSerializer,
@@ -216,6 +217,35 @@ class MapViewportView(APIView):
                 features, bbox=list(bbox.extent), meta=meta
             ).data
         )
+
+
+class MapCharacterDetailView(APIView):
+    """
+    On-demand detail for one character's map detail card (progressive
+    disclosure past its tooltip - see the frontend's DetailCard/
+    CharacterDetail). Deliberately separate from PopulationCentreMapView/
+    MapViewportView's bulk per-poll character features: age/sex/
+    relationships involve extra queries per character, so they're only
+    fetched once, when a player actually opens that one character's card,
+    rather than for every character on every map poll.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, pk):
+        character = get_object_or_404(
+            Character.objects.select_related("needs").prefetch_related(
+                "locations__location",
+                Prefetch(
+                    "journeys",
+                    queryset=Journey.objects.filter(status="active"),
+                    to_attr="active_journey_list",
+                ),
+                _current_activity_prefetch(),
+            ),
+            pk=pk,
+        )
+        return Response(CharacterDetailSerializer(character).data)
 
 
 class MapWorldBoundsView(APIView):


### PR DESCRIPTION
## Summary
- Adds a second level of progressive disclosure on the map: a "View details" affordance in character/building tooltips opens a richer detail card (`DetailSurface`/`DetailCard`) rendered via new `CharacterDetail`/`BuildingDetail` components.
- Backend: new `MapCharacterDetailView` endpoint (`/map/characters/<pk>/`), relationship label helpers in `character/services/relationship_services.py`, and `home_id`/`residential_capacity` added to the map serializers.
- Frontend: `Map.tsx`/`useMap.ts` wired to fetch and display detail data; tooltips extended with an optional `onViewDetails` handler.

## Test plan
- [x] Backend: `character.tests.test_relationship_services`, `locations.tests.test_map_character_detail`, `locations.tests.test_map_serializers` — 32/32 pass
- [x] Backend: full `locations` app suite — 150/150 pass
- [x] Frontend: `tsc --noEmit` — clean
- [x] Frontend: `eslint` — 0 errors (2 pre-existing unrelated warnings)
- [x] Frontend: `vitest run` — 507/507 pass

https://claude.ai/code/session_019Who9FJu8NLdWkUd8eLCzX