### PR TITLE
Parent task chip, due-date split, timestamp tooltip, subtask creation

### DIFF
--- a/frontend/src/components/PlayerItemList/PlayerItemList.tsx
+++ b/frontend/src/components/PlayerItemList/PlayerItemList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import classNames from "classnames";
 
 import Button from "../Button/Button";
@@ -33,6 +33,8 @@ interface PlayerItemListProps<T extends { id?: string | number; name?: string }>
   getItemKey?: (item: T, index: number) => string | number;
   renderItemMeta?: (item: T) => React.ReactNode;
   renderEditSummary?: (item: T, saveHelpers: SaveStatusHelpers) => React.ReactNode;
+  /** Rendered next to the name input in the edit modal's title row (e.g. an icon button). */
+  renderTitleRowActions?: (item: T) => React.ReactNode;
   onEdit?: (item: T, name: string, callbacks?: SaveCallbacks) => void;
   onDelete?: (item: T) => void;
   hoverEdit?: boolean;
@@ -47,6 +49,10 @@ interface PlayerItemListProps<T extends { id?: string | number; name?: string }>
   /** Called once the requested `openItemId` has been opened, so the caller can clear it. */
   onOpenItemHandled?: () => void;
   getChildren?: (item: T) => T[] | undefined;
+  /** Ids of items present in `items` (e.g. for the deep-link lookup) that should not be rendered as rows. */
+  hiddenItemIds?: Set<string | number>;
+  /** Called with the item whose edit modal just closed (via Close, backdrop, or Escape). */
+  onModalClose?: (item: T) => void;
 }
 
 export default function PlayerItemList<T extends { id?: string | number; name?: string }>({
@@ -59,6 +65,7 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
   getItemKey,
   renderItemMeta,
   renderEditSummary,
+  renderTitleRowActions,
   onEdit,
   onDelete,
   hoverEdit = false,
@@ -71,6 +78,8 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
   openItemId,
   onOpenItemHandled,
   getChildren,
+  hiddenItemIds,
+  onModalClose,
 }: PlayerItemListProps<T>) {
   const {
     activeFilterKey,
@@ -125,6 +134,13 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
     onOpenItemHandled?.();
   }, [openItemId, items, handleOpenItem, onOpenItemHandled]);
 
+  // Wraps handleModalClose so a consumer (e.g. to discard an unsaved draft
+  // item) learns which item's modal just closed via Close/backdrop/Escape.
+  const closeModal = useCallback(() => {
+    if (activeItem) onModalClose?.(activeItem);
+    handleModalClose();
+  }, [activeItem, onModalClose, handleModalClose]);
+
   const canToggleComplete = typeof onToggleComplete === "function";
   const canEdit = typeof onEdit === "function";
   const canDelete = typeof onDelete === "function";
@@ -140,16 +156,23 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
     return ids;
   }, [items, getChildren]);
 
+  // Items present in `items` only so the deep-link/openItemId lookup can find
+  // them (e.g. an unsaved draft) are excluded from the rendered rows.
+  const visibleDisplayItems = useMemo(() => {
+    if (!hiddenItemIds || hiddenItemIds.size === 0) return displayItems;
+    return displayItems.filter((item) => item.id === undefined || !hiddenItemIds.has(item.id));
+  }, [displayItems, hiddenItemIds]);
+
   // Sort/filter controls only apply to top-level items; a child keeps its
   // place directly after its parent (in `getChildren`'s order) rather than
   // being reordered independently.
   const flatDisplayItems = useMemo(() => {
-    if (!getChildren) return displayItems;
-    const topLevel = displayItems.filter(
+    if (!getChildren) return visibleDisplayItems;
+    const topLevel = visibleDisplayItems.filter(
       (item) => item.id === undefined || !childIds.has(item.id)
     );
     return topLevel.flatMap((item) => [item, ...(getChildren(item) ?? [])]);
-  }, [displayItems, getChildren, childIds]);
+  }, [visibleDisplayItems, getChildren, childIds]);
 
   const renderRow = (item: T): React.ReactNode => (
     <>
@@ -283,7 +306,7 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
               ? `Delete ${itemLabelLower}?`
               : `Edit ${itemLabelLower}`
           }
-          onClose={handleModalClose}
+          onClose={closeModal}
           onBack={confirmingDelete ? () => setConfirmingDelete(false) : undefined}
           backLabel="Back"
         >
@@ -328,17 +351,20 @@ export default function PlayerItemList<T extends { id?: string | number; name?: 
                       autoFocus
                       onKeyDown={(event) => {
                         if (event.key === "Enter") handleEditSave();
-                        if (event.key === "Escape") handleModalClose();
+                        if (event.key === "Escape") closeModal();
                       }}
                     />
                   ) : null}
+                  {renderTitleRowActions && liveActiveItem
+                    ? renderTitleRowActions(liveActiveItem)
+                    : null}
                 </div>
               ) : null}
               {modalSummary ? (
                 <div className={styles.editConfirmMeta}>{modalSummary}</div>
               ) : null}
               <div className={styles.editConfirmActions}>
-                <Button variant="secondary" onClick={handleModalClose}>
+                <Button variant="secondary" onClick={closeModal}>
                   Close
                 </Button>
                 {canDelete ? (

--- a/frontend/src/components/TasksPanel/TasksPanel.module.scss
+++ b/frontend/src/components/TasksPanel/TasksPanel.module.scss
@@ -99,6 +99,27 @@
   gap: sp.$spacing-sm;
 }
 
+.timestampButton {
+  flex-shrink: 0;
+  height: sp.$form-control-height;
+  width: sp.$form-control-height;
+  padding: 0;
+  border: 1px solid rgba(c.$color-border-primary, 0.35);
+  border-radius: sp.$form-control-radius;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  &:hover {
+    border-color: rgba(c.$color-border-primary, 0.55);
+  }
+}
+
 .timestampLabel {
   font-weight: 600;
   margin-bottom: 2px;

--- a/frontend/src/components/TasksPanel/TasksPanel.test.tsx
+++ b/frontend/src/components/TasksPanel/TasksPanel.test.tsx
@@ -359,7 +359,7 @@ describe("TasksPanel", () => {
       expect(screen.queryByText("Child subtask")).not.toBeInTheDocument();
     });
 
-    it("pre-fills the add-task form with a parent chip via the add-subtask row action", async () => {
+    it("opens the task detail modal for a blank draft subtask without creating one yet", async () => {
       const user = userEvent.setup({ pointerEventsCheck: 0 });
       mockUseTasks.mockReturnValue({
         isLoading: false,
@@ -369,15 +369,65 @@ describe("TasksPanel", () => {
 
       await user.click(screen.getByRole("button", { name: "Add subtask to Parent project task" }));
 
-      expect(screen.getByText(/Subtask of Parent project task/)).toBeInTheDocument();
+      const dialog = await screen.findByRole("dialog");
+      expect(within(dialog).getByLabelText("task name")).toHaveValue("");
+      expect(createMutate).not.toHaveBeenCalled();
+    });
 
-      const input = screen.getByLabelText("new task");
-      await user.type(input, "Buy groceries");
-      await user.click(screen.getByRole("button", { name: "Add subtask" }));
+    it("creates the subtask only once its draft name has actually been edited, then opens the persisted task", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      const newSubtask = { ...childTask, id: 7, name: "New task" };
+      createMutate.mockImplementation((_data, callbacks) => {
+        callbacks?.onSuccess?.(newSubtask);
+      });
+      mockUseTasks.mockReturnValue({
+        isLoading: false,
+        data: [parentTask],
+      });
+      const { rerender } = renderTasksPanel();
+
+      await user.click(screen.getByRole("button", { name: "Add subtask to Parent project task" }));
+      const dialog = await screen.findByRole("dialog");
+      const input = within(dialog).getByLabelText("task name");
+      await user.type(input, "New task");
+      await user.tab();
+
+      expect(createMutate).toHaveBeenCalledWith(
+        { name: "New task", parent: 3 },
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+      );
+
+      // The new subtask isn't in `items` until the tasks query refetches with it included.
+      mockUseTasks.mockReturnValue({
+        isLoading: false,
+        data: [parentTask, newSubtask],
+      });
+      rerender(
+        <TooltipProvider>
+          <TasksPanel />
+        </TooltipProvider>,
+      );
+
+      const reopenedDialog = await screen.findByRole("dialog");
+      expect(within(reopenedDialog).getByDisplayValue("New task")).toBeInTheDocument();
+    });
+
+    it("discards the draft subtask, without creating anything, when its modal is closed unedited", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      mockUseTasks.mockReturnValue({
+        isLoading: false,
+        data: [parentTask],
+      });
+      renderTasksPanel();
+
+      await user.click(screen.getByRole("button", { name: "Add subtask to Parent project task" }));
+      const dialog = await screen.findByRole("dialog");
+      await user.click(within(dialog).getByRole("button", { name: "Close" }));
 
       await waitFor(() => {
-        expect(createMutate).toHaveBeenCalledWith({ name: "Buy groceries", parent: 3 });
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       });
+      expect(createMutate).not.toHaveBeenCalled();
     });
 
     it("disables the parent picker for a task that already has subtasks", async () => {
@@ -406,7 +456,7 @@ describe("TasksPanel", () => {
       );
 
       const dueDateInput = screen.getByLabelText("Due date");
-      await user.type(dueDateInput, "2026-06-01T09:00");
+      await user.type(dueDateInput, "2026-06-01");
       await user.tab();
 
       await waitFor(() => {
@@ -415,6 +465,52 @@ describe("TasksPanel", () => {
           expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
         );
       });
+    });
+
+    it("defaults the date to today when only a time is set", async () => {
+      const user = userEvent.setup();
+      renderTasksPanel();
+
+      await user.click(
+        screen.getAllByRole("button", { name: "Edit task Morning routine" })[0],
+      );
+
+      const dueTimeInput = screen.getByLabelText("Due time");
+      await user.type(dueTimeInput, "0900");
+      await user.tab();
+
+      await waitFor(() => {
+        expect(updateMutate).toHaveBeenCalledWith(
+          { id: 1, data: { due_at: expect.any(String) } },
+          expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+        );
+      });
+
+      const lastCall = updateMutate.mock.calls.at(-1) as [{ data: { due_at: string } }, unknown];
+      const committedDate = new Date(lastCall[0].data.due_at);
+      const today = new Date();
+      expect(committedDate.getFullYear()).toBe(today.getFullYear());
+      expect(committedDate.getMonth()).toBe(today.getMonth());
+      expect(committedDate.getDate()).toBe(today.getDate());
+    });
+  });
+
+  describe("timestamps tooltip", () => {
+    it("shows Created/Modified/Completed on click of the clock button", async () => {
+      const user = userEvent.setup();
+      renderTasksPanel();
+
+      await user.click(
+        screen.getAllByRole("button", { name: "Edit task Morning routine" })[0],
+      );
+
+      expect(screen.queryByText("Created", { selector: "div" })).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "View task timestamps" }));
+
+      expect(screen.getByText("Created", { selector: "div" })).toBeInTheDocument();
+      expect(screen.getByText("Modified", { selector: "div" })).toBeInTheDocument();
+      expect(screen.getByText("Completed", { selector: "div" })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/TasksPanel/TasksPanel.tsx
+++ b/frontend/src/components/TasksPanel/TasksPanel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import classNames from "classnames";
 
 import EntitySearchInput from "../EntitySearchInput/EntitySearchInput";
@@ -6,7 +6,7 @@ import Button from "../Button/Button";
 import PlayerItemList from "../PlayerItemList/PlayerItemList";
 import Tooltip from "../Tooltip/Tooltip";
 import { isTaskComplete, taskSortOptions, useTasksPanel, type ItemRecord } from "./useTasksPanel";
-import { toDatetimeLocalValue, fromDatetimeLocalValue } from "../../utils/formatUtils";
+import { toDateInputValue, toTimeInputValue, fromDateAndTimeInputValues } from "../../utils/formatUtils";
 import styles from "./TasksPanel.module.scss";
 
 interface TasksPanelProps {
@@ -31,9 +31,11 @@ export default function TasksPanel({
     visibleTasks,
     getChildren,
     topLevelTasks,
-    addSubtaskParent,
+    pendingOpenTaskId,
+    hiddenItemIds,
     startAddSubtask,
-    clearAddSubtaskParent,
+    clearPendingOpenTaskId,
+    discardDraftTask,
     handleCreateTask,
     handleSubmitForm,
     handleEdit,
@@ -48,35 +50,27 @@ export default function TasksPanel({
     updateTask,
   } = useTasksPanel(openTaskId, onOpenNote);
 
+  // Only one task's edit summary is ever open at a time (it renders inside a modal), so a
+  // single pair of refs is enough to read the sibling input's value when committing due_at.
+  const dueDateInputRef = useRef<HTMLInputElement>(null);
+  const dueTimeInputRef = useRef<HTMLInputElement>(null);
+
   if (isLoading) return <p>Loading tasks...</p>;
 
   return (
     <div className={styles.page}>
       <div className={styles.content}>
       <form className={styles.addTaskForm} onSubmit={handleSubmitForm}>
-        {addSubtaskParent && (
-          <span className={styles.parentChip}>
-            Subtask of {addSubtaskParent.name}
-            <button
-              type="button"
-              className={styles.parentChipClear}
-              aria-label="Clear subtask parent"
-              onClick={clearAddSubtaskParent}
-            >
-              ×
-            </button>
-          </span>
-        )}
         <EntitySearchInput
           type="task"
           value={newName}
           onChange={(v) => setNewName(v)}
-          onCreate={(name) => handleCreateTask(name, { parent: addSubtaskParent?.id ?? undefined })}
-          placeholder={addSubtaskParent ? "New subtask name" : "New task name"}
+          onCreate={(name) => handleCreateTask(name)}
+          placeholder="New task name"
           className={styles.addTaskInput}
         />
         <Button type="submit">
-          <span className={styles.addButtonText}>{addSubtaskParent ? "Add subtask" : "Add task"}</span>
+          <span className={styles.addButtonText}>Add task</span>
           <span className={styles.addButtonIcon} aria-hidden="true">✓</span>
         </Button>
       </form>
@@ -108,27 +102,19 @@ export default function TasksPanel({
             );
           }}
           renderEditSummary={(taskItem, saveHelpers) => {
+            if (taskItem.id < 0) {
+              // An unsaved draft subtask: nothing to show or edit here yet
+              // (due date, parent, notes) until it's actually been created.
+              return <div className={styles.timestampLabel}>Type a name to create this subtask.</div>;
+            }
+
             const summary = getTaskEditSummary(taskItem);
             const hasSubtasks = (taskItem.subtask_count ?? 0) > 0;
             const parentOptions = topLevelTasks.filter((t) => t.id !== taskItem.id);
+            const parentTask = topLevelTasks.find((t) => t.id === taskItem.parent) ?? null;
 
             return (
               <>
-                <div className={styles.taskTimestamps}>
-                  <div>
-                    <div className={styles.timestampLabel}>Created</div>
-                    <div>{summary.created}</div>
-                  </div>
-                  <div>
-                    <div className={styles.timestampLabel}>Modified</div>
-                    <div>{summary.modified}</div>
-                  </div>
-                  <div>
-                    <div className={styles.timestampLabel}>Completed</div>
-                    <div>{summary.completed}</div>
-                  </div>
-                </div>
-                <hr></hr>
                 <div>
                   Total time: {summary.totalTime}
                 </div>
@@ -154,20 +140,51 @@ export default function TasksPanel({
                   })()
                 ) : null}
                 <div className={styles.dueDateRow}>
-                  <label className={styles.timestampLabel} htmlFor="task-due-at">
+                  <label className={styles.timestampLabel} htmlFor="task-due-at-date">
                     Due date
                   </label>
                   <input
-                    id="task-due-at"
-                    type="datetime-local"
+                    id="task-due-at-date"
+                    ref={dueDateInputRef}
+                    type="date"
                     className={styles.dueDateInput}
-                    defaultValue={toDatetimeLocalValue(taskItem.due_at)}
-                    onBlur={(event) => {
+                    defaultValue={toDateInputValue(taskItem.due_at)}
+                    onBlur={() => {
                       saveHelpers.reportSaving();
                       updateTask.mutate(
                         {
                           id: taskItem.id,
-                          data: { due_at: fromDatetimeLocalValue(event.target.value) },
+                          data: {
+                            due_at: fromDateAndTimeInputValues(
+                              dueDateInputRef.current?.value ?? "",
+                              dueTimeInputRef.current?.value ?? "",
+                            ),
+                          },
+                        },
+                        { onSuccess: saveHelpers.reportSaved, onError: saveHelpers.reportError },
+                      );
+                    }}
+                  />
+                  <input
+                    aria-label="Due time"
+                    ref={dueTimeInputRef}
+                    type="time"
+                    className={styles.dueDateInput}
+                    defaultValue={toTimeInputValue(taskItem.due_at)}
+                    onBlur={() => {
+                      if (dueTimeInputRef.current?.value && dueDateInputRef.current && !dueDateInputRef.current.value) {
+                        dueDateInputRef.current.value = toDateInputValue(new Date().toISOString());
+                      }
+                      saveHelpers.reportSaving();
+                      updateTask.mutate(
+                        {
+                          id: taskItem.id,
+                          data: {
+                            due_at: fromDateAndTimeInputValues(
+                              dueDateInputRef.current?.value ?? "",
+                              dueTimeInputRef.current?.value ?? "",
+                            ),
+                          },
                         },
                         { onSuccess: saveHelpers.reportSaved, onError: saveHelpers.reportError },
                       );
@@ -177,6 +194,8 @@ export default function TasksPanel({
                     <Button
                       variant="secondary"
                       onClick={() => {
+                        if (dueDateInputRef.current) dueDateInputRef.current.value = "";
+                        if (dueTimeInputRef.current) dueTimeInputRef.current.value = "";
                         saveHelpers.reportSaving();
                         updateTask.mutate(
                           { id: taskItem.id, data: { due_at: null } },
@@ -192,39 +211,93 @@ export default function TasksPanel({
                   <label className={styles.timestampLabel} htmlFor="task-parent">
                     Parent task
                   </label>
-                  <Tooltip
-                    content={
-                      hasSubtasks
-                        ? "This task already has subtasks and can't be nested under another task."
-                        : undefined
-                    }
-                  >
-                    <select
-                      id="task-parent"
-                      className={styles.parentSelect}
-                      disabled={hasSubtasks}
-                      defaultValue={taskItem.parent ?? ""}
-                      onChange={(event) => {
-                        saveHelpers.reportSaving();
-                        updateTask.mutate(
-                          {
-                            id: taskItem.id,
-                            data: { parent: event.target.value ? Number(event.target.value) : null },
-                          },
-                          { onSuccess: saveHelpers.reportSaved, onError: saveHelpers.reportError },
-                        );
-                      }}
+                  {parentTask ? (
+                    <span className={styles.parentChip}>
+                      {parentTask.name}
+                      <button
+                        type="button"
+                        className={styles.parentChipClear}
+                        aria-label={`Remove parent task ${parentTask.name}`}
+                        onClick={() => {
+                          saveHelpers.reportSaving();
+                          updateTask.mutate(
+                            { id: taskItem.id, data: { parent: null } },
+                            { onSuccess: saveHelpers.reportSaved, onError: saveHelpers.reportError },
+                          );
+                        }}
+                      >
+                        ×
+                      </button>
+                    </span>
+                  ) : (
+                    <Tooltip
+                      content={
+                        hasSubtasks
+                          ? "This task already has subtasks and can't be nested under another task."
+                          : undefined
+                      }
                     >
-                      <option value="">No parent</option>
-                      {parentOptions.map((option) => (
-                        <option key={option.id} value={option.id}>
-                          {option.name}
-                        </option>
-                      ))}
-                    </select>
-                  </Tooltip>
+                      <select
+                        id="task-parent"
+                        className={styles.parentSelect}
+                        disabled={hasSubtasks}
+                        defaultValue=""
+                        onChange={(event) => {
+                          saveHelpers.reportSaving();
+                          updateTask.mutate(
+                            {
+                              id: taskItem.id,
+                              data: { parent: event.target.value ? Number(event.target.value) : null },
+                            },
+                            { onSuccess: saveHelpers.reportSaved, onError: saveHelpers.reportError },
+                          );
+                        }}
+                      >
+                        <option value="">No parent</option>
+                        {parentOptions.map((option) => (
+                          <option key={option.id} value={option.id}>
+                            {option.name}
+                          </option>
+                        ))}
+                      </select>
+                    </Tooltip>
+                  )}
                 </div>
               </>
+            );
+          }}
+          renderTitleRowActions={(task) => {
+            if (task.id < 0) return null;
+            const summary = getTaskEditSummary(task);
+            return (
+              <Tooltip
+                placement="bottom"
+                align="end"
+                content={
+                  <div className={styles.taskTimestamps}>
+                    <div>
+                      <div className={styles.timestampLabel}>Created</div>
+                      <div>{summary.created}</div>
+                    </div>
+                    <div>
+                      <div className={styles.timestampLabel}>Modified</div>
+                      <div>{summary.modified}</div>
+                    </div>
+                    <div>
+                      <div className={styles.timestampLabel}>Completed</div>
+                      <div>{summary.completed}</div>
+                    </div>
+                  </div>
+                }
+              >
+                <button
+                  type="button"
+                  className={styles.timestampButton}
+                  aria-label="View task timestamps"
+                >
+                  🕐
+                </button>
+              </Tooltip>
             );
           }}
           hoverEdit
@@ -262,8 +335,13 @@ export default function TasksPanel({
           )}
           onEdit={handleEdit}
           onDelete={handleDelete}
-          openItemId={openTaskId}
-          onOpenItemHandled={onOpenTaskHandled}
+          openItemId={openTaskId ?? pendingOpenTaskId}
+          onOpenItemHandled={() => {
+            onOpenTaskHandled?.();
+            clearPendingOpenTaskId();
+          }}
+          hiddenItemIds={hiddenItemIds}
+          onModalClose={discardDraftTask}
           sortOptions={taskSortOptions}
           controls={
             <Button

--- a/frontend/src/components/TasksPanel/useTasksPanel.tsx
+++ b/frontend/src/components/TasksPanel/useTasksPanel.tsx
@@ -13,6 +13,32 @@ import { TASKS_HIDE_COMPLETED_KEY } from "../../utils/userPreferences";
 
 export type ItemRecord = Task & { [key: string]: unknown };
 
+// A client-side-only placeholder for a not-yet-created subtask. It's given a
+// negative id (real task ids are always positive) so it can share the same
+// items array, id-matching deep-link, and edit-modal machinery as real
+// tasks, without ever colliding with one or being mistaken for one.
+function makeDraftSubtask(parentId: number): ItemRecord {
+  const now = new Date().toISOString();
+  return {
+    id: -Date.now(),
+    name: "",
+    description: "",
+    player: 0,
+    project: null,
+    created_at: now,
+    last_updated: now,
+    is_complete: false,
+    completed_at: null,
+    first_completed_at: null,
+    due_at: null,
+    parent: parentId,
+    subtask_count: 0,
+    total_time: 0,
+    total_records: 0,
+    last_worked_on: null,
+  };
+}
+
 export interface TaskEditSummary {
   created: string;
   modified: string;
@@ -116,7 +142,8 @@ export function useTasksPanel(openTaskId?: number | null, onOpenNote?: (noteId: 
       return true;
     }
   });
-  const [addSubtaskParent, setAddSubtaskParent] = useState<ItemRecord | null>(null);
+  const [pendingOpenTaskId, setPendingOpenTaskId] = useState<number | null>(null);
+  const [draftTask, setDraftTask] = useState<ItemRecord | null>(null);
 
   useEffect(() => {
     if (!completionReward) return;
@@ -176,9 +203,17 @@ export function useTasksPanel(openTaskId?: number | null, onOpenNote?: (noteId: 
     });
   }, [safeTasks, hideCompleted, openTaskId]);
 
-  const visibleTasks = useMemo(
-    () => groupedTasks.flatMap((group) => [group.parent, ...group.children]),
-    [groupedTasks]
+  const visibleTasks = useMemo(() => {
+    const flat = groupedTasks.flatMap((group) => [group.parent, ...group.children]);
+    // The draft only needs to be present so PlayerItemList's id-matching
+    // deep-link can find and open it; it's kept out of the rendered rows via
+    // hiddenItemIds below.
+    return draftTask ? [...flat, draftTask] : flat;
+  }, [groupedTasks, draftTask]);
+
+  const hiddenItemIds = useMemo(
+    () => (draftTask ? new Set<number>([draftTask.id]) : undefined),
+    [draftTask]
   );
 
   const childrenByGroupParentId = useMemo(
@@ -223,7 +258,6 @@ export function useTasksPanel(openTaskId?: number | null, onOpenNote?: (noteId: 
         ...(options?.due_at !== undefined ? { due_at: options.due_at } : {}),
       });
       setNewName("");
-      setAddSubtaskParent(null);
     },
     [createTask]
   );
@@ -231,28 +265,62 @@ export function useTasksPanel(openTaskId?: number | null, onOpenNote?: (noteId: 
   const handleSubmitForm = useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      handleCreateTask(newName, { parent: addSubtaskParent?.id ?? undefined });
+      handleCreateTask(newName);
     },
-    [handleCreateTask, newName, addSubtaskParent]
+    [handleCreateTask, newName]
   );
 
   const startAddSubtask = useCallback((task: ItemRecord) => {
-    setAddSubtaskParent(task);
+    const draft = makeDraftSubtask(task.id);
+    setDraftTask(draft);
+    // Reuses the same one-shot open mechanism as reopening a just-created
+    // task: PlayerItemList's deep-link effect only fires while openItemId is
+    // non-null, and onOpenItemHandled clears it straight back to null once
+    // the modal's opened, so it doesn't keep re-opening (and resetting the
+    // in-progress edit) on every subsequent render/keystroke.
+    setPendingOpenTaskId(draft.id);
   }, []);
 
-  const clearAddSubtaskParent = useCallback(() => {
-    setAddSubtaskParent(null);
+  const clearPendingOpenTaskId = useCallback(() => {
+    setPendingOpenTaskId(null);
+  }, []);
+
+  // Discards the draft if its modal is what just closed, i.e. the user
+  // opened "Add subtask" and closed it again without giving it a name.
+  const discardDraftTask = useCallback((item: ItemRecord) => {
+    setDraftTask((current) => (current && current.id === item.id ? null : current));
   }, []);
 
   const handleEdit = useCallback(
     (task: ItemRecord, name: string, callbacks?: { onSuccess?: () => void; onError?: () => void }) => {
+      // A draft subtask isn't persisted until it's actually given a name;
+      // commitNameEdit only calls onEdit once the name has genuinely
+      // changed, so this only fires on the user's first real edit.
+      if (task.id < 0) {
+        createTask.mutate(
+          { name, parent: task.parent },
+          {
+            onSuccess: (created) => {
+              setDraftTask(null);
+              setPendingOpenTaskId(created.id);
+              callbacks?.onSuccess?.();
+            },
+            onError: callbacks?.onError,
+          }
+        );
+        return;
+      }
       updateTask.mutate({ id: task.id, data: { name } }, callbacks);
     },
-    [updateTask]
+    [createTask, updateTask]
   );
 
   const handleDelete = useCallback(
     (task: Task) => {
+      if (task.id < 0) {
+        setDraftTask(null);
+        return;
+      }
       deleteTask.mutate(task.id);
     },
     [deleteTask]
@@ -260,6 +328,7 @@ export function useTasksPanel(openTaskId?: number | null, onOpenNote?: (noteId: 
 
   const handleToggleComplete = useCallback(
     (task: Task) => {
+      if (task.id < 0) return;
       const completing = !isTaskComplete(task);
       updateTask.mutate(
         {
@@ -331,9 +400,12 @@ export function useTasksPanel(openTaskId?: number | null, onOpenNote?: (noteId: 
     groupedTasks,
     getChildren,
     topLevelTasks,
-    addSubtaskParent,
+    pendingOpenTaskId,
+    draftTask,
+    hiddenItemIds,
     startAddSubtask,
-    clearAddSubtaskParent,
+    clearPendingOpenTaskId,
+    discardDraftTask,
     handleCreateTask,
     handleSubmitForm,
     handleEdit,

--- a/frontend/src/utils/formatUtils.test.ts
+++ b/frontend/src/utils/formatUtils.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   formatDueAt,
-  toDatetimeLocalValue,
-  fromDatetimeLocalValue,
+  toDateInputValue,
+  toTimeInputValue,
+  fromDateAndTimeInputValues,
   isOverdue,
 } from "./formatUtils";
 
@@ -85,33 +86,69 @@ describe("formatDueAt", () => {
   });
 });
 
-describe("toDatetimeLocalValue", () => {
+describe("toDateInputValue", () => {
   it("returns an empty string when null", () => {
-    expect(toDatetimeLocalValue(null)).toBe("");
+    expect(toDateInputValue(null)).toBe("");
   });
 
-  it("formats a valid ISO string as YYYY-MM-DDTHH:mm", () => {
-    const value = toDatetimeLocalValue("2026-05-01T08:30:00.000Z");
-    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+  it("formats a valid ISO string as YYYY-MM-DD", () => {
+    const value = toDateInputValue("2026-05-01T08:30:00.000Z");
+    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });
 
-describe("fromDatetimeLocalValue", () => {
-  it("returns null for an empty string", () => {
-    expect(fromDatetimeLocalValue("")).toBeNull();
+describe("toTimeInputValue", () => {
+  it("returns an empty string when null", () => {
+    expect(toTimeInputValue(null)).toBe("");
   });
 
-  it("converts a datetime-local value to an ISO string", () => {
-    const iso = fromDatetimeLocalValue("2026-05-01T08:30");
+  it("formats a valid ISO string as HH:mm", () => {
+    const value = toTimeInputValue("2026-05-01T08:30:00.000Z");
+    expect(value).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it("returns an empty string for the 23:59 no-time-set sentinel", () => {
+    const localMidnight = new Date(2026, 4, 1, 23, 59);
+    expect(toTimeInputValue(localMidnight.toISOString())).toBe("");
+  });
+});
+
+describe("fromDateAndTimeInputValues", () => {
+  it("returns null when both inputs are empty", () => {
+    expect(fromDateAndTimeInputValues("", "")).toBeNull();
+  });
+
+  it("converts a date and time to an ISO string", () => {
+    const iso = fromDateAndTimeInputValues("2026-05-01", "08:30");
     expect(iso).not.toBeNull();
     expect(new Date(iso as string).getFullYear()).toBe(2026);
   });
 
-  it("round-trips through toDatetimeLocalValue", () => {
+  it("defaults the date to today when only a time is given", () => {
+    const iso = fromDateAndTimeInputValues("", "08:30") as string;
+    const result = new Date(iso);
+    const today = new Date();
+    expect(result.getFullYear()).toBe(today.getFullYear());
+    expect(result.getMonth()).toBe(today.getMonth());
+    expect(result.getDate()).toBe(today.getDate());
+    expect(result.getHours()).toBe(8);
+    expect(result.getMinutes()).toBe(30);
+  });
+
+  it("defaults the time to 23:59 when only a date is given", () => {
+    const iso = fromDateAndTimeInputValues("2026-05-01", "") as string;
+    const result = new Date(iso);
+    expect(result.getHours()).toBe(23);
+    expect(result.getMinutes()).toBe(59);
+  });
+
+  it("round-trips through toDateInputValue and toTimeInputValue", () => {
     const original = "2026-05-01T08:30:00.000Z";
-    const localValue = toDatetimeLocalValue(original);
-    const roundTripped = fromDatetimeLocalValue(localValue);
-    expect(toDatetimeLocalValue(roundTripped)).toBe(localValue);
+    const dateValue = toDateInputValue(original);
+    const timeValue = toTimeInputValue(original);
+    const roundTripped = fromDateAndTimeInputValues(dateValue, timeValue);
+    expect(toDateInputValue(roundTripped)).toBe(dateValue);
+    expect(toTimeInputValue(roundTripped)).toBe(timeValue);
   });
 });
 

--- a/frontend/src/utils/formatUtils.ts
+++ b/frontend/src/utils/formatUtils.ts
@@ -122,25 +122,47 @@ export function formatDueAt(dueAt: string | null): string {
   return `${weekday} ${day}${ordinalSuffix(day)} ${month}`;
 }
 
-export function toDatetimeLocalValue(dueAt: string | null): string {
+// Sentinel time used to represent "date set, no time set" — see fromDateAndTimeInputValues.
+const END_OF_DAY_TIME = "23:59";
+
+function todayLocalDateValue(): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const now = new Date();
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+}
+
+export function toDateInputValue(dueAt: string | null): string {
   if (!dueAt) return "";
   const date = new Date(dueAt);
   if (Number.isNaN(date.getTime())) return "";
 
   const pad = (n: number) => String(n).padStart(2, "0");
-  const year = date.getFullYear();
-  const month = pad(date.getMonth() + 1);
-  const day = pad(date.getDate());
-  const hours = pad(date.getHours());
-  const minutes = pad(date.getMinutes());
-
-  return `${year}-${month}-${day}T${hours}:${minutes}`;
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
 }
 
-export function fromDatetimeLocalValue(value: string): string | null {
-  if (!value) return null;
-  const date = new Date(value);
+export function toTimeInputValue(dueAt: string | null): string {
+  if (!dueAt) return "";
+  const date = new Date(dueAt);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  // 23:59 is the sentinel for "no time set" (see fromDateAndTimeInputValues), so it
+  // displays as an empty time field rather than a literal end-of-day time.
+  if (hours === 23 && minutes === 59) return "";
+
+  return `${pad(hours)}:${pad(minutes)}`;
+}
+
+export function fromDateAndTimeInputValues(dateValue: string, timeValue: string): string | null {
+  if (!dateValue && !timeValue) return null;
+
+  const effectiveDate = dateValue || todayLocalDateValue();
+  const effectiveTime = timeValue || END_OF_DAY_TIME;
+  const date = new Date(`${effectiveDate}T${effectiveTime}`);
   if (Number.isNaN(date.getTime())) return null;
+
   return date.toISOString();
 }
 


### PR DESCRIPTION
## Summary
- Display a parent task chip in the task edit modal (select/remove), and split the due-date input into separate date/time fields (#762).
- Move task timestamp display (created/modified/completed) out of the inline summary into a clock-icon tooltip on the edit modal's title row (#764).
- Rework "Add a subtask": clicking it now opens the same task edit/detail modal used everywhere else, seeded with a blank, unsaved draft, instead of adding a "Subtask of X" chip before the task input (#774). The draft is only actually created once its name has been genuinely edited; closing the modal without editing the name discards the draft with no API call.
- Add `PlayerItemList` `hiddenItemIds` (keep an item deep-linkable without rendering it as a row) and `onModalClose` (notify the caller which item's modal just closed) to support the draft-subtask flow.

## Testing
- `npx tsc --noEmit -p .` — clean
- `npx eslint` on touched files — clean
- `npx vitest run` — 561/561 passing (one pre-existing, unrelated Storybook/chromium browser-connection timeout, not a test failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)