### PR TITLE
Fix GitHub Pages docs deploy: remove invalid storybook --base flag

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -55,7 +55,7 @@ jobs:
       run: cd frontend && npm ci
 
     - name: Build Storybook
-      run: cd frontend && npm run build-storybook -- --base=/ProgressRPG/storybook/
+      run: cd frontend && npm run build-storybook
 
     - name: Combine sites
       run: |


### PR DESCRIPTION
## Summary
- `storybook build` doesn't support a `--base` flag (that's a Vite-only option); the `Build Storybook` step in `.github/workflows/deploy-docs.yml` has been failing on every run since the mkdocs conversion, so `progressrpg.github.io/ProgressRPG/` has been stuck serving a stale, pre-mkdocs Storybook-only build.
- The base path is already configured correctly via `viteFinal` in `frontend/.storybook/main.ts`, so the flag was redundant as well as invalid.
- Removes the flag so `npm run build-storybook` succeeds and the combined mkdocs + Storybook site can deploy again.

## Test plan
- [ ] Confirm the `Deploy Docs site to GitHub Pages` workflow run on this PR (or after merge to `main`) completes successfully
- [ ] Visit https://progressrpg.github.io/ProgressRPG/ and confirm it shows the mkdocs docs site, with Storybook reachable at `/ProgressRPG/storybook/`

https://claude.ai/code/session_01QSwWkchRGye37hoCmEfDCz