### PR TITLE
Route mill/bakery ticks through BuildingCapability, key conversion st…

### DIFF
--- a/economy/management/commands/economy_status.py
+++ b/economy/management/commands/economy_status.py
@@ -50,8 +50,7 @@ class Command(BaseCommand):
         buildings_by_centre: dict[int | None, list[Building]] = {}
         buildings = (
             Building.objects.filter(population_centre__in=centres)
-            .select_related("conversion_state")
-            .prefetch_related("goods_stocks")
+            .prefetch_related("goods_stocks", "conversion_states")
             .order_by("building_type", "name")
         )
         for building in buildings:
@@ -81,9 +80,10 @@ class Command(BaseCommand):
         else:
             self.stdout.write("    (no goods stored)")
 
-        state = getattr(building, "conversion_state", None)
-        if state is not None:
-            self.stdout.write(f"    last processed: {state.last_processed_on}")
+        for state in building.conversion_states.all():
+            self.stdout.write(
+                f"    {state.activity} last processed: {state.last_processed_on}"
+            )
 
     def _print_population_capacity(self, centre):
         """

--- a/economy/migrations/0006_goodsconversionstate_activity.py
+++ b/economy/migrations/0006_goodsconversionstate_activity.py
@@ -1,0 +1,36 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("economy", "0005_backfill_building_capabilities"),
+        ("locations", "0010_building_open_time_override_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="goodsconversionstate",
+            name="building",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="conversion_states",
+                to="locations.building",
+            ),
+        ),
+        migrations.AddField(
+            model_name="goodsconversionstate",
+            name="activity",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("milling", "Milling"),
+                    ("baking", "Baking"),
+                    ("farming", "Farming"),
+                ],
+                max_length=20,
+                null=True,
+            ),
+        ),
+    ]

--- a/economy/migrations/0007_backfill_conversion_state_activity.py
+++ b/economy/migrations/0007_backfill_conversion_state_activity.py
@@ -1,0 +1,41 @@
+from django.db import migrations
+
+# Every existing GoodsConversionState row was created by
+# advance_mill_economy_tick or advance_bakery_economy_tick (see
+# economy/tasks.py), so its activity is fully determined by its
+# building's building_type at the time this migration runs.
+BUILDING_TYPE_TO_ACTIVITY = {
+    "mill": "milling",
+    "bakery": "baking",
+}
+
+
+def backfill_activity(apps, schema_editor):
+    GoodsConversionState = apps.get_model("economy", "GoodsConversionState")
+
+    for state in GoodsConversionState.objects.select_related("building"):
+        activity = BUILDING_TYPE_TO_ACTIVITY.get(state.building.building_type)
+        if activity is None:
+            # No known production activity for this building - the state
+            # row is meaningless without one, and none should exist today.
+            state.delete()
+            continue
+        state.activity = activity
+        state.save(update_fields=["activity"])
+
+
+def noop_reverse(apps, schema_editor):
+    # Reversing 0006/0008 already drops the activity column/constraint;
+    # nothing extra to undo here.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("economy", "0006_goodsconversionstate_activity"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_activity, noop_reverse),
+    ]

--- a/economy/migrations/0008_alter_goodsconversionstate_activity.py
+++ b/economy/migrations/0008_alter_goodsconversionstate_activity.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("economy", "0007_backfill_conversion_state_activity"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="goodsconversionstate",
+            name="activity",
+            field=models.CharField(
+                choices=[
+                    ("milling", "Milling"),
+                    ("baking", "Baking"),
+                    ("farming", "Farming"),
+                ],
+                max_length=20,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="goodsconversionstate",
+            constraint=models.UniqueConstraint(
+                fields=("building", "activity"),
+                name="uniq_conversion_state_per_activity",
+            ),
+        ),
+    ]

--- a/economy/models.py
+++ b/economy/models.py
@@ -165,16 +165,36 @@ class BuildingCapability(models.Model):
 
 class GoodsConversionState(models.Model):
     """
-    Per-building idempotency guard for a daily goods-conversion task (e.g.
-    milling). Deliberately thin - unlike FieldCrop, conversion has no growth
-    stages, just a daily "did we already process this building today" check
-    - kept generic so bakery can reuse it unmodified later.
+    Per-(building, activity) idempotency guard for a daily goods-conversion
+    task (e.g. milling). Keyed by activity, not just building, because a
+    single building can hold multiple capabilities (e.g. a communal
+    building that both mills and bakes) - each needs its own "did we
+    already process this today" flag, or the first tick to run would mark
+    the building processed and the second would silently skip (see
+    .claude/plans/building-capabilities-plan.md). Deliberately thin -
+    unlike FieldCrop, conversion has no growth stages, just the daily flag.
     """
 
-    building = models.OneToOneField(
-        "locations.Building", on_delete=models.CASCADE, related_name="conversion_state"
+    building = models.ForeignKey(
+        "locations.Building",
+        on_delete=models.CASCADE,
+        related_name="conversion_states",
+    )
+    activity = models.CharField(
+        max_length=20, choices=BuildingCapability.Activity.choices
     )
     last_processed_on = models.DateField(null=True, blank=True)
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["building", "activity"],
+                name="uniq_conversion_state_per_activity",
+            ),
+        ]
+
     def __str__(self):
-        return f"GoodsConversionState({self.building_id}, {self.last_processed_on})"
+        return (
+            f"GoodsConversionState({self.building_id}, {self.activity}, "
+            f"{self.last_processed_on})"
+        )

--- a/economy/tasks.py
+++ b/economy/tasks.py
@@ -150,10 +150,12 @@ def advance_mill_economy_tick(today=None):
     """
     today = today or timezone.localdate()
 
-    for mill in Building.objects.filter(building_type="mill").select_related(
-        "population_centre"
-    ):
-        state, _ = GoodsConversionState.objects.get_or_create(building=mill)
+    for mill in Building.objects.filter(
+        capabilities__activity="milling"
+    ).select_related("population_centre"):
+        state, _ = GoodsConversionState.objects.get_or_create(
+            building=mill, activity="milling"
+        )
         if state.last_processed_on == today:
             continue
 
@@ -201,10 +203,12 @@ def advance_bakery_economy_tick(today=None):
     """
     today = today or timezone.localdate()
 
-    for bakery in Building.objects.filter(building_type="bakery").select_related(
-        "population_centre"
-    ):
-        state, _ = GoodsConversionState.objects.get_or_create(building=bakery)
+    for bakery in Building.objects.filter(
+        capabilities__activity="baking"
+    ).select_related("population_centre"):
+        state, _ = GoodsConversionState.objects.get_or_create(
+            building=bakery, activity="baking"
+        )
         if state.last_processed_on == today:
             continue
 

--- a/economy/tests/test_tasks.py
+++ b/economy/tests/test_tasks.py
@@ -638,6 +638,82 @@ class AdvanceBakeryEconomyTickTests(TestCase):
         )
 
 
+class MultiCapabilityBuildingTests(TestCase):
+    """
+    A building holding more than one capability (e.g. a communal building
+    that both mills and bakes) must be ticked for every one of them on the
+    same day. Regression coverage for the GoodsConversionState collision
+    described in .claude/plans/building-capabilities-plan.md: before
+    GoodsConversionState was keyed by (building, activity), the first tick
+    to run would mark the building "processed today" and the second would
+    silently skip it.
+    """
+
+    def test_milling_and_baking_both_run_on_the_same_day_for_one_building(self):
+        centre = PopulationCentre.objects.create(
+            name="Communalville",
+            location=Point(0, 0, srid=3857),
+            boundary=_square(0, 0, 50),
+        )
+        granary = _make_granary(centre)
+        GoodsStock.objects.create(
+            building=granary,
+            good_type=GoodsStock.GoodType.WHEAT,
+            quantity=500_000.0,
+        )
+
+        communal = Building.objects.create(
+            name="Communal Hall",
+            building_type="communal",
+            location=Point(80, 0, srid=3857),
+            footprint=_square(80, 0, 5),
+            population_centre=centre,
+        )
+        BuildingCapability.objects.create(building=communal, activity="milling")
+        BuildingCapability.objects.create(building=communal, activity="baking")
+        InteriorSpace.objects.create(
+            building=communal, name="Flour store", usage="flour_storage", area=1000.0
+        )
+        InteriorSpace.objects.create(
+            building=communal, name="Bread store", usage="storage", area=1000.0
+        )
+        node = Node.objects.create(
+            name="Node for Communal Hall",
+            location=communal.location,
+            kind=Node.Kind.BUILDING,
+            building=communal,
+        )
+        Character.objects.create(
+            given_name="Worker1",
+            location=communal.location,
+            current_node=node,
+            is_moving=False,
+        )
+
+        with _unlimited_demand():
+            advance_mill_economy_tick()
+            advance_bakery_economy_tick()
+
+        # Bread can only exist if baking found flour to consume - and the
+        # only source of flour is the same building's milling tick having
+        # already run today, so a positive bread quantity is proof both
+        # ticks actually ran rather than the second silently no-opping.
+        # (Flour itself may end up fully consumed here, since milling and
+        # baking share one building with no minimum retention between
+        # them - that's expected, not asserted on directly.)
+        bread = GoodsStock.objects.get(building=communal, good_type="bread")
+        self.assertGreater(bread.quantity, 0)
+
+        milling_state = GoodsConversionState.objects.get(
+            building=communal, activity="milling"
+        )
+        baking_state = GoodsConversionState.objects.get(
+            building=communal, activity="baking"
+        )
+        self.assertEqual(milling_state.last_processed_on, timezone.localdate())
+        self.assertEqual(baking_state.last_processed_on, timezone.localdate())
+
+
 class AdvanceBreadConsumptionTickTests(TestCase):
     def _make_centre_with_home(self, name="Eatville"):
         centre_point = Point(0, 0, srid=3857)


### PR DESCRIPTION
…ate by activity

advance_mill_economy_tick/advance_bakery_economy_tick now iterate buildings by capabilities__activity instead of building_type, so a building with multiple capabilities (e.g. a communal building that both mills and bakes) gets ticked for each one.

GoodsConversionState moves from a per-building OneToOneField to a per-(building, activity) ForeignKey + unique constraint, with a backfill migration mapping existing rows by their building's building_type. This is required alongside the tick change: with a single per-building flag, the first tick to run today would mark the building "processed" and the second would silently skip - see .claude/plans/building-capabilities-plan.md's Edge Cases. Added a regression test (MultiCapabilityBuildingTests) covering exactly this: a communal building with both capabilities produces bread on the same day, which is only possible if both ticks ran.

economy_status now prints every conversion state on a building instead of assuming one. Step 3 of the plan.


Claude-Session: https://claude.ai/code/session_01LxvVvCwZw9HrxFcspgbmSK