### PR TITLE
feat: gate TodayPointsBadge on map behind a feature flag

### DIFF
--- a/frontend/src/featureFlags.ts
+++ b/frontend/src/featureFlags.ts
@@ -17,6 +17,7 @@ const featureFlags: Record<FeatureFlagKey, FeatureFlagValue> = {
   unified_homepage: [],
   results_mode: [],
   map: ['testers'],
+  todayPointsBadge: ['all'],
 };
 
 export default featureFlags;

--- a/frontend/src/pages/MapPage/MapPage.tsx
+++ b/frontend/src/pages/MapPage/MapPage.tsx
@@ -6,6 +6,7 @@ import PopulationCentreMap, {
   type PopulationCentreMapHandle,
 } from "../../components/Map/Map";
 import TodayPointsBadge from "../../components/TodayPointsBadge/TodayPointsBadge";
+import FeatureToggle from "../../components/FeatureToggle";
 import {
   useInitialMapCentre,
   useMapViewport,
@@ -123,7 +124,9 @@ export default function MapPage(): React.ReactElement {
             onViewportChange={handleViewportChange}
             worldBounds={worldBounds?.bbox}
           >
-            <TodayPointsBadge />
+            <FeatureToggle flag="todayPointsBadge" fallback={null}>
+              <TodayPointsBadge />
+            </FeatureToggle>
             {nextVillage && (
               <Button
                 type="button"

--- a/frontend/src/types/enums.ts
+++ b/frontend/src/types/enums.ts
@@ -25,7 +25,8 @@ export type FeatureFlagKey =
   | "onlinePlayerCount"
   | "unified_homepage"
   | "results_mode"
-  | "map";
+  | "map"
+  | "todayPointsBadge";
 
 // ---------------------------------------------------------------------------
 // Timer statuses (Timer.STATUS_CHOICES in gameplay/models.py)


### PR DESCRIPTION
## Summary

- Adds a `todayPointsBadge` feature flag key (`FeatureFlagKey` in `types/enums.ts`)
- Defaults it to `['all']` in `featureFlags.ts`, matching the badge's current unconditional-render behavior
- Wraps `<TodayPointsBadge />` in `MapPage.tsx` with `<FeatureToggle flag="todayPointsBadge" fallback={null}>`, following the same pattern already used for `OnlineCountBadge`/`onlinePlayerCount`

This lets the badge be toggled independently (e.g. restricted to `testers` or disabled) without a code change, via either the local default or a remote (server-driven) override.

## Test plan

- [x] `npx vitest run` on `MapPage.test.tsx`, `TodayPointsBadge.test.tsx`, `FeatureToggle.test.tsx` — 16/16 passing
- [x] `npm run lint` — no new errors (2 pre-existing unrelated warnings)
- [x] `npx tsc --noEmit` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaKSLZB1wCxE3Tq387mAQ4)_