### PR TITLE
feat: sync activity timer across a player's open sessions

### DIFF
--- a/frontend/src/context/WebSocketContext.tsx
+++ b/frontend/src/context/WebSocketContext.tsx
@@ -10,7 +10,7 @@ import { handleGlobalWebSocketEvent } from '../websockets/handleGlobalWebSocketE
 import { useMaintenanceStatus } from '../hooks/useMaintenanceStatus';
 import { useMaintenanceContext } from './MaintenanceContext';
 import { WebSocketContext } from './webSocketContext';
-import type { IncomingWebSocketMessage, OutgoingWebSocketMessage } from '../types';
+import type { ActivityTimerApiData, IncomingWebSocketMessage, OutgoingWebSocketMessage } from '../types';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -30,7 +30,7 @@ const HEARTBEAT_INTERVAL_MS = 60_000;
 // ---------------------------------------------------------------------------
 
 export const WebSocketProvider = ({ children }: ProviderProps): ReactElement => {
-  const { player } = useGame();
+  const { player, activityTimer, freeTimerLimitSeconds } = useGame();
   const { setOnlinePlayerCount } = useOnlineCount();
   const { isAuthenticated, loading: authLoading } = useAuth();
   const { showToast } = useToast();
@@ -40,14 +40,26 @@ export const WebSocketProvider = ({ children }: ProviderProps): ReactElement => 
   const eventHandlersRef = useRef<Set<(data: IncomingWebSocketMessage) => void>>(new Set());
   const wsEnabled = Boolean(!authLoading && isAuthenticated && player?.id);
 
+  const { loadFromServer } = activityTimer;
+  const onActivityTimerUpdate = useCallback((activityTimerData: ActivityTimerApiData) => {
+    // Reconciles this session's timer to the authoritative state pushed
+    // whenever another of the player's open sessions (tabs/devices) starts,
+    // labels, or submits the activity timer. loadFromServer just overwrites
+    // local state, so applying it to the session that originated the change
+    // (an echo of its own update) is harmless.
+    loadFromServer(activityTimerData, {
+      limitSeconds: player?.is_premium ? null : freeTimerLimitSeconds,
+    });
+  }, [loadFromServer, player?.is_premium, freeTimerLimitSeconds]);
+
   const onMessage = useCallback((data: IncomingWebSocketMessage) => {
     if (data.type === 'online_count') {
       setOnlinePlayerCount(data.count);
     }
     //console.log("[WS Provider] showToast:", showToast);
-    handleGlobalWebSocketEvent(data, { showToast, maintenanceRefetch, setMaintenance });
+    handleGlobalWebSocketEvent(data, { showToast, maintenanceRefetch, setMaintenance, onActivityTimerUpdate });
     eventHandlersRef.current.forEach((handler) => handler(data));
-  }, [showToast, maintenanceRefetch, setMaintenance, setOnlinePlayerCount]);
+  }, [showToast, maintenanceRefetch, setMaintenance, setOnlinePlayerCount, onActivityTimerUpdate]);
 
   const onError = useCallback(() => {
     console.error('WebSocket connection error');

--- a/frontend/src/types/timers.ts
+++ b/frontend/src/types/timers.ts
@@ -157,13 +157,19 @@ export interface WebSocketErrorMessage extends WebSocketMessageBase {
 /** Server-initiated action message (maintenance refresh, game events) */
 export interface WebSocketActionMessage {
   type: "action";
-  action: "refresh" | "load-game";
+  action: "refresh" | "load-game" | "activity_timer_update";
   message?: string;
   maintenance_active?: boolean;
   name?: string;
   description?: string;
   start_time?: string | null;
   end_time?: string | null;
+  /**
+   * Present when action is "activity_timer_update" — pushed whenever another
+   * of this player's sessions (tabs/devices) starts, labels, or submits the
+   * activity timer, so every open session can reconcile to server state.
+   */
+  data?: { activity_timer: ActivityTimerApiData };
 }
 
 /** Generic server message (currently unused payload) */

--- a/frontend/src/websockets/handleGlobalWebSocketEvent.ts
+++ b/frontend/src/websockets/handleGlobalWebSocketEvent.ts
@@ -1,16 +1,23 @@
 // websockets/handleGlobalWebSocketEvent.ts
-import type { IncomingWebSocketMessage } from '../types';
+import type { ActivityTimerApiData, IncomingWebSocketMessage } from '../types';
 import type { MaintenanceState } from '../context/MaintenanceContext';
 
 interface HandleGlobalWebSocketEventOptions {
   showToast?: (message: string) => void;
   maintenanceRefetch?: () => Promise<MaintenanceState>;
   setMaintenance?: (state: MaintenanceState) => void;
+  /**
+   * Called when the server pushes an authoritative activity-timer snapshot
+   * (another of this player's sessions started/labelled/submitted the
+   * timer) so the caller can reconcile local timer state, e.g. via
+   * useActivityTimer's loadFromServer.
+   */
+  onActivityTimerUpdate?: (activityTimer: ActivityTimerApiData) => void;
 }
 
 export async function handleGlobalWebSocketEvent(
   data: IncomingWebSocketMessage,
-  { showToast, maintenanceRefetch, setMaintenance }: HandleGlobalWebSocketEventOptions,
+  { showToast, maintenanceRefetch, setMaintenance, onActivityTimerUpdate }: HandleGlobalWebSocketEventOptions,
 ): Promise<void> {
   switch (data.type) {
     case 'notification':
@@ -65,6 +72,11 @@ export async function handleGlobalWebSocketEvent(
           break;
         case 'load-game':
           console.log("[WS] Django consumer 'load-game' message not currently in use.");
+          break;
+        case 'activity_timer_update':
+          if (data.data?.activity_timer) {
+            onActivityTimerUpdate?.(data.data.activity_timer);
+          }
           break;
         default:
           console.warn('[WS] Unknown action:', data);

--- a/gameplay/tasks.py
+++ b/gameplay/tasks.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from character.models import PlayerCharacterLink
 from .models import XpModifier
+from .utils import broadcast_activity_timer
 
 DISCONNECT_TASK_CACHE_KEY = "disconnect_task:{player_id}"
 
@@ -44,6 +45,7 @@ def auto_complete_timer_on_disconnect(self, player_id: int):
         return f"skipped:{timer.status}"
 
     timer.complete(completion_source="auto")
+    broadcast_activity_timer(timer)
     cache.delete(DISCONNECT_TASK_CACHE_KEY.format(player_id=player_id))
     return "completed"
 
@@ -72,6 +74,7 @@ def auto_complete_timers_for_stale_players():
     completed_count = 0
     for timer in stale_timers:
         timer.complete(completion_source="auto")
+        broadcast_activity_timer(timer)
         completed_count += 1
 
     return completed_count

--- a/gameplay/tests/test_disconnect_grace.py
+++ b/gameplay/tests/test_disconnect_grace.py
@@ -141,12 +141,18 @@ class AutoCompleteTimerTaskTests(TransactionTestCase):
 
         with patch.object(
             ActivityTimer, "complete", return_value={"xp_gained": 50}
-        ) as mock_complete:
+        ) as mock_complete, patch(
+            "gameplay.tasks.broadcast_activity_timer"
+        ) as mock_broadcast:
             result = _run_task(self.player.id, self.TASK_ID)
 
         self.assertEqual(result, "completed")
         mock_complete.assert_called_once_with(completion_source="auto")
         self.assertIsNone(cache.get(self._cache_key()))
+        # Any other open session (tabs/devices) for this player should be
+        # told the timer was auto-completed, so it stops ticking a timer
+        # the server has already closed out.
+        mock_broadcast.assert_called_once_with(self.timer)
 
 
 # ── consumer disconnect tests ──────────────────────────────────────────────────

--- a/gameplay/tests/test_stale_connection_sweep.py
+++ b/gameplay/tests/test_stale_connection_sweep.py
@@ -60,11 +60,16 @@ class AutoCompleteStaleTimersTaskTests(TestCase):
             timezone.now() - (STALE_TIMER_THRESHOLD + timedelta(seconds=1))
         )
 
-        with patch.object(ActivityTimer, "complete") as mock_complete:
+        with patch.object(ActivityTimer, "complete") as mock_complete, patch(
+            "gameplay.tasks.broadcast_activity_timer"
+        ) as mock_broadcast:
             result = auto_complete_timers_for_stale_players()
 
         mock_complete.assert_called_once_with(completion_source="auto")
         self.assertEqual(result, 1)
+        # Any other open session (tabs/devices) for this player should be
+        # told the timer was auto-completed by this sweep.
+        mock_broadcast.assert_called_once_with(self.timer)
 
     def test_completes_timer_when_last_seen_was_never_set(self):
         self._make_active(None)

--- a/gameplay/tests/test_views.py
+++ b/gameplay/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
@@ -94,3 +96,62 @@ class LabelActivityViewTests(APITestCase):
         response = self.client.post(self.url, {"activityName": "Nope"})
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class ActivityTimerBroadcastTests(APITestCase):
+    """
+    Every mutating activity-timer endpoint should push the updated timer to
+    the player's other open sessions (tabs/devices) over the `player_{id}`
+    WebSocket group, so they can reconcile via loadFromServer instead of
+    drifting until their next manual fetch. See issue #759.
+    """
+
+    def setUp(self):
+        self.user = user_factory(with_player=True)
+        self.player = self.user.player
+        self.client.force_authenticate(user=self.user)
+
+    def test_set_activity_broadcasts_timer_update(self):
+        with patch("gameplay.views.broadcast_activity_timer") as mock_broadcast:
+            response = self.client.post(
+                reverse("activitytimer-set-activity"), {"activityName": "Focus time"}
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_broadcast.assert_called_once_with(self.player.activity_timer)
+
+    def test_start_broadcasts_timer_update(self):
+        self.player.activity_timer.new_activity(name="Focus time")
+
+        with patch("gameplay.views.broadcast_activity_timer") as mock_broadcast:
+            response = self.client.post(reverse("activitytimer-start"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_broadcast.assert_called_once_with(self.player.activity_timer)
+
+    def test_label_activity_broadcasts_timer_update(self):
+        timer = self.player.activity_timer
+        timer.new_activity(name="Focus time")
+        timer.start()
+
+        with patch("gameplay.views.broadcast_activity_timer") as mock_broadcast:
+            response = self.client.post(
+                reverse("activitytimer-label-activity"), {"activityName": "Deep work"}
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_broadcast.assert_called_once_with(timer)
+
+    def test_complete_broadcasts_timer_update(self):
+        timer = self.player.activity_timer
+        timer.new_activity(name="Focus time")
+        timer.start()
+
+        with patch("gameplay.views.broadcast_activity_timer") as mock_broadcast:
+            response = self.client.post(
+                reverse("activitytimer-complete"),
+                {"activityName": "Focus time", "elapsedSeconds": 30},
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_broadcast.assert_called_once_with(timer)

--- a/gameplay/utils.py
+++ b/gameplay/utils.py
@@ -204,6 +204,26 @@ def process_completion(player: Player, character: Character, action: str) -> boo
         return True
 
 
+def broadcast_activity_timer(timer: ActivityTimer) -> None:
+    """
+    Push `timer`'s current state to every other open session (tabs, devices)
+    this player has connected, so they can reconcile via useActivityTimer's
+    loadFromServer instead of drifting until their next manual fetch.
+    Reuses the per-player `player_{id}` group that TimerConsumer already
+    joins on connect. Safe to call from sync contexts (views, Celery tasks).
+    """
+    from .serializers import ActivityTimerSerializer
+
+    async_to_sync(send_group_message)(
+        f"player_{timer.player_id}",
+        {
+            "type": "action",
+            "action": "activity_timer_update",
+            "data": {"activity_timer": ActivityTimerSerializer(timer).data},
+        },
+    )
+
+
 async def send_group_message(group_name: str, message: dict) -> bool:
     logger.info(
         f"[SEND GROUP MESSAGE] Sending message to group {group_name}. Message: {message}"

--- a/gameplay/views.py
+++ b/gameplay/views.py
@@ -8,6 +8,7 @@ from rest_framework.serializers import BaseSerializer
 import logging
 
 from .serializers import ActivityTimerSerializer
+from .utils import broadcast_activity_timer
 
 from progression.models import Task
 
@@ -34,22 +35,28 @@ class BaseTimerViewSet(viewsets.ViewSet):
         assert self.serializer_class is not None
         return self.serializer_class(timer).data
 
+    def broadcast_timer_update(self, timer):
+        broadcast_activity_timer(timer)
+
     @action(detail=False, methods=["post"])
     def start(self, request):
         timer = self.get_timer(request)
         timer.start()
+        self.broadcast_timer_update(timer)
         return Response(self.serialize(timer))
 
     @action(detail=False, methods=["post"])
     def pause(self, request):
         timer = self.get_timer(request)
         timer.pause()
+        self.broadcast_timer_update(timer)
         return Response(self.serialize(timer))
 
     @action(detail=False, methods=["post"])
     def reset(self, request):
         timer = self.get_timer(request)
         timer.reset()
+        self.broadcast_timer_update(timer)
         return Response(self.serialize(timer))
 
     @action(detail=False, methods=["post"])
@@ -58,6 +65,7 @@ class BaseTimerViewSet(viewsets.ViewSet):
         name = request.data.get("activityName")
 
         timer.complete(newName=name)
+        self.broadcast_timer_update(timer)
         return Response(self.serialize(timer))
 
 
@@ -90,6 +98,7 @@ class ActivityTimerViewSet(BaseTimerViewSet):
             client_elapsed_seconds=client_elapsed_seconds,
             completion_source=completion_source,
         )
+        self.broadcast_timer_update(timer)
 
         return Response({"activity_timer": self.serialize(timer), **completion})
 
@@ -108,6 +117,7 @@ class ActivityTimerViewSet(BaseTimerViewSet):
 
         updated = timer.new_activity(name=name, task=task)
         updated.refresh_from_db()
+        self.broadcast_timer_update(updated)
         return Response({"success": True, "activity_timer": self.serialize(updated)})
 
     @action(detail=False, methods=["post"])
@@ -135,5 +145,6 @@ class ActivityTimerViewSet(BaseTimerViewSet):
             timer.change_task(task)
 
         timer.rename_activity(name)
+        self.broadcast_timer_update(timer)
 
         return Response({"success": True, "activity_timer": self.serialize(timer)})


### PR DESCRIPTION
## Summary
Fixes #759. If a player has more than one session open (two browser tabs, or a phone + a laptop), starting, labelling, or submitting an activity in one session had no effect on the others — each session's `useActivityTimer` state was purely local, seeded once from the server and never invalidated by another session's writes.

## Changes

**Backend**
- Add `gameplay.utils.broadcast_activity_timer(timer)`, reusing the existing per-player `player_{id}` channel group and the `send_group_message`/`{"type": "action"}` pattern already used by `gameplay/signals.py` and `utils.control_timers`.
- Call it after every timer mutation: `start`/`pause`/`reset`/`complete` in `BaseTimerViewSet`, and `set_activity`/`label_activity`/`complete` in `ActivityTimerViewSet`.
- Also call it from both auto-complete paths in `gameplay/tasks.py` (the 30s disconnect grace period, and the stale-connection sweep) — these complete a timer server-side without any originating request, so a tab left open elsewhere needs telling too.
- No `TimerConsumer` changes needed: its existing generic `action` handler already relays any `{"type": "action", ...}` group message straight to the socket.

**Frontend**
- Extend `WebSocketActionMessage` with the new `"activity_timer_update"` action and its `data.activity_timer` payload.
- Wire the previously-stubbed `handleGlobalWebSocketEvent` dispatcher with an `onActivityTimerUpdate` option (the `load-game` stub is left as-is for future use).
- `WebSocketContext` calls `activityTimer.loadFromServer` on receipt, mirroring `GameContext`'s existing bootstrap load (same `limitSeconds`/`is_premium` resolution). `loadFromServer` just overwrites local state, so a session echoing its own update back to itself is a harmless no-op.

## Testing
- Added/updated backend tests asserting `broadcast_activity_timer` is called from `start`/`complete`/`set_activity`/`label_activity` and from both Celery auto-complete tasks.
- User confirmed the full test suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)