### PR TITLE
Re-enable player-presence XP modifiers and add live character productivity

### DIFF
--- a/character/models/character.py
+++ b/character/models/character.py
@@ -520,6 +520,15 @@ class Character(LevelProgressionMixin, LifeCycleMixin, Movable):
         """
         return PlayerCharacterLink.total_link_points(self.links.all())
 
+    def get_productivity(self, now=None):
+        """
+        Live productivity signal - see progression.ap.get_productivity for
+        what drives it (authored baseline x current active XpModifiers).
+        """
+        from progression import ap
+
+        return ap.get_productivity(self, now=now)
+
 
 ########################################################################
 ####    PLAYER CHARACTER LINK MODEL

--- a/gameplay/services/xp_modifiers.py
+++ b/gameplay/services/xp_modifiers.py
@@ -13,20 +13,34 @@ PLAYER_ONLINE_MULTIPLIER = 1.25
 ACTIVITY_ACTIVE_KEY = "activity_active"
 ACTIVITY_ACTIVE_CHARACTER_MULTIPLIER = 1.5
 ACTIVITY_ACTIVE_PLAYER_MULTIPLIER = 1.25
+# Grace window before an activity_active modifier actually ends once a
+# player stops timing, so a gap between a character's activity blocks (or a
+# quick pause/resume) doesn't drop and reactivate the boost - see issue #750.
+ACTIVITY_ACTIVE_GRACE_MINUTES = 5
 
 
 @transaction.atomic
 def activate_link_modifier(
-    *, link, key: str, multiplier, duration=None, ends_at=None, now=None
+    *,
+    link,
+    key: str,
+    multiplier,
+    scope=XpModifier.Scope.CHARACTER,
+    duration=None,
+    ends_at=None,
+    now=None,
 ):
     now = now or timezone.now()
     if ends_at is None and duration is not None:
         ends_at = now + duration
 
+    owner_field = "character" if scope == XpModifier.Scope.CHARACTER else "player"
+    owner = link.character if scope == XpModifier.Scope.CHARACTER else link.player
+
     mod, _created = XpModifier.objects.update_or_create(
-        scope=XpModifier.Scope.CHARACTER,
-        character=link.character,
+        scope=scope,
         key=key,
+        **{owner_field: owner},
         defaults={
             "multiplier": multiplier,
             "starts_at": now,
@@ -78,81 +92,47 @@ def schedule_modifier_end(
 
 @transaction.atomic
 def schedule_online_end(link: PlayerCharacterLink, cooldown_minutes=30):
-    # player_online modifiers are temporarily disabled while premium activity XP
-    # is being isolated and verified.
-    return None
-    # now = timezone.now()
-    # ends_at = now + timedelta(minutes=cooldown_minutes)
-    #
-    # mod = (
-    #     XpModifier.objects.filter(
-    #         scope=XpModifier.Scope.CHARACTER,
-    #         character=link.character,
-    #         key=PLAYER_ONLINE_KEY,
-    #     )
-    #     .order_by("-starts_at")
-    #     .first()
-    # )
-    # if mod:
-    #     mod.multiplier = PLAYER_ONLINE_MULTIPLIER
-    #     mod.is_active = True
-    #     mod.save(update_fields=["multiplier", "is_active"])
-    # else:
-    #     mod = XpModifier.objects.create(
-    #         scope=XpModifier.Scope.CHARACTER,
-    #         character=link.character,
-    #         key=PLAYER_ONLINE_KEY,
-    #         multiplier=PLAYER_ONLINE_MULTIPLIER,
-    #         starts_at=now,
-    #         ends_at=None,
-    #         is_active=True,
-    #     )
-    #
-    # return schedule_modifier_end(mod=mod, ends_at=ends_at)
+    """
+    Called when a player disconnects: keep the player_online modifier active
+    for `cooldown_minutes` instead of ending it immediately, so a brief
+    reconnect doesn't cost the character its boost, then let the scheduled
+    Celery task end it if the player doesn't come back in time.
+    """
+    now = timezone.now()
+    ends_at = now + timedelta(minutes=cooldown_minutes)
+
+    mod = activate_link_modifier(
+        link=link,
+        key=PLAYER_ONLINE_KEY,
+        multiplier=PLAYER_ONLINE_MULTIPLIER,
+        now=now,
+    )
+    return schedule_modifier_end(mod=mod, ends_at=ends_at)
 
 
 @transaction.atomic
 def handle_online_login(player: Player):
-    # player_online modifiers are temporarily disabled while premium activity XP
-    # is being isolated and verified.
-    return None
-    # link = player.active_link
-    # if not link:
-    #     return None
-    # link = PlayerCharacterLink.objects.get(id=link.id)
-    # mod = (
-    #     XpModifier.objects.filter(
-    #         scope=XpModifier.Scope.CHARACTER,
-    #         character=link.character,
-    #         key=PLAYER_ONLINE_KEY,
-    #     )
-    #     .order_by("-starts_at")
-    #     .first()
-    # )
-    #
-    # now = timezone.now()
-    #
-    # if not mod:
-    #     mod = XpModifier.objects.create(
-    #         scope=XpModifier.Scope.CHARACTER,
-    #         character=link.character,
-    #         key=PLAYER_ONLINE_KEY,
-    #         multiplier=PLAYER_ONLINE_MULTIPLIER,
-    #         starts_at=now,
-    #         ends_at=None,
-    #         is_active=True,
-    #         task_id=None,
-    #     )
-    #     return mod
-    # if mod.task_id:
-    #     current_app.control.revoke(mod.task_id)
-    #     mod.task_id = None
-    #
-    # mod.multiplier = PLAYER_ONLINE_MULTIPLIER
-    # mod.is_active = True
-    # mod.ends_at = None
-    # mod.save(update_fields=["multiplier", "is_active", "ends_at", "task_id"])
-    # return mod
+    """
+    Called whenever a player is confirmed online (login, or any
+    authenticated poll while connected): (re)activate the player_online
+    character modifier and cancel any cooldown-end task left over from a
+    previous disconnect.
+    """
+    link = player.active_link
+    if not link:
+        return None
+    link = PlayerCharacterLink.objects.select_related("character").get(id=link.id)
+
+    mod = activate_link_modifier(
+        link=link,
+        key=PLAYER_ONLINE_KEY,
+        multiplier=PLAYER_ONLINE_MULTIPLIER,
+    )
+    if mod.task_id:
+        current_app.control.revoke(mod.task_id)
+        mod.task_id = None
+        mod.save(update_fields=["task_id"])
+    return mod
 
 
 @transaction.atomic
@@ -162,73 +142,58 @@ def set_activity_active_modifiers(player: Player, *, is_active: bool):
 
     - Character gets a higher bonus while player is actively recording.
     - Player gets their own bonus while actively recording.
+
+    Stopping doesn't end the modifiers outright: `ends_at` is pushed out by
+    ACTIVITY_ACTIVE_GRACE_MINUTES and a Celery task is scheduled to end them
+    then. If the player starts another activity within that window,
+    activate_link_modifier's update_or_create refreshes the same modifier
+    row (and the pending end task is cancelled) rather than dropping and
+    reactivating it.
     """
-    # activity_active modifiers are temporarily disabled while premium activity
-    # XP is being isolated and verified.
-    return []
-    # link = player.active_link
-    # if not link:
-    #     return []
-    #
-    # link = PlayerCharacterLink.objects.select_related("character", "player").get(
-    #     id=link.id
-    # )
-    # now = timezone.now()
-    #
-    # character_mod = (
-    #     XpModifier.objects.filter(
-    #         scope=XpModifier.Scope.CHARACTER,
-    #         character=link.character,
-    #         key=ACTIVITY_ACTIVE_KEY,
-    #     )
-    #     .order_by("-starts_at")
-    #     .first()
-    # )
-    # if not character_mod and is_active:
-    #     character_mod = XpModifier.objects.create(
-    #         scope=XpModifier.Scope.CHARACTER,
-    #         character=link.character,
-    #         key=ACTIVITY_ACTIVE_KEY,
-    #         multiplier=ACTIVITY_ACTIVE_CHARACTER_MULTIPLIER,
-    #         starts_at=now,
-    #         ends_at=None,
-    #         is_active=True,
-    #         task_id=None,
-    #     )
-    # elif character_mod:
-    #     character_mod.multiplier = ACTIVITY_ACTIVE_CHARACTER_MULTIPLIER
-    #     character_mod.is_active = is_active
-    #     character_mod.ends_at = None if is_active else now
-    #     character_mod.task_id = None
-    #     character_mod.save(
-    #         update_fields=["multiplier", "is_active", "ends_at", "task_id"]
-    #     )
-    #
-    # player_mod = (
-    #     XpModifier.objects.filter(
-    #         scope=XpModifier.Scope.PLAYER,
-    #         player=link.player,
-    #         key=ACTIVITY_ACTIVE_KEY,
-    #     )
-    #     .order_by("-starts_at")
-    #     .first()
-    # )
-    # if not player_mod and is_active:
-    #     player_mod = XpModifier.objects.create(
-    #         scope=XpModifier.Scope.PLAYER,
-    #         player=link.player,
-    #         key=ACTIVITY_ACTIVE_KEY,
-    #         multiplier=ACTIVITY_ACTIVE_PLAYER_MULTIPLIER,
-    #         starts_at=now,
-    #         ends_at=None,
-    #         is_active=True,
-    #         task_id=None,
-    #     )
-    # elif player_mod:
-    #     player_mod.multiplier = ACTIVITY_ACTIVE_PLAYER_MULTIPLIER
-    #     player_mod.is_active = is_active
-    #     player_mod.ends_at = None if is_active else now
-    #     player_mod.task_id = None
-    #     player_mod.save(update_fields=["multiplier", "is_active", "ends_at", "task_id"])
-    #
-    # return [m for m in [character_mod, player_mod] if m]
+    link = player.active_link
+    if not link:
+        return []
+
+    link = PlayerCharacterLink.objects.select_related("character", "player").get(
+        id=link.id
+    )
+
+    if is_active:
+        mods = [
+            activate_link_modifier(
+                link=link,
+                key=ACTIVITY_ACTIVE_KEY,
+                multiplier=ACTIVITY_ACTIVE_CHARACTER_MULTIPLIER,
+                scope=XpModifier.Scope.CHARACTER,
+            ),
+            activate_link_modifier(
+                link=link,
+                key=ACTIVITY_ACTIVE_KEY,
+                multiplier=ACTIVITY_ACTIVE_PLAYER_MULTIPLIER,
+                scope=XpModifier.Scope.PLAYER,
+            ),
+        ]
+        for mod in mods:
+            if mod.task_id:
+                current_app.control.revoke(mod.task_id)
+                mod.task_id = None
+                mod.save(update_fields=["task_id"])
+        return mods
+
+    grace_ends_at = timezone.now() + timedelta(minutes=ACTIVITY_ACTIVE_GRACE_MINUTES)
+    mods = []
+    for scope, owner_field, owner in (
+        (XpModifier.Scope.CHARACTER, "character", link.character),
+        (XpModifier.Scope.PLAYER, "player", link.player),
+    ):
+        mod = (
+            XpModifier.objects.filter(
+                scope=scope, key=ACTIVITY_ACTIVE_KEY, **{owner_field: owner}
+            )
+            .order_by("-starts_at")
+            .first()
+        )
+        if mod and mod.is_active:
+            mods.append(schedule_modifier_end(mod=mod, ends_at=grace_ends_at))
+
+    return mods

--- a/gameplay/tests/test_xp_modifiers.py
+++ b/gameplay/tests/test_xp_modifiers.py
@@ -1,0 +1,288 @@
+from datetime import timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from character.models import Character, PlayerCharacterLink
+from gameplay.models import XpModifier
+from gameplay.services import xp_modifiers as xpm
+from progression.models import ActivityDefinition, CharacterActivity
+
+from users.tests import user_factory
+
+
+def _linked_player_and_character():
+    user = user_factory(with_player=True)
+    player = user.player
+    character = Character.objects.create(given_name="Hero")
+    link = PlayerCharacterLink.objects.create(player=player, character=character)
+    return player, character, link
+
+
+class ActivateLinkModifierTests(TestCase):
+    def setUp(self):
+        self.player, self.character, self.link = _linked_player_and_character()
+
+    def test_defaults_to_character_scope(self):
+        mod = xpm.activate_link_modifier(
+            link=self.link, key="test_key", multiplier=Decimal("1.5")
+        )
+        self.assertEqual(mod.scope, XpModifier.Scope.CHARACTER)
+        self.assertEqual(mod.character_id, self.character.id)
+        self.assertIsNone(mod.player_id)
+        self.assertTrue(mod.is_active)
+        self.assertIsNone(mod.ends_at)
+
+    def test_can_target_player_scope(self):
+        mod = xpm.activate_link_modifier(
+            link=self.link,
+            key="test_key",
+            multiplier=Decimal("1.25"),
+            scope=XpModifier.Scope.PLAYER,
+        )
+        self.assertEqual(mod.scope, XpModifier.Scope.PLAYER)
+        self.assertEqual(mod.player_id, self.player.id)
+        self.assertIsNone(mod.character_id)
+
+    def test_second_call_updates_same_row_instead_of_duplicating(self):
+        first = xpm.activate_link_modifier(
+            link=self.link, key="test_key", multiplier=Decimal("1.5")
+        )
+        second = xpm.activate_link_modifier(
+            link=self.link, key="test_key", multiplier=Decimal("2.0")
+        )
+        self.assertEqual(first.id, second.id)
+        self.assertEqual(XpModifier.objects.filter(key="test_key").count(), 1)
+        self.assertEqual(second.multiplier, Decimal("2.0"))
+
+    def test_duration_computes_ends_at(self):
+        now = timezone.now()
+        mod = xpm.activate_link_modifier(
+            link=self.link,
+            key="test_key",
+            multiplier=Decimal("1.5"),
+            duration=timedelta(minutes=30),
+            now=now,
+        )
+        self.assertEqual(mod.ends_at, now + timedelta(minutes=30))
+
+
+class HandleOnlineLoginTests(TestCase):
+    def setUp(self):
+        self.user = user_factory(with_player=True)
+        self.player = self.user.player
+        self.character = Character.objects.create(given_name="Hero")
+
+    def test_returns_none_without_active_link(self):
+        self.assertIsNone(xpm.handle_online_login(self.player))
+        self.assertFalse(XpModifier.objects.exists())
+
+    def test_activates_indefinite_player_online_modifier(self):
+        PlayerCharacterLink.objects.create(player=self.player, character=self.character)
+        mod = xpm.handle_online_login(self.player)
+        self.assertIsNotNone(mod)
+        self.assertEqual(mod.key, xpm.PLAYER_ONLINE_KEY)
+        self.assertEqual(mod.scope, XpModifier.Scope.CHARACTER)
+        self.assertEqual(mod.character_id, self.character.id)
+        self.assertEqual(mod.multiplier, Decimal(str(xpm.PLAYER_ONLINE_MULTIPLIER)))
+        self.assertTrue(mod.is_active)
+        self.assertIsNone(mod.ends_at)
+
+    def test_relogin_cancels_pending_cooldown_end_task(self):
+        link = PlayerCharacterLink.objects.create(
+            player=self.player, character=self.character
+        )
+        mock_result = MagicMock(id="scheduled-task-id")
+        with patch.object(
+            xpm.end_online_boost, "apply_async", return_value=mock_result
+        ):
+            xpm.schedule_online_end(link)
+
+        mod = XpModifier.objects.get(key=xpm.PLAYER_ONLINE_KEY)
+        self.assertEqual(mod.task_id, "scheduled-task-id")
+        self.assertIsNotNone(mod.ends_at)
+
+        with patch.object(xpm, "current_app") as mock_app:
+            xpm.handle_online_login(self.player)
+
+        mock_app.control.revoke.assert_called_once_with("scheduled-task-id")
+        mod.refresh_from_db()
+        self.assertIsNone(mod.task_id)
+        self.assertIsNone(mod.ends_at)
+        self.assertTrue(mod.is_active)
+
+
+class ScheduleOnlineEndTests(TestCase):
+    def setUp(self):
+        self.player, self.character, self.link = _linked_player_and_character()
+
+    def test_schedules_end_after_cooldown_instead_of_ending_immediately(self):
+        mock_result = MagicMock(id="scheduled-task-id")
+        with patch.object(
+            xpm.end_online_boost, "apply_async", return_value=mock_result
+        ) as mock_apply_async:
+            xpm.schedule_online_end(self.link, cooldown_minutes=30)
+
+        mod = XpModifier.objects.get(key=xpm.PLAYER_ONLINE_KEY)
+        self.assertTrue(mod.is_active)
+        self.assertIsNotNone(mod.ends_at)
+        self.assertAlmostEqual(
+            mod.ends_at,
+            timezone.now() + timedelta(minutes=30),
+            delta=timedelta(seconds=5),
+        )
+        self.assertEqual(mod.task_id, "scheduled-task-id")
+        mock_apply_async.assert_called_once()
+        self.assertEqual(
+            mock_apply_async.call_args.kwargs["kwargs"], {"modifier_id": mod.id}
+        )
+
+
+class SetActivityActiveModifiersTests(TestCase):
+    def setUp(self):
+        self.player, self.character, self.link = _linked_player_and_character()
+
+    def test_returns_empty_list_without_active_link(self):
+        user = user_factory(with_player=True)
+        self.assertEqual(
+            xpm.set_activity_active_modifiers(user.player, is_active=True), []
+        )
+        self.assertFalse(XpModifier.objects.exists())
+
+    def test_activating_creates_character_and_player_modifiers(self):
+        mods = xpm.set_activity_active_modifiers(self.player, is_active=True)
+        self.assertEqual(len(mods), 2)
+
+        character_mod = XpModifier.objects.get(
+            scope=XpModifier.Scope.CHARACTER, key=xpm.ACTIVITY_ACTIVE_KEY
+        )
+        self.assertEqual(character_mod.character_id, self.character.id)
+        self.assertEqual(
+            character_mod.multiplier,
+            Decimal(str(xpm.ACTIVITY_ACTIVE_CHARACTER_MULTIPLIER)),
+        )
+        self.assertTrue(character_mod.is_active)
+        self.assertIsNone(character_mod.ends_at)
+
+        player_mod = XpModifier.objects.get(
+            scope=XpModifier.Scope.PLAYER, key=xpm.ACTIVITY_ACTIVE_KEY
+        )
+        self.assertEqual(player_mod.player_id, self.player.id)
+        self.assertEqual(
+            player_mod.multiplier, Decimal(str(xpm.ACTIVITY_ACTIVE_PLAYER_MULTIPLIER))
+        )
+
+    def test_deactivating_without_prior_activation_does_nothing(self):
+        mods = xpm.set_activity_active_modifiers(self.player, is_active=False)
+        self.assertEqual(mods, [])
+        self.assertFalse(XpModifier.objects.exists())
+
+    def test_deactivating_extends_ends_at_instead_of_ending_immediately(self):
+        xpm.set_activity_active_modifiers(self.player, is_active=True)
+
+        mock_result = MagicMock(id="grace-task-id")
+        with patch.object(
+            xpm.end_online_boost, "apply_async", return_value=mock_result
+        ):
+            xpm.set_activity_active_modifiers(self.player, is_active=False)
+
+        character_mod = XpModifier.objects.get(
+            scope=XpModifier.Scope.CHARACTER, key=xpm.ACTIVITY_ACTIVE_KEY
+        )
+        player_mod = XpModifier.objects.get(
+            scope=XpModifier.Scope.PLAYER, key=xpm.ACTIVITY_ACTIVE_KEY
+        )
+
+        for mod in (character_mod, player_mod):
+            self.assertTrue(mod.is_active)
+            self.assertIsNotNone(mod.ends_at)
+            self.assertAlmostEqual(
+                mod.ends_at,
+                timezone.now() + timedelta(minutes=xpm.ACTIVITY_ACTIVE_GRACE_MINUTES),
+                delta=timedelta(seconds=5),
+            )
+            self.assertEqual(mod.task_id, "grace-task-id")
+
+    def test_reactivating_within_grace_window_refreshes_and_cancels_pending_end(self):
+        xpm.set_activity_active_modifiers(self.player, is_active=True)
+
+        mock_result = MagicMock(id="grace-task-id")
+        with patch.object(
+            xpm.end_online_boost, "apply_async", return_value=mock_result
+        ):
+            xpm.set_activity_active_modifiers(self.player, is_active=False)
+
+        with patch.object(xpm, "current_app") as mock_app:
+            xpm.set_activity_active_modifiers(self.player, is_active=True)
+
+        self.assertEqual(mock_app.control.revoke.call_count, 2)
+
+        character_mod = XpModifier.objects.get(
+            scope=XpModifier.Scope.CHARACTER, key=xpm.ACTIVITY_ACTIVE_KEY
+        )
+        player_mod = XpModifier.objects.get(
+            scope=XpModifier.Scope.PLAYER, key=xpm.ACTIVITY_ACTIVE_KEY
+        )
+        for mod in (character_mod, player_mod):
+            self.assertTrue(mod.is_active)
+            self.assertIsNone(mod.ends_at)
+            self.assertIsNone(mod.task_id)
+
+        # Refreshed the existing rows rather than creating new ones.
+        self.assertEqual(
+            XpModifier.objects.filter(key=xpm.ACTIVITY_ACTIVE_KEY).count(), 2
+        )
+
+
+class CharacterActivityRewardConsumptionTests(TestCase):
+    """
+    Confirms CharacterActivity.get_xp_reward_summary() (progression/models.py)
+    still picks up the modifiers these functions create, now that they're
+    live again - see issue #750.
+    """
+
+    def setUp(self):
+        self.player, self.character, self.link = _linked_player_and_character()
+        self.activity_definition = ActivityDefinition.objects.create(
+            name="tending crops", kind=ActivityDefinition.Kind.WORK
+        )
+
+    def _make_activity(self, duration=600):
+        now = timezone.now()
+        return CharacterActivity.objects.create(
+            character=self.character,
+            activity_definition=self.activity_definition,
+            started_at=now - timedelta(seconds=duration),
+            duration=duration,
+        )
+
+    def test_no_active_modifiers_gives_unboosted_reward(self):
+        activity = self._make_activity()
+        summary = activity.get_xp_reward_summary()
+        self.assertEqual(summary["boost_multiplier"], 1)
+
+    def test_player_online_modifier_boosts_reward(self):
+        xpm.handle_online_login(self.player)
+        activity = self._make_activity()
+        summary = activity.get_xp_reward_summary()
+        self.assertEqual(summary["boost_multiplier"], xpm.PLAYER_ONLINE_MULTIPLIER)
+
+    def test_activity_active_modifier_boosts_reward(self):
+        xpm.set_activity_active_modifiers(self.player, is_active=True)
+        activity = self._make_activity()
+        summary = activity.get_xp_reward_summary()
+        self.assertEqual(
+            summary["boost_multiplier"], xpm.ACTIVITY_ACTIVE_CHARACTER_MULTIPLIER
+        )
+
+    def test_stacked_modifiers_multiply(self):
+        xpm.handle_online_login(self.player)
+        xpm.set_activity_active_modifiers(self.player, is_active=True)
+        activity = self._make_activity()
+        summary = activity.get_xp_reward_summary()
+        expected = (
+            xpm.PLAYER_ONLINE_MULTIPLIER * xpm.ACTIVITY_ACTIVE_CHARACTER_MULTIPLIER
+        )
+        self.assertEqual(summary["boost_multiplier"], expected)

--- a/progression/ap.py
+++ b/progression/ap.py
@@ -79,3 +79,25 @@ def get_multiplier(person, now=None) -> Decimal:
         mult *= m.multiplier
 
     return mult
+
+
+# Authored baseline productivity for every character - flat for v1, may
+# later factor in role/mood/history (see issue #750).
+CHARACTER_BASELINE_PRODUCTIVITY = Decimal("1.0")
+
+
+def get_productivity(character, now=None) -> Decimal:
+    """
+    Live "how productive is this character right now" signal: the authored
+    baseline times whatever XpModifier multiplier is currently active on the
+    character (player-online / player-actively-timing boosts - see
+    gameplay.services.xp_modifiers).
+
+    Deliberately not derived from lifetime AP total - an old character
+    accumulates AP over a long life regardless of whether a player is
+    currently engaged with it, which would read as misleadingly
+    "productive". Reading live modifier state instead gives instant
+    feedback: productivity moves the moment a boost activates or clears, no
+    averaging/smoothing/lag.
+    """
+    return CHARACTER_BASELINE_PRODUCTIVITY * get_multiplier(character, now=now)

--- a/progression/tests/test_ap.py
+++ b/progression/tests/test_ap.py
@@ -140,3 +140,57 @@ class GetMultiplierTests(TestCase):
             is_active=True,
         )
         self.assertEqual(ap.get_multiplier(player, now=self.now), Decimal("1.5"))
+
+
+class GetProductivityTests(TestCase):
+    def setUp(self):
+        self.character = Character.objects.create(given_name="Test")
+        self.now = timezone.now()
+
+    def test_no_modifiers_returns_baseline(self):
+        self.assertEqual(
+            ap.get_productivity(self.character, now=self.now),
+            ap.CHARACTER_BASELINE_PRODUCTIVITY,
+        )
+
+    def test_active_modifier_scales_baseline(self):
+        XpModifier.objects.create(
+            scope=XpModifier.Scope.CHARACTER,
+            character=self.character,
+            key="test_modifier",
+            multiplier=Decimal("1.5"),
+            starts_at=self.now - timedelta(hours=1),
+            is_active=True,
+        )
+        self.assertEqual(
+            ap.get_productivity(self.character, now=self.now),
+            ap.CHARACTER_BASELINE_PRODUCTIVITY * Decimal("1.5"),
+        )
+
+    def test_inactive_modifier_excluded(self):
+        XpModifier.objects.create(
+            scope=XpModifier.Scope.CHARACTER,
+            character=self.character,
+            key="test_modifier",
+            multiplier=Decimal("2"),
+            starts_at=self.now - timedelta(hours=1),
+            is_active=False,
+        )
+        self.assertEqual(
+            ap.get_productivity(self.character, now=self.now),
+            ap.CHARACTER_BASELINE_PRODUCTIVITY,
+        )
+
+    def test_character_get_productivity_matches_ap_function(self):
+        XpModifier.objects.create(
+            scope=XpModifier.Scope.CHARACTER,
+            character=self.character,
+            key="test_modifier",
+            multiplier=Decimal("1.25"),
+            starts_at=self.now - timedelta(hours=1),
+            is_active=True,
+        )
+        self.assertEqual(
+            self.character.get_productivity(now=self.now),
+            ap.get_productivity(self.character, now=self.now),
+        )


### PR DESCRIPTION
## Summary

Closes #750.

`XpModifier` and its consumption path (`progression/ap.py get_multiplier` → `progression/mixins.py get_xp_multiplier` → `CharacterActivity.get_xp_reward_summary`) were fully built but non-functional: `handle_online_login`, `set_activity_active_modifiers`, and `schedule_online_end` were all disabled with early returns in `870afd2`, pending premium-XP isolation work (now done). This re-enables them per the design decisions on the issue:

- Re-enabled the three functions, all routing modifier creation through the existing `activate_link_modifier` helper rather than reimplementing it. `activate_link_modifier` gained a `scope` parameter (default `CHARACTER`) so it can also create the `PLAYER`-scope modifier `set_activity_active_modifiers` needs, without duplicating its `update_or_create` logic.
- Added grace-period handling to the `activity_active` end path: stopping an activity no longer ends the modifier immediately — `ends_at` is pushed out by `ACTIVITY_ACTIVE_GRACE_MINUTES` (5 min) via the existing `schedule_modifier_end`/`end_online_boost` machinery already used for the `player_online` cooldown. Starting another activity inside that window refreshes the same modifier row (`activate_link_modifier`'s `update_or_create`) and cancels the pending end task, instead of a drop-then-reactivate.
- Added `progression.ap.get_productivity` / `Character.get_productivity`: an authored baseline (flat constant for v1, `CHARACTER_BASELINE_PRODUCTIVITY`) times whatever `XpModifier` multiplier is currently active on the character — read live, not derived from lifetime AP total, per the issue's decision 3/4.
- Confirmed `CharacterActivity.get_xp_reward_summary()` still picks up active modifiers correctly now that they're live again (new integration tests below).

Out of scope, per the issue: renaming `XpModifier` to a generic `Modifier` model, modifier decay after disconnect, and shortening character activity duration for capacity/feel.

## Test plan

- [x] `gameplay/tests/test_xp_modifiers.py` (new) — `activate_link_modifier` scope handling and update-or-create refresh; `handle_online_login` activation and pending-task cancellation on relogin; `schedule_online_end` cooldown scheduling; `set_activity_active_modifiers` activation, grace-period deactivation, and in-window reactivation refresh; end-to-end `CharacterActivity.get_xp_reward_summary()` consumption with player-online, activity-active, and stacked modifiers.
- [x] `progression/tests/test_ap.py` — added `GetProductivityTests` covering baseline-only, active-modifier scaling, inactive-modifier exclusion, and `Character.get_productivity` matching `ap.get_productivity`.
- [x] Ran `gameplay`, `character`, `progression`, `api`, and `users` test suites locally (Postgres + PostGIS, no Docker available in this environment) — all passing except 4 pre-existing failures unrelated to this change (a `broadcast_activity_timer` mock-patch target issue in `test_disconnect_grace.py`/`test_stale_connection_sweep.py`, and a missing `staticfiles` manifest in this sandbox), confirmed to fail identically on `development` before this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8Siy6MEuhLq9kCa3ujBwf)_