### PR TITLE
fix: keep parent-task field editable and render subtasks as indented rows

### DIFF
--- a/frontend/src/components/PlayerItemList/PlayerItemList.module.scss
+++ b/frontend/src/components/PlayerItemList/PlayerItemList.module.scss
@@ -156,19 +156,12 @@
   }
 }
 
-.childList {
-  list-style: none;
-  margin: sp.$spacing-xs 0 0;
-  padding: 0 0 0 sp.$spacing-lg;
-  display: flex;
-  flex-direction: column;
-  gap: sp.$spacing-xs;
-}
-
 .childItem {
-  background: transparent;
-  border-color: rgba(c.$color-border-primary, 0.12);
-  opacity: 0.9;
+  // Shrink width by the indent instead of just shifting it, so the right
+  // edge still lines up with the parent's — .listItem's width: 100% would
+  // otherwise push the box that far past the parent's right edge.
+  width: calc(100% - #{sp.$spacing-lg});
+  margin-left: sp.$spacing-lg;
 }
 
 .itemCompleted {

--- a/frontend/src/components/PlayerItemList/PlayerItemList.test.tsx
+++ b/frontend/src/components/PlayerItemList/PlayerItemList.test.tsx
@@ -154,7 +154,7 @@ describe("PlayerItemList", () => {
     const child = { id: 11, name: "Child task" };
     const flatItems = [parent, child];
 
-    it("renders children nested under their parent without a top-level row", () => {
+    it("renders children as independent rows, indented, directly after their parent", () => {
       render(
         <PlayerItemList
           items={flatItems}
@@ -165,8 +165,15 @@ describe("PlayerItemList", () => {
 
       expect(screen.getByRole("button", { name: "Open task Parent task" })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Open task Child task" })).toBeInTheDocument();
-      // The child is not rendered as its own top-level list item.
+      // The child is not duplicated as a second top-level entry sourced from `items`.
       expect(screen.getAllByRole("button", { name: /^Open task / })).toHaveLength(2);
+
+      // Both render as siblings within the list, not one nested inside the other.
+      const rows = screen.getAllByRole("listitem");
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toHaveTextContent("Parent task");
+      expect(rows[1]).toHaveTextContent("Child task");
+      expect(within(rows[0]).queryByText("Child task")).not.toBeInTheDocument();
     });
 
     it("is unaffected when getChildren is not passed (ProjectsPanel-style usage)", () => {

--- a/frontend/src/components/PlayerItemList/PlayerItemList.tsx
+++ b/frontend/src/components/PlayerItemList/PlayerItemList.tsx
@@ -3,7 +3,6 @@ import classNames from "classnames";
 
 import Button from "../Button/Button";
 import List from "../List/List";
-import Li from "../List/Li";
 import Modal from "../Modal/Modal";
 import { usePlayerItemListControls } from "./usePlayerItemListControls";
 import { usePlayerItemModal } from "./usePlayerItemModal";
@@ -137,11 +136,15 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
     return ids;
   }, [items, getChildren]);
 
-  const topLevelDisplayItems = useMemo(() => {
+  // Sort/filter controls only apply to top-level items; a child keeps its
+  // place directly after its parent (in `getChildren`'s order) rather than
+  // being reordered independently.
+  const flatDisplayItems = useMemo(() => {
     if (!getChildren) return displayItems;
-    return displayItems.filter(
+    const topLevel = displayItems.filter(
       (item) => item.id === undefined || !childIds.has(item.id)
     );
+    return topLevel.flatMap((item) => [item, ...(getChildren(item) ?? [])]);
   }, [displayItems, getChildren, childIds]);
 
   const renderRow = (item: T): React.ReactNode => (
@@ -252,7 +255,7 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
       ) : null}
       <div className={styles.listScroll}>
       <List
-        items={topLevelDisplayItems}
+        items={flatDisplayItems}
         ariaLabel={ariaLabel}
         canHover
         className={classNames(styles.list, listClassName)}
@@ -260,31 +263,11 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
         getKey={getItemKey}
         getItemClassName={(item) =>
           classNames(styles.item, {
+            [styles.childItem]: item.id !== undefined && childIds.has(item.id),
             [styles.itemCompleted]: isItemComplete?.(item),
           })
         }
-        renderItem={(item) => {
-          const children = getChildren?.(item);
-          return (
-            <>
-              {renderRow(item)}
-              {children?.length ? (
-                <ul className={styles.childList}>
-                  {children.map((child, index) => (
-                    <Li
-                      key={(child.id as string | number | undefined) ?? index}
-                      className={classNames(styles.item, styles.childItem, {
-                        [styles.itemCompleted]: isItemComplete?.(child),
-                      })}
-                    >
-                      {renderRow(child)}
-                    </Li>
-                  ))}
-                </ul>
-              ) : null}
-            </>
-          );
-        }}
+        renderItem={(item) => renderRow(item)}
       />
       </div>
 

--- a/frontend/src/components/TasksPanel/TasksPanel.test.tsx
+++ b/frontend/src/components/TasksPanel/TasksPanel.test.tsx
@@ -325,7 +325,7 @@ describe("TasksPanel", () => {
       total_records: 0,
     };
 
-    it("renders a subtask nested under its parent", () => {
+    it("renders a subtask as an independent, indented row directly after its parent", () => {
       mockUseTasks.mockReturnValue({
         isLoading: false,
         data: [parentTask, childTask],
@@ -336,9 +336,14 @@ describe("TasksPanel", () => {
       const childButton = screen.getAllByRole("button", { name: "Edit task Child subtask" })[0];
       expect(parentButton).toBeInTheDocument();
       expect(childButton).toBeInTheDocument();
-      // The subtask is nested inside the parent's <li>, not a sibling top-level row.
+      // The subtask is its own sibling row, not nested inside the parent's <li>.
       const parentListItem = parentButton.closest("li");
-      expect(parentListItem).toContainElement(childButton);
+      const childListItem = childButton.closest("li");
+      expect(parentListItem).not.toBe(childListItem);
+      expect(parentListItem).not.toContainElement(childButton);
+
+      const rows = screen.getAllByRole("listitem");
+      expect(rows.indexOf(childListItem!)).toBe(rows.indexOf(parentListItem!) + 1);
     });
 
     it("hides a completed parent and its subtasks together", () => {

--- a/frontend/src/components/TasksPanel/TasksPanel.tsx
+++ b/frontend/src/components/TasksPanel/TasksPanel.tsx
@@ -180,40 +180,38 @@ export default function TasksPanel({
                     </Button>
                   )}
                 </div>
-                {taskItem.parent == null && (
-                  <div className={styles.parentRow}>
-                    <label className={styles.timestampLabel} htmlFor="task-parent">
-                      Parent task
-                    </label>
-                    <Tooltip
-                      content={
-                        hasSubtasks
-                          ? "This task already has subtasks and can't be nested under another task."
-                          : undefined
+                <div className={styles.parentRow}>
+                  <label className={styles.timestampLabel} htmlFor="task-parent">
+                    Parent task
+                  </label>
+                  <Tooltip
+                    content={
+                      hasSubtasks
+                        ? "This task already has subtasks and can't be nested under another task."
+                        : undefined
+                    }
+                  >
+                    <select
+                      id="task-parent"
+                      className={styles.parentSelect}
+                      disabled={hasSubtasks}
+                      defaultValue={taskItem.parent ?? ""}
+                      onChange={(event) =>
+                        updateTask.mutate({
+                          id: taskItem.id,
+                          data: { parent: event.target.value ? Number(event.target.value) : null },
+                        })
                       }
                     >
-                      <select
-                        id="task-parent"
-                        className={styles.parentSelect}
-                        disabled={hasSubtasks}
-                        defaultValue={taskItem.parent ?? ""}
-                        onChange={(event) =>
-                          updateTask.mutate({
-                            id: taskItem.id,
-                            data: { parent: event.target.value ? Number(event.target.value) : null },
-                          })
-                        }
-                      >
-                        <option value="">No parent</option>
-                        {parentOptions.map((option) => (
-                          <option key={option.id} value={option.id}>
-                            {option.name}
-                          </option>
-                        ))}
-                      </select>
-                    </Tooltip>
-                  </div>
-                )}
+                      <option value="">No parent</option>
+                      {parentOptions.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.name}
+                        </option>
+                      ))}
+                    </select>
+                  </Tooltip>
+                </div>
               </>
             );
           }}

--- a/gameplay/tasks.py
+++ b/gameplay/tasks.py
@@ -7,7 +7,6 @@ from django.utils import timezone
 
 from character.models import PlayerCharacterLink
 from .models import XpModifier
-from .utils import broadcast_activity_timer
 
 DISCONNECT_TASK_CACHE_KEY = "disconnect_task:{player_id}"
 
@@ -28,6 +27,7 @@ def auto_complete_timer_on_disconnect(self, player_id: int):
     Revoked by TimerConsumer.connect() if the player reconnects in time.
     """
     from .models import ActivityTimer
+    from .utils import broadcast_activity_timer
 
     stored_task_id = cache.get(DISCONNECT_TASK_CACHE_KEY.format(player_id=player_id))
     if stored_task_id != self.request.id:
@@ -63,6 +63,7 @@ def auto_complete_timers_for_stale_players():
     completes them the same way the disconnect grace period does.
     """
     from .models import ActivityTimer
+    from .utils import broadcast_activity_timer
 
     cutoff = timezone.now() - STALE_TIMER_THRESHOLD
     stale_timers = (


### PR DESCRIPTION
## Summary
Fixes #765.

- **Bug 1** — `TasksPanel`: the "Parent task" select disappeared entirely once a task had a parent, with no way to revert it or pick a different parent. It now always renders (still disabled, with an explanatory tooltip, when the task itself has subtasks — matching the existing nesting guard).
- **Bug 2** — `PlayerItemList`: child tasks rendered nested inside the parent's own `<li>` (structurally and visually boxed inside it). They now render as independent rows — siblings of other top-level items in display order — indented via a width/margin modifier so the right edge still lines up with the parent's. `getChildren` is used only by `TasksPanel`, so no other panel (Skills/Projects/Categories/Activities) is affected.
- **Bonus fix** — `gameplay/tasks.py`: a circular import (`gameplay.utils` → `gameplay.services.xp_modifiers` → `gameplay.tasks` → back to `gameplay.utils`) was crashing `web`/`celery` on startup with `ImportError: cannot import name 'broadcast_activity_timer'`. Fixed by deferring that import into the two functions that use it.

## Testing
- `npx vitest run` — 540 tests pass (updated `PlayerItemList.test.tsx` / `TasksPanel.test.tsx` assertions to match the new sibling-row DOM structure instead of nested-`<li>`).
- `npm run lint` — clean.
- `npx tsc --noEmit` — clean.
- Manually verified in a running app: parent field stays editable/revertible, subtask renders as its own indented row with matching width and styling to the parent, and `web`/`celery` start cleanly after the import fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)