### PR TITLE
Extend formatDueAt with weeks/months granularity

### DIFF
--- a/frontend/src/utils/formatUtils.test.ts
+++ b/frontend/src/utils/formatUtils.test.ts
@@ -31,16 +31,16 @@ describe("formatDueAt", () => {
     expect(formatDueAt(null)).toBe("-");
   });
 
-  it("labels the current day as Today", () => {
-    expect(formatDueAt(atLocalMidnight(0))).toBe("Today");
+  it("labels the current day as today", () => {
+    expect(formatDueAt(atLocalMidnight(0))).toBe("today");
   });
 
-  it("labels the next day as Tomorrow", () => {
-    expect(formatDueAt(atLocalMidnight(1))).toBe("Tomorrow");
+  it("labels the next day as tomorrow", () => {
+    expect(formatDueAt(atLocalMidnight(1))).toBe("tomorrow");
   });
 
-  it("labels the previous day as Yesterday", () => {
-    expect(formatDueAt(atLocalMidnight(-1))).toBe("Yesterday");
+  it("labels the previous day as yesterday", () => {
+    expect(formatDueAt(atLocalMidnight(-1))).toBe("yesterday");
   });
 
   it("labels a few days out as 'in N days'", () => {
@@ -51,13 +51,37 @@ describe("formatDueAt", () => {
     expect(formatDueAt(atLocalMidnight(-3))).toBe("3 days ago");
   });
 
-  it("labels a further-back date in weeks", () => {
+  it("labels a further-back date in whole weeks", () => {
     expect(formatDueAt(atLocalMidnight(-14))).toBe("2 weeks ago");
   });
 
-  it("labels a further-out date as an absolute weekday/day/month", () => {
-    // 9 days out from Wed 15 Jul 2026 is Fri 24 Jul 2026.
-    expect(formatDueAt(atLocalMidnight(9))).toBe("Fri 24th Jul");
+  it("labels a further-out date in weeks, with a leftover-days remainder", () => {
+    expect(formatDueAt(atLocalMidnight(9))).toBe("in 1 week, 2 days");
+  });
+
+  it("labels a further-out whole-week date without a days remainder", () => {
+    expect(formatDueAt(atLocalMidnight(14))).toBe("in 2 weeks");
+  });
+
+  it("labels a further-back date in weeks, with a leftover-days remainder", () => {
+    expect(formatDueAt(atLocalMidnight(-20))).toBe("2 weeks, 6 days ago");
+  });
+
+  it("labels a date beyond the week cutoff in months (future)", () => {
+    expect(formatDueAt(atLocalMidnight(60))).toBe("in 2 months");
+  });
+
+  it("labels a date beyond the week cutoff in months (past)", () => {
+    expect(formatDueAt(atLocalMidnight(-60))).toBe("2 months ago");
+  });
+
+  it("keeps counting months uncapped on the past side", () => {
+    expect(formatDueAt(atLocalMidnight(-200))).toBe("7 months ago");
+  });
+
+  it("falls back to an absolute date beyond the month cap (future)", () => {
+    // 200 days out from Wed 15 Jul 2026 is Sun 31 Jan 2027.
+    expect(formatDueAt(atLocalMidnight(200))).toBe("Sun 31st Jan");
   });
 });
 

--- a/frontend/src/utils/formatUtils.ts
+++ b/frontend/src/utils/formatUtils.ts
@@ -75,6 +75,21 @@ function startOfDay(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
+const WEEK_CUTOFF_DAYS = 56; // 8 weeks: weeks[, days] granularity applies up to this many days out/back
+const MONTH_CUTOFF_DAYS = 180; // 6 months: beyond this on the future side, fall back to an absolute date
+
+function formatWeeksAndDays(totalDays: number): string {
+  const weeks = Math.floor(totalDays / 7);
+  const days = totalDays % 7;
+  const weeksPart = `${weeks} ${pluralize(weeks, "week")}`;
+  return days > 0 ? `${weeksPart}, ${days} ${pluralize(days, "day")}` : weeksPart;
+}
+
+function formatMonths(totalDays: number): string {
+  const months = Math.max(1, Math.round(totalDays / 30));
+  return `${months} ${pluralize(months, "month")}`;
+}
+
 export function formatDueAt(dueAt: string | null): string {
   if (!dueAt) return "-";
   const date = new Date(dueAt);
@@ -84,19 +99,23 @@ export function formatDueAt(dueAt: string | null): string {
     (startOfDay(date).getTime() - startOfDay(new Date()).getTime()) / (24 * 60 * 60 * 1000)
   );
 
-  if (diffDays === 0) return "Today";
-  if (diffDays === 1) return "Tomorrow";
-  if (diffDays === -1) return "Yesterday";
+  if (diffDays === 0) return "today";
+  if (diffDays === 1) return "tomorrow";
+  if (diffDays === -1) return "yesterday";
 
   if (diffDays > 1 && diffDays <= 6) return `in ${diffDays} days`;
   if (diffDays < -1 && diffDays >= -6) return `${-diffDays} days ago`;
 
-  if (diffDays < -6) {
-    const weeks = Math.round(-diffDays / 7);
-    return `${weeks} week${weeks === 1 ? "" : "s"} ago`;
+  if (diffDays > 6 && diffDays <= WEEK_CUTOFF_DAYS) return `in ${formatWeeksAndDays(diffDays)}`;
+  if (diffDays < -6 && diffDays >= -WEEK_CUTOFF_DAYS) return `${formatWeeksAndDays(-diffDays)} ago`;
+
+  if (diffDays < -WEEK_CUTOFF_DAYS) return `${formatMonths(-diffDays)} ago`;
+
+  if (diffDays > WEEK_CUTOFF_DAYS && diffDays <= MONTH_CUTOFF_DAYS) {
+    return `in ${formatMonths(diffDays)}`;
   }
 
-  // diffDays > 6: further out than a week, show an absolute date.
+  // diffDays > MONTH_CUTOFF_DAYS: further out than ~6 months, show an absolute date.
   const weekday = date.toLocaleDateString(undefined, { weekday: "short" });
   const month = date.toLocaleDateString(undefined, { month: "short" });
   const day = date.getDate();


### PR DESCRIPTION
## Summary
- Extends `formatDueAt` (`frontend/src/utils/formatUtils.ts`) so due-date granularity scales smoothly on both sides of "now": days (2-6) → weeks[, leftover days] → months, mirroring the pattern already used by "last worked on" (`useTasksPanel.tsx`).
- Past dates: `N days ago` → `N weeks[, M days] ago` (up to 8 weeks) → `N months ago` (uncapped).
- Future dates: `in N days` → `in N weeks[, M days]` (up to 8 weeks) → `in N months` (up to ~6 months) → absolute date fallback beyond that.

**Cutover points (flagging per the issue's request):** weeks/months flip at 8 weeks (56 days) on both sides; the future-side absolute-date fallback kicks in beyond 6 months (180 days). These are implementation calls, not specified in the issue.

## Test plan
- [x] `npx vitest run src/utils/formatUtils.test.ts` — 23 tests pass, including new coverage for weeks-with-remainder, whole weeks, months on both sides, uncapped past months, and the future absolute-date fallback beyond the month cap.
- [x] `npx eslint` and `npx tsc --noEmit` clean on changed files.

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)