### PR TITLE
Fix character activity schedule to respect the assigned work building…

### DIFF
--- a/character/services/behaviour_services.py
+++ b/character/services/behaviour_services.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from character.utils import window_for_date, work_activities_for
+from locations.services.schedule import work_hours_for
 from progression.models import ActivityDefinition, CharacterActivity
 
 _FIXED_KINDS = [
@@ -54,32 +55,39 @@ def generate_day(behaviour, date, replace_future=True):
     def jitter_minutes(base_dt, minutes):
         return base_dt + timedelta(minutes=rng.randint(-minutes, minutes))
 
-    sleep_start = aware(date, time(23, 0))
     wake = aware(date, time(7, 0))
     wake = jitter_minutes(wake, 15)
 
     morning_start = wake
     morning_end = morning_start + timedelta(hours=1)
 
-    work1_start = morning_end
-    work1_end = aware(date, time(12, 0))
+    # The work window comes from the character's actual assigned work
+    # building's hours (same source movement uses - see
+    # locations.services.schedule.target_role_for) rather than a fixed
+    # 8-17 assumption, so e.g. an inn open until 23:00 keeps its workers'
+    # scheduled activity as "working" that late instead of falling through
+    # to the fixed evening leisure block.
+    default_work_start, default_work_end = work_hours_for(behaviour.character)
+    work_start = max(morning_end, aware(date, default_work_start))
+    work_end = aware(date, default_work_end)
 
-    lunch_start = work1_end
-    lunch_start = jitter_minutes(lunch_start, 10)
+    lunch_midpoint = work_start + (work_end - work_start) / 2
+    lunch_start = jitter_minutes(lunch_midpoint, 10)
     lunch_end = lunch_start + timedelta(hours=1)
 
+    work1_start = work_start
+    work1_end = lunch_start
     work2_start = lunch_end
-    work2_end = aware(date, time(17, 0))
+    work2_end = work_end
 
-    dinner_start = aware(date, time(17, 30))
-    dinner_start = jitter_minutes(dinner_start, 10)
+    dinner_start = jitter_minutes(max(work_end, aware(date, time(17, 30))), 10)
     dinner_end = dinner_start + timedelta(hours=1)
 
     leisure_start = dinner_end
-    leisure_end = aware(date, time(22, 30))
+    leisure_end = max(leisure_start, aware(date, time(22, 30)))
 
     wind_start = leisure_end
-    wind_end = aware(date, time(23, 0))
+    wind_end = max(wind_start, aware(date, time(23, 0)))
 
     day_window(behaviour, date)
 
@@ -87,7 +95,7 @@ def generate_day(behaviour, date, replace_future=True):
     next_wake = aware(next_day, time(7, 0))
     next_wake = jitter_minutes(next_wake, 15)
 
-    sleep_start = aware(date, time(23, 0))
+    sleep_start = wind_end
     sleep_end = next_wake
 
     fixed = _fixed_activity_definitions()

--- a/character/tests/test_behaviour_services.py
+++ b/character/tests/test_behaviour_services.py
@@ -1,11 +1,13 @@
-from datetime import date
+from datetime import date, datetime, time
 
 from django.contrib.gis.geos import Point
 from django.test import TestCase
+from django.utils import timezone
 
-from character.models import Character
+from character.models import Character, CharacterLocation
 from character.services.behaviour_services import _FIXED_KINDS
 from character.utils import work_activities_for
+from locations.models import Building
 from progression.models import (
     ActivityDefinition,
     CharacterActivity,
@@ -128,6 +130,34 @@ class GenerateDayWorkActivityTests(TestCase):
         )
 
         self.assertEqual(first_ids, second_ids)
+
+    def test_late_building_hours_extend_the_work_block_past_the_default_workday(self):
+        # Inn hours run 06:00-23:00 (see Building.BUILDING_TYPE_HOURS) - well
+        # past generate_day's old fixed 17:00 work cutoff. An inn worker
+        # should still be scheduled as "working" in the evening instead of
+        # falling through to the fixed leisure block (issue: characters
+        # assigned to the inn showed as "Relaxing" during their shift).
+        inn = Building.objects.create(
+            name="The Tipsy Griffin",
+            building_type="inn",
+            location=Point(0, 0, srid=3857),
+        )
+        CharacterLocation.objects.create(
+            character=self.character,
+            location=inn,
+            role=CharacterLocation.Role.WORK,
+            is_primary=True,
+        )
+
+        self.character.behaviour.generate_day(date(2026, 1, 5))
+
+        evening = timezone.make_aware(datetime.combine(date(2026, 1, 5), time(21, 0)))
+        activity_at_evening = CharacterActivity.objects.get(
+            character=self.character,
+            scheduled_start__lte=evening,
+            scheduled_end__gt=evening,
+        )
+        self.assertEqual(activity_at_evening.activity_definition.kind, "work")
 
 
 class DeleteDayTests(TestCase):

--- a/locations/services/schedule.py
+++ b/locations/services/schedule.py
@@ -21,17 +21,16 @@ def _stagger_offset_seconds(character_id: int) -> int:
     return (character_id % span) - MAX_STAGGER_SECONDS
 
 
-def target_role_for(character, now=None) -> str:
-    """Which role (home/work) a character should currently be at.
-
-    The work window comes from the character's assigned work building's
-    open_time/close_time if set, else falls back to the fixed WORK_START/
-    WORK_END constants. A per-character stagger is applied to whichever
-    window is resolved, so the whole village doesn't flip in lockstep."""
+def work_hours_for(character) -> tuple[time, time]:
+    """The (open, close) window a character should be at work, from their
+    assigned work building's open_time/close_time if set, else the fixed
+    WORK_START/WORK_END constants. Shared by target_role_for (drives
+    physical movement) and behaviour_services.generate_day (drives the
+    scheduled CharacterActivity blocks), so a character's actual work
+    building's hours - e.g. an inn open until 23:00 - govern both rather
+    than generate_day assuming a fixed 8-17 workday that leaves late
+    building hours showing as an unrelated leisure/"Relaxing" block."""
     from character.models import CharacterLocation
-
-    now = now or timezone.localtime()
-    seconds_since_midnight = now.hour * 3600 + now.minute * 60 + now.second
 
     work_start, work_end = WORK_START, WORK_END
     work_location = (
@@ -45,6 +44,22 @@ def target_role_for(character, now=None) -> str:
         building = work_location.location
         if building.open_time is not None and building.close_time is not None:
             work_start, work_end = building.open_time, building.close_time
+    return work_start, work_end
+
+
+def target_role_for(character, now=None) -> str:
+    """Which role (home/work) a character should currently be at.
+
+    The work window comes from the character's assigned work building's
+    open_time/close_time if set, else falls back to the fixed WORK_START/
+    WORK_END constants. A per-character stagger is applied to whichever
+    window is resolved, so the whole village doesn't flip in lockstep."""
+    from character.models import CharacterLocation
+
+    now = now or timezone.localtime()
+    seconds_since_midnight = now.hour * 3600 + now.minute * 60 + now.second
+
+    work_start, work_end = work_hours_for(character)
 
     offset = _stagger_offset_seconds(character.id)
     work_start_seconds = work_start.hour * 3600 + work_start.minute * 60 + offset


### PR DESCRIPTION
…'s hours

generate_day hardcoded a fixed 8:00-17:00 work window regardless of the character's actual work building, while movement (target_role_for) already read the building's real open_time/close_time. For a late-closing building like the inn (06:00-23:00), this meant a worker was still physically at the inn well into the evening but their scheduled activity had already fallen through to the fixed leisure block, showing "Relaxing" instead of a work activity. Extracted the building-hours lookup into a shared work_hours_for helper and use it to size the work blocks (and push dinner/leisure/wind-down after work actually ends) in generate_day too.