### PR TITLE
feat: add offline activity logging modal

### DIFF
--- a/frontend/src/api/activities.ts
+++ b/frontend/src/api/activities.ts
@@ -1,6 +1,17 @@
 // src/api/activities.ts
 import type { PlayerActivity } from "../types";
+import type { OfflineActivityLogResponse } from "../types/api";
 import { apiFetch } from "../utils/api";
+
+export interface OfflineActivityLogPayload {
+  /** Name for a newly-created task; ignored (and optional) when `task` is set. */
+  name?: string;
+  description?: string;
+  skill?: number;
+  task?: number;
+  started_at: string;
+  completed_at: string;
+}
 
 export function fetchActivities(): Promise<PlayerActivity[]> {
   return (async () => {
@@ -43,5 +54,14 @@ export function updateActivity(id: number, data: Partial<PlayerActivity>): Promi
 export function deleteActivity(id: number): Promise<void> {
   return apiFetch<void>(`/player-activities/${id}/`, {
     method: "DELETE",
+  });
+}
+
+export function logOfflineActivity(
+  data: OfflineActivityLogPayload
+): Promise<OfflineActivityLogResponse> {
+  return apiFetch<OfflineActivityLogResponse>("/player-activities/log_offline/", {
+    method: "POST",
+    body: JSON.stringify(data),
   });
 }

--- a/frontend/src/components/ActivitiesPanel/ActivitiesPanel.module.scss
+++ b/frontend/src/components/ActivitiesPanel/ActivitiesPanel.module.scss
@@ -14,13 +14,37 @@
   flex-direction: column;
 }
 
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: sp.$spacing-sm;
+  margin-bottom: sp.$spacing-md;
+  width: 100%;
+}
+
 .dateTabs {
   display: flex;
   gap: sp.$spacing-sm;
-  margin-bottom: sp.$spacing-md;
   flex-wrap: wrap;
   justify-content: center;
-  width: 100%;
+  flex: 1;
+}
+
+.addOfflineButton {
+  @include c.apply-button-variant(primary);
+  flex-shrink: 0;
+  border: none;
+  border-radius: 50%;
+  width: 2.25rem;
+  height: 2.25rem;
+  min-width: 2.25rem;
+  padding: 0;
+  font-size: 1.25rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
 }
 
 .dateButton {

--- a/frontend/src/components/ActivitiesPanel/ActivitiesPanel.test.tsx
+++ b/frontend/src/components/ActivitiesPanel/ActivitiesPanel.test.tsx
@@ -2,7 +2,16 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { TooltipProvider } from "../Tooltip/Tooltip";
 import ActivitiesPanel from "./ActivitiesPanel";
+
+function renderActivitiesPanel() {
+  return render(
+    <TooltipProvider>
+      <ActivitiesPanel />
+    </TooltipProvider>
+  );
+}
 
 const mockUseActivities = vi.fn();
 const mockUseDeleteActivity = vi.fn();
@@ -39,7 +48,7 @@ describe("ActivitiesPanel", () => {
 
   it("renders activities and delegates edit through PlayerItemList", async () => {
     const user = userEvent.setup();
-    render(<ActivitiesPanel />);
+    renderActivitiesPanel();
 
     expect(screen.getByText("Write docs")).toBeInTheDocument();
 
@@ -59,7 +68,7 @@ describe("ActivitiesPanel", () => {
 
   it("delegates delete confirmation through PlayerItemList", async () => {
     const user = userEvent.setup();
-    render(<ActivitiesPanel />);
+    renderActivitiesPanel();
 
     await user.click(screen.getByRole("button", { name: "Open activity Write docs" }));
     await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Delete" }));

--- a/frontend/src/components/ActivitiesPanel/ActivitiesPanel.tsx
+++ b/frontend/src/components/ActivitiesPanel/ActivitiesPanel.tsx
@@ -6,6 +6,8 @@ import { formatDurationShort, pluralize } from "../../utils/formatUtils";
 
 import Button from "../Button/Button";
 import PlayerItemList from "../PlayerItemList/PlayerItemList";
+import Tooltip from "../Tooltip/Tooltip";
+import LogOfflineActivityModal from "../LogOfflineActivityModal/LogOfflineActivityModal";
 import styles from "./ActivitiesPanel.module.scss";
 
 type DateCategory = "today" | "yesterday" | "older";
@@ -68,6 +70,7 @@ export default function ActivitiesPanel(): React.ReactElement | null {
   const deleteActivity = useDeleteActivity();
   const updateActivity = useUpdateActivity();
   const [activeTab, setActiveTab] = useState<DateCategory>("today");
+  const [isLogModalOpen, setIsLogModalOpen] = useState(false);
 
   const bucketed = useMemo(() => bucketActivities(activities ?? []), [activities]);
 
@@ -127,8 +130,8 @@ export default function ActivitiesPanel(): React.ReactElement | null {
   return (
     <div className={styles.page}>
       <div className={styles.content}>
-      {hasActivities && (
-        <>
+      <div className={styles.toolbar}>
+        {hasActivities && (
           <div className={styles.dateTabs}>
             {dateTabs.map(({ key, label }) => (
               <Button
@@ -141,7 +144,25 @@ export default function ActivitiesPanel(): React.ReactElement | null {
               </Button>
             ))}
           </div>
+        )}
+        <Tooltip content="Add offline activity">
+          <button
+            type="button"
+            className={styles.addOfflineButton}
+            aria-label="Add offline activity"
+            onClick={() => setIsLogModalOpen(true)}
+          >
+            +
+          </button>
+        </Tooltip>
+      </div>
 
+      {isLogModalOpen && (
+        <LogOfflineActivityModal onClose={() => setIsLogModalOpen(false)} />
+      )}
+
+      {hasActivities && (
+        <>
           {hasTabActivities ? (
             <div className={styles.activitiesList}>
               {Object.entries(activitiesByDay).map(([dateKey, dayActivities]) => {

--- a/frontend/src/components/BuildingDetail/BuildingDetail.test.tsx
+++ b/frontend/src/components/BuildingDetail/BuildingDetail.test.tsx
@@ -56,7 +56,7 @@ describe('BuildingDetail', () => {
     expect(screen.queryByText(/Wheat/)).not.toBeInTheDocument();
   });
 
-  it('shows each resident, with "walking" overriding their scheduled activity', () => {
+  it('shows each resident by name only', () => {
     render(
       <BuildingDetail
         buildingType="residential"
@@ -67,8 +67,8 @@ describe('BuildingDetail', () => {
       />
     );
 
-    expect(screen.getByText('Alice — idle')).toBeInTheDocument();
-    expect(screen.getByText('Bob — walking')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
   });
 
   it('calls onSelectResident when a resident row is clicked', async () => {

--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -23,6 +23,7 @@ function EyeOffIcon() {
 interface InputProps {
   id: string;
   label?: string;
+  ariaLabel?: string;
   type?: string;
   value?: string;
   onChange?: (value: string | boolean) => void;
@@ -34,6 +35,8 @@ interface InputProps {
   checked?: boolean;
   minLength?: number;
   maxLength?: number;
+  min?: string | number;
+  max?: string | number;
   className?: string;
   inputClassName?: string;
   disabled?: boolean;
@@ -44,6 +47,7 @@ interface InputProps {
 export default function Input({
   id,
   label,
+  ariaLabel,
   type = 'text',
   value,
   onChange,
@@ -55,6 +59,8 @@ export default function Input({
   checked,
   minLength,
   maxLength,
+  min,
+  max,
   className,
   inputClassName,
   disabled = false,
@@ -91,13 +97,15 @@ export default function Input({
       onBlur={onBlur}
       onKeyDown={onKeyDown}
       placeholder={placeholder}
+      aria-label={!label ? ariaLabel : undefined}
       aria-invalid={!!error}
       aria-describedby={describedBy}
       aria-required={required}
       autoComplete={autoComplete}
-      required={required}
       minLength={minLength}
       maxLength={maxLength}
+      min={min}
+      max={max}
       disabled={disabled}
     />
   );

--- a/frontend/src/components/LogOfflineActivityModal/LogOfflineActivityModal.module.scss
+++ b/frontend/src/components/LogOfflineActivityModal/LogOfflineActivityModal.module.scss
@@ -1,0 +1,126 @@
+@use '../../styles/semantic/spacing' as sp;
+@use '../../styles/semantic/typography' as t;
+@use '../../styles/semantic/colors' as c;
+@use '../../styles/utilities/mixins' as m;
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-md;
+  width: 100%;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-xs;
+}
+
+.label {
+  @include t.apply-text-style(t.$text-body);
+  font-weight: 600;
+}
+
+.required {
+  color: c.$color-error;
+}
+
+.row {
+  display: flex;
+  gap: sp.$spacing-sm;
+  width: 100%;
+
+  > * {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+.durationPartField {
+  flex: 0 0 auto;
+  width: 4.5rem;
+  max-width: 4.5rem;
+
+  input[type='number'] {
+    appearance: textfield;
+    -moz-appearance: textfield;
+
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      appearance: none;
+      -webkit-appearance: none;
+      margin: 0;
+    }
+  }
+}
+
+.taskInput {
+  width: 100%;
+}
+
+.durationPreview {
+  @include t.apply-text-style(t.$text-body);
+  opacity: 0.75;
+  margin: 0;
+}
+
+.errorText {
+  @include t.apply-text-style(t.$text-body);
+  color: c.$color-error;
+  margin: 0;
+}
+
+.eligibilityBanner {
+  @include t.apply-text-style(t.$text-body);
+  margin: 0;
+  padding: sp.$spacing-sm sp.$spacing-md;
+  border-radius: sp.$border-radius;
+  border: 1px solid transparent;
+
+  &.info {
+    background: rgba(c.$color-status-info, 0.1);
+    border-color: rgba(c.$color-status-info, 0.4);
+  }
+
+  &.success {
+    background: rgba(c.$color-status-success, 0.1);
+    border-color: rgba(c.$color-status-success, 0.4);
+  }
+
+  &.warning {
+    background: rgba(c.$color-warning, 0.12);
+    border-color: rgba(c.$color-warning, 0.4);
+  }
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: sp.$spacing-sm;
+  margin-top: sp.$spacing-sm;
+}
+
+.confirmation {
+  display: flex;
+  flex-direction: column;
+  gap: sp.$spacing-md;
+  width: 100%;
+  text-align: center;
+}
+
+.confirmationHeadline {
+  @include t.apply-text-style(t.$text-body);
+  margin: 0;
+}
+
+.confirmationActions {
+  display: flex;
+  justify-content: center;
+  gap: sp.$spacing-sm;
+}
+
+@include m.respond-to(sm, down) {
+  .row {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/components/LogOfflineActivityModal/LogOfflineActivityModal.test.tsx
+++ b/frontend/src/components/LogOfflineActivityModal/LogOfflineActivityModal.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "../Tooltip/Tooltip";
+import LogOfflineActivityModal from "./LogOfflineActivityModal";
+
+const logMutate = vi.fn();
+const fetchPlayerAndCharacter = vi.fn();
+let gameValue: Record<string, unknown>;
+
+vi.mock("../../hooks/useActivities", () => ({
+  useLogOfflineActivity: () => ({ mutate: logMutate, isPending: false }),
+}));
+
+vi.mock("../../hooks/useGame", () => ({
+  useGame: () => gameValue,
+}));
+
+// Stub the autocomplete input so these tests don't depend on the search cache.
+vi.mock("../EntitySearchInput/EntitySearchInput", () => ({
+  default: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string;
+    onChange?: (v: string) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      aria-label="Task"
+      placeholder={placeholder}
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  ),
+}));
+
+function renderModal(onClose = vi.fn()) {
+  return render(
+    <TooltipProvider>
+      <LogOfflineActivityModal onClose={onClose} />
+    </TooltipProvider>
+  );
+}
+
+describe("LogOfflineActivityModal", () => {
+  beforeEach(() => {
+    logMutate.mockReset();
+    fetchPlayerAndCharacter.mockReset();
+    gameValue = { player: { is_premium: true }, fetchPlayerAndCharacter };
+  });
+
+  it("blocks submission and shows errors when required fields are missing", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole("button", { name: "Log activity" }));
+
+    expect(await screen.findByText("Enter or select a task.")).toBeInTheDocument();
+    expect(screen.getByText("Enter a duration greater than zero.")).toBeInTheDocument();
+    expect(logMutate).not.toHaveBeenCalled();
+  });
+
+  it("submits a valid entry and shows the XP confirmation", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText("Task"), "Write docs");
+    await user.type(screen.getByLabelText("Minutes"), "30");
+
+    await user.click(screen.getByRole("button", { name: "Log activity" }));
+
+    await waitFor(() => expect(logMutate).toHaveBeenCalledTimes(1));
+    const [payload, callbacks] = logMutate.mock.calls[0];
+    expect(payload.name).toBe("Write docs");
+    expect(payload.started_at < payload.completed_at).toBe(true);
+
+    callbacks.onSuccess({
+      success: true,
+      message: "Activity logged",
+      activity: { name: "Write docs" },
+      xp_gained: 42,
+      xp_eligible_seconds: 1800,
+      level_ups: [],
+    });
+
+    expect(await screen.findByText("+42 XP awarded")).toBeInTheDocument();
+    expect(fetchPlayerAndCharacter).toHaveBeenCalled();
+  });
+
+  it("surfaces the backend error message on failure", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText("Task"), "Write docs");
+    await user.type(screen.getByLabelText("Minutes"), "30");
+    await user.click(screen.getByRole("button", { name: "Log activity" }));
+
+    await waitFor(() => expect(logMutate).toHaveBeenCalledTimes(1));
+    const [, callbacks] = logMutate.mock.calls[0];
+
+    callbacks.onError(new Error(JSON.stringify({ success: false, message: "Daily limit reached." })));
+
+    expect(await screen.findByText("Daily limit reached.")).toBeInTheDocument();
+  });
+
+  it("warns free-tier users that XP won't be awarded", async () => {
+    gameValue = { player: { is_premium: false }, fetchPlayerAndCharacter };
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText("Minutes"), "10");
+
+    expect(
+      await screen.findByText(
+        "This will be recorded, but offline activities only earn XP for Premium accounts."
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/LogOfflineActivityModal/LogOfflineActivityModal.tsx
+++ b/frontend/src/components/LogOfflineActivityModal/LogOfflineActivityModal.tsx
@@ -1,0 +1,171 @@
+import classNames from "classnames";
+
+import Modal from "../Modal/Modal";
+import Button from "../Button/Button";
+import Input from "../Input/Input";
+import EntitySearchInput from "../EntitySearchInput/EntitySearchInput";
+import { formatDurationShort } from "../../utils/formatUtils";
+import { useLogOfflineActivityForm } from "./useLogOfflineActivityForm";
+import styles from "./LogOfflineActivityModal.module.scss";
+
+interface LogOfflineActivityModalProps {
+  onClose: () => void;
+}
+
+export default function LogOfflineActivityModal({ onClose }: LogOfflineActivityModalProps) {
+  const {
+    taskName,
+    handleTaskNameChange,
+    handleTaskSelect,
+    durationHours,
+    setDurationHours,
+    durationMinutes,
+    setDurationMinutes,
+    totalDurationMinutes,
+    completionDate,
+    handleCompletionDateChange,
+    completionTime,
+    handleCompletionTimeChange,
+    maxCompletionDate,
+    fieldErrors,
+    submitError,
+    result,
+    eligibility,
+    isSubmitting,
+    handleSubmit,
+    reset,
+  } = useLogOfflineActivityForm();
+
+  if (result) {
+    return (
+      <Modal title="Activity logged" onClose={onClose} size="sm">
+        <div className={styles.confirmation}>
+          <p className={styles.confirmationHeadline}>
+            &ldquo;{result.activity.name}&rdquo; has been recorded.
+          </p>
+          {result.xp_gained > 0 ? (
+            <p className={classNames(styles.eligibilityBanner, styles.success)}>
+              +{result.xp_gained} XP awarded
+            </p>
+          ) : (
+            <p className={classNames(styles.eligibilityBanner, styles.info)}>
+              No XP was awarded for this activity.
+            </p>
+          )}
+          <div className={styles.confirmationActions}>
+            <Button variant="secondary" onClick={reset}>
+              Log another
+            </Button>
+            <Button onClick={onClose}>Done</Button>
+          </div>
+        </div>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal title="Log offline activity" onClose={onClose} size="sm">
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <div className={styles.field}>
+          <span className={styles.label}>
+            Task <span className={styles.required} aria-label="required">*</span>
+          </span>
+          <EntitySearchInput
+            type="task"
+            value={taskName}
+            onChange={handleTaskNameChange}
+            onSelect={handleTaskSelect}
+            placeholder="Search or enter a task name"
+            ariaLabel="Task"
+            inputClassName={styles.taskInput}
+          />
+          {fieldErrors.task && (
+            <p className={styles.errorText} role="alert">{fieldErrors.task}</p>
+          )}
+        </div>
+
+        <div className={styles.field}>
+          <span className={styles.label}>
+            Duration <span className={styles.required} aria-label="required">*</span>
+          </span>
+          <div className={styles.row}>
+            <Input
+              id="offline-activity-duration-hours"
+              ariaLabel="Hours"
+              type="number"
+              placeholder="hh"
+              value={durationHours}
+              onChange={(value) => setDurationHours(value as string)}
+              className={styles.durationPartField}
+            />
+            <Input
+              id="offline-activity-duration-minutes"
+              ariaLabel="Minutes"
+              type="number"
+              placeholder="mm"
+              value={durationMinutes}
+              onChange={(value) => setDurationMinutes((value as string).slice(0, 2))}
+              maxLength={2}
+              className={styles.durationPartField}
+            />
+          </div>
+          {fieldErrors.duration && (
+            <p className={styles.errorText} role="alert">{fieldErrors.duration}</p>
+          )}
+        </div>
+
+        <div className={styles.field}>
+          <span className={styles.label}>Completed</span>
+          <div className={styles.row}>
+            <Input
+              id="offline-activity-date"
+              ariaLabel="Completion date"
+              type="date"
+              value={completionDate}
+              onChange={(value) => handleCompletionDateChange(value as string)}
+              max={maxCompletionDate}
+            />
+            <Input
+              id="offline-activity-time"
+              ariaLabel="Completion time"
+              type="time"
+              value={completionTime}
+              onChange={(value) => handleCompletionTimeChange(value as string)}
+            />
+          </div>
+          {fieldErrors.completedAt && (
+            <p className={styles.errorText} role="alert">{fieldErrors.completedAt}</p>
+          )}
+        </div>
+
+        {!Number.isNaN(totalDurationMinutes) && totalDurationMinutes > 0 && (
+          <p className={styles.durationPreview}>
+            Logging {formatDurationShort(Math.round(totalDurationMinutes * 60))}
+          </p>
+        )}
+
+        {eligibility && (
+          <p
+            className={classNames(styles.eligibilityBanner, styles[eligibility.tone])}
+            role="status"
+          >
+            {eligibility.message}
+          </p>
+        )}
+
+        {submitError && (
+          <p className={styles.errorText} role="alert">{submitError}</p>
+        )}
+
+        <div className={styles.actions}>
+          <Button type="button" variant="secondary" onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Logging…" : "Log activity"}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/components/LogOfflineActivityModal/useLogOfflineActivityForm.ts
+++ b/frontend/src/components/LogOfflineActivityModal/useLogOfflineActivityForm.ts
@@ -1,0 +1,242 @@
+import { useCallback, useMemo, useState } from "react";
+
+import { useLogOfflineActivity } from "../../hooks/useActivities";
+import { useGame } from "../../hooks/useGame";
+import type { SearchEntity } from "../EntitySearchInput/useEntitySearchInput";
+import type { OfflineActivityLogResponse } from "../../types";
+
+// Must match OFFLINE_XP_ELIGIBLE_BACKDATE_WINDOW in progression/services.py —
+// duplicated here only for the client-side "will this earn XP" hint; the
+// backend remains the authority on whether XP is actually awarded.
+const XP_ELIGIBLE_BACKDATE_DAYS = 7;
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function todayDateValue(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+}
+
+function nowTimeValue(): string {
+  const now = new Date();
+  return `${pad(now.getHours())}:${pad(now.getMinutes())}`;
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    try {
+      const parsed = JSON.parse(error.message) as Record<string, unknown>;
+      if (typeof parsed.message === "string") return parsed.message;
+
+      const firstFieldError = Object.values(parsed).find(
+        (value): value is string[] =>
+          Array.isArray(value) && typeof value[0] === "string"
+      );
+      if (firstFieldError) return firstFieldError[0];
+    } catch {
+      // Not a JSON error body — fall back to the raw message below.
+    }
+    return error.message;
+  }
+  return "Something went wrong logging this activity. Please try again.";
+}
+
+export interface FieldErrors {
+  task?: string;
+  duration?: string;
+  completedAt?: string;
+}
+
+export function useLogOfflineActivityForm(onLogged?: () => void) {
+  const { player, fetchPlayerAndCharacter } = useGame();
+  const isPremium = Boolean(player?.is_premium);
+  const logOfflineActivity = useLogOfflineActivity();
+
+  const [taskName, setTaskName] = useState("");
+  const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
+  const [durationHours, setDurationHours] = useState("");
+  const [durationMinutes, setDurationMinutes] = useState("");
+  const [completionDate, setCompletionDate] = useState(todayDateValue);
+  const [completionTime, setCompletionTime] = useState(nowTimeValue);
+  // Fixed at mount: caps the native date picker so future dates can't be
+  // selected at all, rather than allowing them and erroring afterwards.
+  const [maxCompletionDate] = useState(todayDateValue);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [result, setResult] = useState<OfflineActivityLogResponse | null>(null);
+  // Read once at mount (a lazy initializer, not a render-phase call) and
+  // refreshed by the date/time change handlers below — those are event
+  // handlers, where reading the clock is fine.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  const handleCompletionDateChange = useCallback((value: string) => {
+    setCompletionDate(value);
+    setNowMs(Date.now());
+  }, []);
+
+  const handleCompletionTimeChange = useCallback((value: string) => {
+    setCompletionTime(value);
+    setNowMs(Date.now());
+  }, []);
+
+  const handleTaskNameChange = useCallback((value: string) => {
+    setTaskName(value);
+    setSelectedTaskId(null);
+  }, []);
+
+  const handleTaskSelect = useCallback((entity: SearchEntity) => {
+    setTaskName(entity.name);
+    setSelectedTaskId(typeof entity.id === "number" ? entity.id : Number(entity.id));
+  }, []);
+
+  const totalDurationMinutes = useMemo(() => {
+    const hours = Number(durationHours || 0);
+    const minutes = Number(durationMinutes || 0);
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) return NaN;
+    return hours * 60 + minutes;
+  }, [durationHours, durationMinutes]);
+
+  const completedAt = useMemo(() => {
+    if (!completionDate || !completionTime) return null;
+    const date = new Date(`${completionDate}T${completionTime}`);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }, [completionDate, completionTime]);
+
+  const eligibility = useMemo(() => {
+    if (!completedAt) return null;
+
+    if (!isPremium) {
+      return {
+        tone: "info" as const,
+        message: "This will be recorded, but offline activities only earn XP for Premium accounts.",
+      };
+    }
+
+    const ageDays = (nowMs - completedAt.getTime()) / (24 * 60 * 60 * 1000);
+    if (ageDays > XP_ELIGIBLE_BACKDATE_DAYS) {
+      return {
+        tone: "warning" as const,
+        message: `This is more than ${XP_ELIGIBLE_BACKDATE_DAYS} days old, so it will be recorded but won't earn XP.`,
+      };
+    }
+
+    return {
+      tone: "success" as const,
+      message: "This activity is eligible for XP, subject to your daily logging limits.",
+    };
+  }, [completedAt, isPremium, nowMs]);
+
+  const validate = useCallback((): FieldErrors => {
+    const errors: FieldErrors = {};
+
+    if (!taskName.trim()) {
+      errors.task = "Enter or select a task.";
+    }
+
+    const hours = durationHours ? Number(durationHours) : 0;
+    const minutes = durationMinutes ? Number(durationMinutes) : 0;
+    if (Number.isNaN(hours) || hours < 0) {
+      errors.duration = "Hours must be a positive number.";
+    } else if (Number.isNaN(minutes) || minutes < 0 || minutes > 59) {
+      errors.duration = "Minutes must be between 0 and 59.";
+    } else if (totalDurationMinutes <= 0) {
+      errors.duration = "Enter a duration greater than zero.";
+    }
+
+    if (!completionDate || !completionTime) {
+      errors.completedAt = "Enter a completion date and time.";
+    } else if (!completedAt) {
+      errors.completedAt = "Enter a valid completion date and time.";
+    } else if (completedAt.getTime() > Date.now()) {
+      errors.completedAt = "Completion date/time can't be in the future.";
+    }
+
+    return errors;
+  }, [
+    completedAt,
+    completionDate,
+    completionTime,
+    durationHours,
+    durationMinutes,
+    taskName,
+    totalDurationMinutes,
+  ]);
+
+  const reset = useCallback(() => {
+    setTaskName("");
+    setSelectedTaskId(null);
+    setDurationHours("");
+    setDurationMinutes("");
+    setCompletionDate(todayDateValue());
+    setCompletionTime(nowTimeValue());
+    setNowMs(Date.now());
+    setFieldErrors({});
+    setSubmitError(null);
+    setResult(null);
+  }, []);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setSubmitError(null);
+
+      const errors = validate();
+      setFieldErrors(errors);
+      if (Object.keys(errors).length > 0 || !completedAt) return;
+
+      const durationSeconds = Math.round(totalDurationMinutes * 60);
+      const startedAt = new Date(completedAt.getTime() - durationSeconds * 1000);
+
+      logOfflineActivity.mutate(
+        {
+          ...(selectedTaskId ? { task: selectedTaskId } : { name: taskName.trim() }),
+          started_at: startedAt.toISOString(),
+          completed_at: completedAt.toISOString(),
+        },
+        {
+          onSuccess: (data) => {
+            setResult(data);
+            if (data.xp_gained > 0) fetchPlayerAndCharacter();
+            onLogged?.();
+          },
+          onError: (error) => setSubmitError(extractErrorMessage(error)),
+        }
+      );
+    },
+    [
+      completedAt,
+      fetchPlayerAndCharacter,
+      logOfflineActivity,
+      onLogged,
+      selectedTaskId,
+      taskName,
+      totalDurationMinutes,
+      validate,
+    ]
+  );
+
+  return {
+    taskName,
+    handleTaskNameChange,
+    handleTaskSelect,
+    durationHours,
+    setDurationHours,
+    durationMinutes,
+    setDurationMinutes,
+    totalDurationMinutes,
+    completionDate,
+    handleCompletionDateChange,
+    completionTime,
+    handleCompletionTimeChange,
+    maxCompletionDate,
+    fieldErrors,
+    submitError,
+    result,
+    eligibility,
+    isSubmitting: logOfflineActivity.isPending,
+    handleSubmit,
+    reset,
+  };
+}

--- a/frontend/src/components/Map/Map.test.tsx
+++ b/frontend/src/components/Map/Map.test.tsx
@@ -1165,7 +1165,6 @@ describe('PopulationCentreMap entity detail card', () => {
     const dialog = await screen.findByRole('dialog', { name: 'House 2' });
     expect(dialog).toHaveTextContent('1 / 4');
     expect(dialog).toHaveTextContent('Alice');
-    expect(dialog).toHaveTextContent('idle');
   });
 
   it('switches to a resident\'s own detail card when clicked inside the building detail card', async () => {

--- a/frontend/src/components/Modal/Modal.module.scss
+++ b/frontend/src/components/Modal/Modal.module.scss
@@ -53,8 +53,7 @@
   overflow-y: auto;
   overflow-x: hidden;
   min-height: 0;
-  padding-top: sp.$spacing-md;
-  padding-bottom: sp.$spacing-md;
+  padding: sp.$spacing-md sp.$spacing-sm;
   @include tc.two-column-layout;
 
   justify-content: flex-start;

--- a/frontend/src/hooks/useActivities.ts
+++ b/frontend/src/hooks/useActivities.ts
@@ -1,7 +1,7 @@
 // src/hooks/useActivities.ts
 
 import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
-import { updateActivity, deleteActivity, fetchActivities, createActivity } from "../api/activities";
+import { updateActivity, deleteActivity, fetchActivities, createActivity, logOfflineActivity } from "../api/activities";
 import type { PlayerActivity } from "../types";
 
 
@@ -21,6 +21,20 @@ export function useCreateActivity() {
     mutationFn: createActivity,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["activities"] });
+    },
+  });
+}
+
+
+export function useLogOfflineActivity() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: logOfflineActivity,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["activities"] });
+      // A task may have been auto-created (or its total time updated) by the log.
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
     },
   });
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -97,6 +97,16 @@ export interface AnnouncementReadMutationResponse {
   unread_count: number;
 }
 
+/** Response from POST /player-activities/log_offline/ */
+export interface OfflineActivityLogResponse {
+  success: boolean;
+  message: string;
+  activity: PlayerActivity;
+  xp_gained: number;
+  xp_eligible_seconds: number;
+  level_ups: number[];
+}
+
 // Forward references resolved in domain.ts
 import type { Player } from "./domain";
 import type { Character } from "./domain";
@@ -104,4 +114,5 @@ import type { Announcement } from "./domain";
 import type { ActivityTimerApiData } from "./timers";
 import type { PopulationCentre } from "./domain";
 import type { XpModifier } from "./domain";
+import type { PlayerActivity } from "./domain";
 import type { LoginState } from "./enums";

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -19,6 +19,7 @@ export type {
   AnnouncementListResponse,
   AnnouncementUnreadCountResponse,
   AnnouncementReadMutationResponse,
+  OfflineActivityLogResponse,
 } from "./api";
 
 // Enums and literal union types


### PR DESCRIPTION
## Summary
- Adds a "Log activity" flow (closes #704): a "+" entry point next to the activities summary opens a modal to search/enter a task, split hours+minutes duration, and a completion date/time (native date picker capped at today). Submits to the existing backend endpoint and surfaces its XP-eligibility messaging — backend stays authoritative on XP; client only does obvious sanity-checks.
- Fixes `Input.tsx`'s native `required` attribute silently blocking form submission (kept `aria-required` for a11y, dropped the browser-validation UI conflict with the app's own styled errors).
- Fixes `Modal.module.scss`'s `.modalContent` clipping the focus ring on full-width inputs (`overflow-x: hidden` with no horizontal padding).
- Updates `BuildingDetail.test.tsx`/`Map.test.tsx`, which were failing on `development` after `37f09c66` simplified resident-line display but left the tests unupdated.

## Test plan
- [x] `npx vitest run` — full suite green (552/552, unrelated storybook/chromium connection-timeout noise aside)
- [x] `npx eslint .` — clean
- [x] `npx tsc --noEmit -p .` — clean
- [ ] Manual browser check of the modal (open/submit flow, mobile, keyboard nav) — not verified in this session, no browser tool available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mur33yGv419VMfAaKxjaGS