### PR TITLE
feat: Storybook coverage — bucket 1 + layout chrome (#749)

### DIFF
--- a/frontend/.storybook/decorators/withAuthContext.tsx
+++ b/frontend/.storybook/decorators/withAuthContext.tsx
@@ -1,0 +1,19 @@
+import type { Decorator } from '@storybook/react-vite';
+import { AuthContext, type AuthContextValue } from '../../src/context/authContext';
+import { mockAuthContextValue } from '../../src/testUtils/mockAuthContext';
+
+/**
+ * Wraps a story in `AuthContext` with a mock value, for components that read
+ * `useAuth()` outside of a real session. `authenticated` controls whether the
+ * mock represents a logged-in or logged-out user; `overrides` reaches any
+ * other field (e.g. `user: { is_staff: true }`).
+ */
+export function withAuthContext(
+  overrides: Partial<AuthContextValue> & { authenticated?: boolean } = {}
+): Decorator {
+  return (Story) => (
+    <AuthContext.Provider value={mockAuthContextValue(overrides)}>
+      <Story />
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/.storybook/decorators/withGameContext.tsx
+++ b/frontend/.storybook/decorators/withGameContext.tsx
@@ -1,0 +1,14 @@
+import type { Decorator } from '@storybook/react-vite';
+import { GameContext } from '../../src/context/gameContext';
+import { mockGameContextValue } from '../../src/testUtils/mockGameContext';
+
+/**
+ * Wraps a story in `GameContext` with `mockGameContextValue`, for components
+ * that read `useGame()` (directly, or transitively via `useFeatureFlag`)
+ * outside of a real game session.
+ */
+export const withGameContext: Decorator = (Story) => (
+  <GameContext.Provider value={mockGameContextValue}>
+    <Story />
+  </GameContext.Provider>
+);

--- a/frontend/.storybook/decorators/withQueryClient.tsx
+++ b/frontend/.storybook/decorators/withQueryClient.tsx
@@ -1,0 +1,27 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { Decorator } from '@storybook/react-vite';
+
+/**
+ * Wraps a story in a fresh `QueryClient` per render, so components that call
+ * TanStack Query hooks (`useQuery`/`useQueryClient`) don't crash outside a
+ * provider. Retries are disabled - Storybook has no real API to fetch from,
+ * so a failed request should render its empty/error state immediately
+ * rather than retrying for several seconds.
+ *
+ * Seed data for a specific query (so a component renders populated instead
+ * of loading/empty) via a story's own decorator + `queryClient.setQueryData`,
+ * see `EntitySearchInput.stories.tsx` / `TutorialModal.stories.tsx`.
+ */
+export const withQueryClient: Decorator = (Story) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Story />
+    </QueryClientProvider>
+  );
+};

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,7 +1,13 @@
 import type { Preview } from '@storybook/react-vite';
 import '../src/styles/main.scss';
+import { withQueryClient } from './decorators/withQueryClient';
 
 const preview: Preview = {
+  // Global so any component that calls a TanStack Query hook - directly or
+  // transitively (e.g. `useFeatureFlag` -> `useAppConfig`) - doesn't crash
+  // for lack of a QueryClientProvider ancestor. See withQueryClient's
+  // comment for how a story seeds its own query data.
+  decorators: [withQueryClient],
   parameters: {
     controls: {
       matchers: {

--- a/frontend/src/components/Achievements/Achievements.stories.tsx
+++ b/frontend/src/components/Achievements/Achievements.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Achievements from './Achievements';
+
+/**
+ * `Achievements` renders a grid of achievement badges from a plain
+ * `achievements[]` prop - tier colour, progress bar, and the "time" vs.
+ * count value formatting are all derived from each achievement's fields.
+ */
+const meta: Meta<typeof Achievements> = {
+  title: 'Shared/Achievements',
+  component: Achievements,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Achievements>;
+
+export const Default: Story = {
+  args: {
+    achievements: [
+      {
+        type: 'tasks_completed',
+        label: 'Task Master',
+        symbol: '✅',
+        tier: 1,
+        complete: false,
+        color: 'grey',
+        value: 12,
+        threshold: 25,
+      },
+      {
+        type: 'tasks_completed',
+        label: 'Task Master',
+        symbol: '✅',
+        tier: 2,
+        complete: true,
+        color: 'green',
+        value: 50,
+        threshold: 50,
+      },
+      {
+        type: 'time',
+        label: 'Time Invested',
+        symbol: '⏱️',
+        tier: 3,
+        complete: false,
+        color: 'blue',
+        value: 5400,
+        threshold: 36000,
+      },
+      {
+        type: 'streak',
+        label: 'Consistency',
+        symbol: '🔥',
+        tier: 4,
+        complete: false,
+        color: 'purple',
+        value: 8,
+        threshold: 30,
+      },
+      {
+        type: 'level',
+        label: 'Levelled Up',
+        symbol: '⭐',
+        tier: 5,
+        complete: true,
+        color: 'gold',
+        value: 20,
+        threshold: 20,
+      },
+    ],
+  },
+};
+
+/** Every tier colour Achievements knows about (`grey`/`green`/`blue`/`purple`/`gold`), all mid-progress. */
+export const AllTiers: Story = {
+  args: {
+    achievements: (['grey', 'green', 'blue', 'purple', 'gold'] as const).map((color, i) => ({
+      type: 'tasks_completed',
+      label: `Tier ${i + 1}`,
+      symbol: '🏅',
+      tier: i + 1,
+      complete: false,
+      color,
+      value: (i + 1) * 5,
+      threshold: 50,
+    })),
+  },
+};
+
+export const Empty: Story = {
+  args: { achievements: [] },
+};

--- a/frontend/src/components/BackToTopButton/BackToTopButton.stories.tsx
+++ b/frontend/src/components/BackToTopButton/BackToTopButton.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import BackToTopButton from './BackToTopButton';
+
+/**
+ * `BackToTopButton` is a fixed-position button that smooth-scrolls the page
+ * to the top (instantly, if the user prefers reduced motion). No props -
+ * visibility/positioning is left to the page that mounts it.
+ */
+const meta: Meta<typeof BackToTopButton> = {
+  title: 'Shared/BackToTopButton',
+  component: BackToTopButton,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof BackToTopButton>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Back to top' })).toBeVisible();
+  },
+};

--- a/frontend/src/components/EntitySearchInput/EntitySearchInput.stories.tsx
+++ b/frontend/src/components/EntitySearchInput/EntitySearchInput.stories.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import EntitySearchInput from './EntitySearchInput';
+import { GameContext } from '../../context/gameContext';
+import { mockGameContextValue } from '../../testUtils/mockGameContext';
+
+/**
+ * `EntitySearchInput` is a fuzzy-search combobox over the player's past
+ * activities/tasks (`useEntitySearchCache`, a TanStack Query hook that in
+ * turn calls `useFeatureFlag` -> `useGame()`). The story seeds the cache's
+ * query directly and supplies a mock `GameContext` so it renders without a
+ * real API or game session - see `.storybook/decorators/`.
+ */
+const entities = [
+  { id: 'a1', name: 'Wash dishes', taskId: null, completedAt: null, source: 'activity', isOptimistic: false, frequency: 4 },
+  { id: 'a2', name: 'Write report', taskId: null, completedAt: null, source: 'activity', isOptimistic: false, frequency: 2 },
+  { id: 't1', name: 'Write tests', taskId: 12, completedAt: null, source: 'task', isOptimistic: false, frequency: 0 },
+];
+
+function withSeededCache(Story: () => React.ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  queryClient.setQueryData(['entity-search', 'activity'], entities);
+  queryClient.setQueryData(['appConfig'], { feature_flags: {} });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <GameContext.Provider value={mockGameContextValue}>
+        <Story />
+      </GameContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+const meta: Meta<typeof EntitySearchInput> = {
+  title: 'Shared/EntitySearchInput',
+  component: EntitySearchInput,
+  tags: ['autodocs'],
+  decorators: [withSeededCache],
+  args: {
+    type: 'activity',
+    ariaLabel: 'Activity name',
+    placeholder: 'What are you working on?',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EntitySearchInput>;
+
+function ControlledInput(props: Partial<React.ComponentProps<typeof EntitySearchInput>>) {
+  const [value, setValue] = useState(props.value ?? '');
+  return <EntitySearchInput {...(props as React.ComponentProps<typeof EntitySearchInput>)} value={value} onChange={setValue} />;
+}
+
+export const Default: Story = {
+  render: (args) => <ControlledInput {...args} />,
+};
+
+/** Typing surfaces matching activities/tasks in a dropdown, grouped by source when both are present. */
+export const WithSuggestions: Story = {
+  render: (args) => <ControlledInput {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByRole('combobox'), 'write');
+
+    await waitFor(async () => {
+      await expect(canvas.getByRole('listbox')).toBeVisible();
+    });
+    await expect(canvas.getByRole('option', { name: 'Write tests' })).toBeVisible();
+    await expect(canvas.getByRole('option', { name: 'Write report' })).toBeVisible();
+  },
+};
+
+/** `alwaysOpen` keeps the dropdown mounted regardless of focus (persistent list mode), falling back to `emptyMessage` when there are no rows. */
+export const AlwaysOpenEmpty: Story = {
+  args: {
+    alwaysOpen: true,
+    emptyMessage: 'No recent activities yet.',
+    defaultResults: [],
+  },
+  render: (args) => <ControlledInput {...args} />,
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, value: 'Timer running...' },
+};

--- a/frontend/src/components/List/Li.stories.tsx
+++ b/frontend/src/components/List/Li.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Li from './Li';
+
+/**
+ * `Li` is the single-row primitive `List` maps over. Storied directly for
+ * its own states (`isSelected`, `isHidden`, `tone`) - `List`'s stories cover
+ * it in context, as a full `<ul>`.
+ */
+const meta: Meta<typeof Li> = {
+  title: 'Shared/List/Li',
+  component: Li,
+  tags: ['autodocs'],
+  render: (args) => (
+    <ul>
+      <Li {...args} />
+    </ul>
+  ),
+  args: {
+    children: 'Row content',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Li>;
+
+export const Default: Story = {};
+
+export const Selected: Story = {
+  args: { isSelected: true },
+};
+
+export const Hidden: Story = {
+  args: { isHidden: true },
+};
+
+export const PlayerTone: Story = {
+  args: { tone: 'player', children: 'You finished Write docs' },
+};
+
+export const CharacterTone: Story = {
+  args: { tone: 'character', children: 'Rosie finished Deliver goods' },
+};

--- a/frontend/src/components/List/List.stories.tsx
+++ b/frontend/src/components/List/List.stories.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent } from 'storybook/test';
+import List from './List';
+
+/**
+ * `List` renders a `<ul>` of `Li` rows and underlies `PlayerItemList` (which
+ * adds sort/filter/edit-modal behaviour on top). On its own it handles
+ * selection, hover/compact styling, and per-item tone (e.g. distinguishing
+ * player vs. character rows in an activity feed).
+ */
+interface DemoItem {
+  id: string;
+  name: string;
+  player?: unknown;
+  character?: unknown;
+  isHidden?: boolean;
+}
+
+const items: DemoItem[] = [
+  { id: '1', name: 'Alice' },
+  { id: '2', name: 'Bob' },
+  { id: '3', name: 'Carol' },
+];
+
+const meta: Meta<typeof List<DemoItem>> = {
+  title: 'Shared/List',
+  component: List,
+  tags: ['autodocs'],
+  args: {
+    items,
+    ariaLabel: 'Names',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof List<DemoItem>>;
+
+export const Default: Story = {};
+
+export const CanHover: Story = {
+  args: { canHover: true },
+};
+
+export const Compact: Story = {
+  args: { compact: true },
+};
+
+/** A hidden item (e.g. a deep-link placeholder) stays in the DOM but is visually suppressed via `isHidden`. */
+export const WithHiddenItem: Story = {
+  args: {
+    items: [...items, { id: '4', name: 'Dave', isHidden: true }],
+  },
+};
+
+/** `itemTone`/`getItemTone` colour rows by origin - e.g. an activity feed mixing player and character entries. */
+export const MixedTone: Story = {
+  args: {
+    items: [
+      { id: '1', name: 'You finished Write docs', player: {} },
+      { id: '2', name: 'Rosie finished Deliver goods', character: {} },
+    ],
+  },
+};
+
+/** `canSelect` renders a `listbox`/`option` pair with keyboard (Enter/Space) activation instead of a plain list. */
+export const Selectable: Story = {
+  render: (args) => {
+    function Wrapper() {
+      const [selectedItem, setSelectedItem] = useState<DemoItem | null>(null);
+      return <List {...args} selectedItem={selectedItem} onSelect={setSelectedItem} canSelect />;
+    }
+    return <Wrapper />;
+  },
+  play: async ({ canvas }) => {
+    const option = canvas.getByRole('option', { name: 'Bob' });
+    await userEvent.click(option);
+    await expect(option).toHaveAttribute('aria-selected', 'true');
+  },
+};

--- a/frontend/src/components/ModeSwitcher/ModeSwitcher.stories.tsx
+++ b/frontend/src/components/ModeSwitcher/ModeSwitcher.stories.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent } from 'storybook/test';
+import ModeSwitcher from './ModeSwitcher';
+import type { ModeOption } from './ModeSwitcher';
+
+/**
+ * `ModeSwitcher` is a `radiogroup` of chips (e.g. Tasks/Activities panel
+ * mode). Fully generic over `modes`/`activeKey`/`onSelect`; arrow keys move
+ * (and select) between options, Home/End jump to the first/last.
+ */
+const modes: ModeOption[] = [
+  { key: 'tasks', label: 'Tasks' },
+  { key: 'activities', label: 'Activities' },
+  { key: 'skills', label: 'Skills' },
+];
+
+const meta: Meta<typeof ModeSwitcher> = {
+  title: 'Shared/ModeSwitcher',
+  component: ModeSwitcher,
+  tags: ['autodocs'],
+  args: {
+    modes,
+    activeKey: 'tasks',
+    ariaLabel: 'View mode',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ModeSwitcher>;
+
+export const Default: Story = {
+  render: (args) => {
+    function Wrapper() {
+      const [activeKey, setActiveKey] = useState(args.activeKey);
+      return <ModeSwitcher {...args} activeKey={activeKey} onSelect={setActiveKey} />;
+    }
+    return <Wrapper />;
+  },
+  play: async ({ canvas }) => {
+    const activities = canvas.getByRole('radio', { name: 'Activities' });
+    await userEvent.click(activities);
+    await expect(activities).toHaveAttribute('aria-checked', 'true');
+  },
+};

--- a/frontend/src/components/PlayerItemList/PlayerItemList.stories.tsx
+++ b/frontend/src/components/PlayerItemList/PlayerItemList.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import PlayerItemList from './PlayerItemList';
+import type { FilterOption, SortOption } from './PlayerItemList';
+
+/**
+ * `PlayerItemList` is the generic, prop-driven list underlying
+ * `CategoriesPanel`, `ProjectsPanel`, `SkillsPanel`, `TasksPanel`, and
+ * `ActivitiesPanel` - it owns sorting, filtering, the edit/delete modal,
+ * hover-edit affordances, and nested children, while the panel supplies the
+ * item shape and callbacks. Storying it here documents most of what those
+ * five panels visually do.
+ */
+interface DemoItem {
+  id: number;
+  name: string;
+  detail: string;
+  complete?: boolean;
+}
+
+const items: DemoItem[] = [
+  { id: 1, name: 'Write docs', detail: 'Duration: 15m · 15 XP gained', complete: false },
+  { id: 2, name: 'Fix login bug', detail: 'Duration: 42m · 40 XP gained', complete: true },
+  { id: 3, name: 'Plan sprint', detail: 'Duration: 5m · 5 XP gained', complete: false },
+];
+
+const sortOptions: SortOption<DemoItem>[] = [
+  { key: 'name', label: 'Name', compareFn: (a, b) => a.name.localeCompare(b.name) },
+  { key: 'newest', label: 'Newest', compareFn: (a, b) => b.id - a.id },
+];
+
+const filterOptions: FilterOption<DemoItem>[] = [
+  { key: 'all', label: 'All', predicate: () => true },
+  { key: 'incomplete', label: 'Incomplete', predicate: (item) => !item.complete },
+];
+
+const meta: Meta<typeof PlayerItemList<DemoItem>> = {
+  title: 'Shared/PlayerItemList',
+  component: PlayerItemList,
+  tags: ['autodocs'],
+  args: {
+    items,
+    itemLabel: 'activity',
+    ariaLabel: 'Activities',
+    renderItemMeta: (item: DemoItem) => item.detail,
+    onEdit: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PlayerItemList<DemoItem>>;
+
+export const Default: Story = {};
+
+/** `hoverEdit` swaps the row's click-to-open button for a persistent detail area plus a hover-revealed edit icon - used by panels where the row itself does something else on click. */
+export const HoverEdit: Story = {
+  args: { hoverEdit: true },
+};
+
+/** `isItemComplete`/`onToggleComplete` add a per-row checkbox, e.g. for `TasksPanel`. */
+export const WithCompleteToggle: Story = {
+  args: {
+    isItemComplete: (item: DemoItem) => Boolean(item.complete),
+    onToggleComplete: () => {},
+  },
+};
+
+/** `sortOptions`/`filterOptions` render a controls bar above the list. */
+export const WithSortAndFilter: Story = {
+  args: { sortOptions, filterOptions },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('group', { name: 'Filter activitys' })).toBeVisible();
+    await expect(canvas.getByLabelText('Sort:')).toBeVisible();
+  },
+};
+
+/** `getChildren` nests an item's children directly under it (e.g. subtasks), independent of the active sort/filter. */
+export const WithNestedChildren: Story = {
+  args: {
+    items: [
+      { id: 1, name: 'Ship v1', detail: '2 subtasks', complete: false },
+      { id: 2, name: 'Write changelog', detail: 'Duration: 10m', complete: false },
+      { id: 3, name: 'Cut release', detail: 'Duration: 5m', complete: true },
+    ],
+    getChildren: (item: DemoItem) =>
+      item.id === 1
+        ? [
+            { id: 2, name: 'Write changelog', detail: 'Duration: 10m', complete: false },
+            { id: 3, name: 'Cut release', detail: 'Duration: 5m', complete: true },
+          ]
+        : undefined,
+  },
+};
+
+/** No items - the shared empty list state (an empty `<ul>`, no placeholder copy of its own). */
+export const Empty: Story = {
+  args: { items: [] },
+};
+
+/** Clicking a row opens the edit modal; `onDelete` adds a Delete action with its own confirm step. */
+export const EditModal: Story = {
+  args: { onDelete: () => {} },
+  play: async ({ canvasElement, canvas }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Open activity Write docs' }));
+
+    const body = within(canvasElement.ownerDocument.body);
+    const dialog = await body.findByRole('dialog', { name: 'Edit activity' });
+    await expect(dialog).toBeVisible();
+    await expect(body.getByRole('button', { name: 'Delete' })).toBeVisible();
+  },
+};

--- a/frontend/src/components/StaticBanner/StaticBanner.stories.tsx
+++ b/frontend/src/components/StaticBanner/StaticBanner.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import StaticBanner from './StaticBanner';
+
+/**
+ * `StaticBanner` is a single-line site announcement. It renders nothing
+ * when `message` is empty/unset, so a running app with no announcement
+ * configured shows no banner at all.
+ */
+const meta: Meta<typeof StaticBanner> = {
+  title: 'Shared/StaticBanner',
+  component: StaticBanner,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof StaticBanner>;
+
+export const Default: Story = {
+  args: { message: "Scheduled maintenance tonight at 10pm UTC - the app may be briefly unavailable." },
+};
+
+/** No `message` - renders nothing. */
+export const NoMessage: Story = {
+  args: {},
+};

--- a/frontend/src/components/Toast/ToastManager.stories.tsx
+++ b/frontend/src/components/Toast/ToastManager.stories.tsx
@@ -1,0 +1,52 @@
+import * as RadixToast from '@radix-ui/react-toast';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import ToastManager from './ToastManager';
+
+/**
+ * `ToastManager` renders a `messages[]` prop as Radix `Toast.Root`s plus the
+ * shared `Toast.Viewport`. It must be mounted under a Radix `Toast.Provider`
+ * (normally supplied by `ToastContext`) - the story provides one directly.
+ */
+const meta: Meta<typeof ToastManager> = {
+  title: 'Shared/ToastManager',
+  component: ToastManager,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <RadixToast.Provider>
+        <Story />
+      </RadixToast.Provider>
+    ),
+  ],
+  args: {
+    onDismiss: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ToastManager>;
+
+export const Default: Story = {
+  args: {
+    messages: [{ id: '1', message: 'Task saved.' }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Task saved.')).toBeVisible();
+  },
+};
+
+export const Multiple: Story = {
+  args: {
+    messages: [
+      { id: '1', message: 'Task saved.' },
+      { id: '2', message: 'Activity logged - 15 XP gained.' },
+      { id: '3', message: 'Level up! You reached level 6.' },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: { messages: [] },
+};

--- a/frontend/src/components/TutorialModal/TutorialModal.stories.tsx
+++ b/frontend/src/components/TutorialModal/TutorialModal.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { expect, within } from 'storybook/test';
+import TutorialModal from './TutorialModal';
+import type { TutorialStep } from '../../types';
+
+/**
+ * `TutorialModal` walks through `TutorialStep`s fetched via `useTutorialSteps`
+ * (a TanStack Query hook - see `withQueryClient` in `.storybook/preview.tsx`).
+ * Each story seeds the `["tutorial-steps"]` query directly with
+ * `queryClient.setQueryData` so the modal renders without a real API call.
+ */
+const steps: TutorialStep[] = [
+  {
+    id: 1,
+    order: 1,
+    title: 'Welcome to Progress RPG',
+    body: 'Your character levels up as you complete real-world tasks and activities.',
+    image_url: null,
+    alt_text: '',
+    youtube_url: null,
+  },
+  {
+    id: 2,
+    order: 2,
+    title: 'Start a timer',
+    body: 'Type what you\'re working on and hit Start - XP accrues while the timer runs.',
+    image_url: null,
+    alt_text: '',
+    youtube_url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+  },
+  {
+    id: 3,
+    order: 3,
+    title: "You're all set",
+    body: 'That\'s the core loop. Explore the map to see other characters at work.',
+    image_url: null,
+    alt_text: '',
+    youtube_url: null,
+  },
+];
+
+/** Seeds `["tutorial-steps"]` with `data` before the story renders. */
+function withSeededSteps(data: TutorialStep[]) {
+  return (Story: () => React.ReactElement) => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['tutorial-steps'], data);
+    return (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    );
+  };
+}
+
+const meta: Meta<typeof TutorialModal> = {
+  title: 'Shared/TutorialModal',
+  component: TutorialModal,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      story: { inline: false, iframeHeight: 420 },
+    },
+  },
+  args: {
+    onClose: () => {},
+  },
+  decorators: [withSeededSteps(steps)],
+};
+
+export default meta;
+type Story = StoryObj<typeof TutorialModal>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(await body.findByRole('dialog', { name: 'Welcome to Progress RPG' })).toBeVisible();
+    await expect(body.getByText('1 / 3')).toBeVisible();
+  },
+};
+
+/** `startAtStepId` opens directly on a later step, e.g. re-opening from a "Learn more" link elsewhere in the app. */
+export const StartAtLaterStep: Story = {
+  args: { startAtStepId: 2 },
+};
+
+export const NoSteps: Story = {
+  decorators: [withSeededSteps([])],
+};

--- a/frontend/src/components/WaitlistForm/WaitlistForm.stories.tsx
+++ b/frontend/src/components/WaitlistForm/WaitlistForm.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import WaitlistForm from './WaitlistForm';
+
+/**
+ * `WaitlistForm` is a single-field email form backed by `useWaitlistJoin`,
+ * which posts to the real waitlist API - the story only exercises the idle,
+ * pre-submission render (an interactive Storybook play test would hit a
+ * live endpoint).
+ */
+const meta: Meta<typeof WaitlistForm> = {
+  title: 'Shared/WaitlistForm',
+  component: WaitlistForm,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof WaitlistForm>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Join the Waitlist' })).toBeVisible();
+    await expect(canvas.getByLabelText('Email:')).toBeVisible();
+  },
+};
+
+export const CustomTitle: Story = {
+  args: { title: 'Be first in line' },
+};

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,36 +1,14 @@
-import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
-import type { Dispatch, ReactElement, ReactNode, SetStateAction } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { apiFetch, ApiFetchError, setUnauthorizedHandler } from "../utils/api";
 import { clearAuthStorage, getStoredAuthTokens, storeAuthTokens } from '../utils/authStorage';
 import { clearUserPreferences } from '../utils/userPreferences';
+import { AuthContext, type AuthContextValue } from './authContext';
 import type { User } from '../types';
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface AuthContextValue {
-  accessToken: string | null;
-  refreshToken: string | null;
-  isAuthenticated: boolean;
-  user: User | null;
-  setUser: Dispatch<SetStateAction<User | null>>;
-  login: (accessToken: string, refreshToken: string, options?: { rememberMe?: boolean }) => Promise<unknown>;
-  logout: () => void;
-  /** Thin wrapper around apiFetch — use apiFetch directly for typed responses. */
-  authFetch: <T = unknown>(path: string, options?: Parameters<typeof apiFetch>[1]) => Promise<T>;
-  loading: boolean;
-}
 
 interface ProviderProps {
   children: ReactNode;
 }
-
-// ---------------------------------------------------------------------------
-// Context
-// ---------------------------------------------------------------------------
-
-const AuthContext = createContext<AuthContextValue | null>(null);
 
 // ---------------------------------------------------------------------------
 // Provider

--- a/frontend/src/context/authContext.ts
+++ b/frontend/src/context/authContext.ts
@@ -1,0 +1,19 @@
+import { createContext } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { apiFetch } from '../utils/api';
+import type { User } from '../types';
+
+export interface AuthContextValue {
+  accessToken: string | null;
+  refreshToken: string | null;
+  isAuthenticated: boolean;
+  user: User | null;
+  setUser: Dispatch<SetStateAction<User | null>>;
+  login: (accessToken: string, refreshToken: string, options?: { rememberMe?: boolean }) => Promise<unknown>;
+  logout: () => void;
+  /** Thin wrapper around apiFetch — use apiFetch directly for typed responses. */
+  authFetch: <T = unknown>(path: string, options?: Parameters<typeof apiFetch>[1]) => Promise<T>;
+  loading: boolean;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/frontend/src/layout/Footer/Footer.stories.tsx
+++ b/frontend/src/layout/Footer/Footer.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MemoryRouter } from 'react-router';
+import { expect, within } from 'storybook/test';
+import Footer from './Footer';
+import { AuthContext } from '../../context/authContext';
+import { mockAuthContextValue } from '../../testUtils/mockAuthContext';
+
+/**
+ * `Footer` reads `useAuth()` only, to gate the "Admin Panel" link behind a
+ * staff user. Wrapped in `MemoryRouter` since its internal links use
+ * `react-router`'s `Link`.
+ */
+function withAuth(overrides: Parameters<typeof mockAuthContextValue>[0] = {}) {
+  return (Story: () => React.ReactElement) => (
+    <MemoryRouter>
+      <AuthContext.Provider value={mockAuthContextValue(overrides)}>
+        <Story />
+      </AuthContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+const meta: Meta<typeof Footer> = {
+  title: 'Layout/Footer',
+  component: Footer,
+  tags: ['autodocs'],
+  decorators: [withAuth()],
+};
+
+export default meta;
+type Story = StoryObj<typeof Footer>;
+
+export const LoggedOut: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('link', { name: 'Support' })).toBeVisible();
+    await expect(canvas.queryByRole('link', { name: 'Admin Panel' })).not.toBeInTheDocument();
+  },
+};
+
+export const LoggedIn: Story = {
+  decorators: [withAuth({ authenticated: true })],
+};
+
+export const StaffUser: Story = {
+  decorators: [
+    withAuth({
+      authenticated: true,
+      user: { email: 'staff@example.com', is_confirmed: true, is_staff: true, is_superuser: false, date_of_birth: null, timezone: 'UTC' },
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
+  },
+};

--- a/frontend/src/layout/Infobar/Infobar.stories.tsx
+++ b/frontend/src/layout/Infobar/Infobar.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import Infobar from './Infobar';
+import { GameContext } from '../../context/gameContext';
+import { mockGameContextValue } from '../../testUtils/mockGameContext';
+import type { Player } from '../../types';
+
+/**
+ * `Infobar` reads `player`/`loading` off `useGame()` - see
+ * `.storybook/decorators/withGameContext.tsx` for the shared mock, extended
+ * here per story with a concrete `player`.
+ */
+const demoPlayer: Player = {
+  id: 1,
+  name: 'Alex',
+  xp: 340,
+  xp_next_level: 500,
+  xp_modifier: 1,
+  level: 7,
+  total_time: 54000,
+  total_activities: 42,
+  achievements: [
+    { type: 'tasks_completed', label: 'Task Master', symbol: '✅', tier: 2, complete: true, color: 'green', value: 50, threshold: 50 },
+    { type: 'streak', label: 'Consistency', symbol: '🔥', tier: 1, complete: false, color: 'grey', value: 8, threshold: 30 },
+  ],
+  is_premium: false,
+  is_tester: false,
+  has_previous_subscription: false,
+  is_trialing: false,
+  trial_end: null,
+  onboarding_step: 5,
+  onboarding_completed: true,
+  login_streak: 8,
+  unseen_tutorial_step_ids: [],
+};
+
+function withPlayer(player: Player | null, loading = false) {
+  return (Story: () => React.ReactElement) => (
+    <GameContext.Provider value={{ ...mockGameContextValue, player, loading }}>
+      <Story />
+    </GameContext.Provider>
+  );
+}
+
+const meta: Meta<typeof Infobar> = {
+  title: 'Layout/Infobar',
+  component: Infobar,
+  tags: ['autodocs'],
+  decorators: [withPlayer(demoPlayer)],
+};
+
+export default meta;
+type Story = StoryObj<typeof Infobar>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Alex')).toBeVisible();
+    await expect(canvas.getByText('Level 7')).toBeVisible();
+  },
+};
+
+export const PremiumPlayer: Story = {
+  decorators: [withPlayer({ ...demoPlayer, is_premium: true })],
+};
+
+export const Loading: Story = {
+  decorators: [withPlayer(null, true)],
+};
+
+/** Renders nothing once loaded without a player (e.g. between logout and redirect). */
+export const NoPlayer: Story = {
+  decorators: [withPlayer(null, false)],
+};

--- a/frontend/src/layout/NavDrawer/NavDrawer.stories.tsx
+++ b/frontend/src/layout/NavDrawer/NavDrawer.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MemoryRouter } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import NavDrawer from './NavDrawer';
+import { AuthContext } from '../../context/authContext';
+import { GameContext } from '../../context/gameContext';
+import { mockAuthContextValue } from '../../testUtils/mockAuthContext';
+import { mockGameContextValue } from '../../testUtils/mockGameContext';
+
+/**
+ * `NavDrawer` is the mobile side-nav - it reads `useAuth()` for which links
+ * to show and `useFeatureFlag("map")` (via a seeded `["appConfig"]` query,
+ * see `useFeatureFlag.ts`) to gate the Map link. Rendered inline via
+ * `parameters.docs.story` since it's a fixed-position overlay, not
+ * document-flow content.
+ */
+function withNavDrawerContext({
+  authenticated = true,
+  featureFlags = {},
+}: {
+  authenticated?: boolean;
+  featureFlags?: Record<string, unknown>;
+}) {
+  return (Story: () => React.ReactElement) => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['appConfig'], { feature_flags: featureFlags });
+
+    return (
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <AuthContext.Provider value={mockAuthContextValue({ authenticated })}>
+            <GameContext.Provider value={mockGameContextValue}>
+              <Story />
+            </GameContext.Provider>
+          </AuthContext.Provider>
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+  };
+}
+
+const meta: Meta<typeof NavDrawer> = {
+  title: 'Layout/NavDrawer',
+  component: NavDrawer,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      story: { inline: true, iframeHeight: 360 },
+    },
+  },
+  args: {
+    drawerOpen: true,
+    onClose: fn(),
+  },
+  decorators: [withNavDrawerContext({})],
+};
+
+export default meta;
+type Story = StoryObj<typeof NavDrawer>;
+
+export const LoggedIn: Story = {
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('link', { name: /Timer/ })).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Close navigation drawer' }));
+    await expect(args.onClose).toHaveBeenCalled();
+  },
+};
+
+export const LoggedOut: Story = {
+  decorators: [withNavDrawerContext({ authenticated: false })],
+};
+
+/** `map` is `["testers"]`-gated by default - enabling it here mirrors a tester/premium account. */
+export const WithMapEnabled: Story = {
+  decorators: [withNavDrawerContext({ featureFlags: { map: 'all' } })],
+};
+
+export const Closed: Story = {
+  args: { drawerOpen: false },
+};

--- a/frontend/src/layout/Navbar/Navbar.stories.tsx
+++ b/frontend/src/layout/Navbar/Navbar.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MemoryRouter } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import Navbar from './Navbar';
+import { AuthContext } from '../../context/authContext';
+import { GameContext } from '../../context/gameContext';
+import { mockAuthContextValue } from '../../testUtils/mockAuthContext';
+import { mockGameContextValue } from '../../testUtils/mockGameContext';
+import type { AnnouncementListResponse } from '../../types';
+
+/**
+ * `Navbar` reads `useAuth()` (nav links), `useGame()` (unread-announcement
+ * badge) and two `useFeatureFlag()` checks (`map`, `announcements`) that
+ * resolve via a seeded `["appConfig"]` query - see `useFeatureFlag.ts`. Each
+ * story seeds its own `QueryClient` and wraps in `MemoryRouter` since
+ * `Navbar` reads the current route to highlight the active link.
+ */
+function withNavbarContext({
+  authenticated = true,
+  path = '/timer',
+  featureFlags = {},
+  announcements,
+}: {
+  authenticated?: boolean;
+  path?: string;
+  featureFlags?: Record<string, unknown>;
+  announcements?: AnnouncementListResponse;
+}) {
+  return (Story: () => React.ReactElement) => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['appConfig'], { feature_flags: featureFlags });
+    if (announcements) {
+      queryClient.setQueryData(['announcements'], announcements);
+    }
+
+    return (
+      <MemoryRouter initialEntries={[path]}>
+        <QueryClientProvider client={queryClient}>
+          <AuthContext.Provider value={mockAuthContextValue({ authenticated })}>
+            <GameContext.Provider value={mockGameContextValue}>
+              <Story />
+            </GameContext.Provider>
+          </AuthContext.Provider>
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+  };
+}
+
+const meta: Meta<typeof Navbar> = {
+  title: 'Layout/Navbar',
+  component: Navbar,
+  tags: ['autodocs'],
+  decorators: [withNavbarContext({})],
+};
+
+export default meta;
+type Story = StoryObj<typeof Navbar>;
+
+export const LoggedOut: Story = {
+  decorators: [withNavbarContext({ authenticated: false, path: '/' })],
+};
+
+export const LoggedIn: Story = {};
+
+/** `map` and `announcements` are `["testers"]`-gated by default - enabling them here via the seeded `appConfig` mirrors a tester/premium account. */
+export const WithAnnouncements: Story = {
+  decorators: [
+    withNavbarContext({
+      featureFlags: { announcements: 'all' },
+      announcements: {
+        unread_count: 1,
+        results: [
+          {
+            id: 1,
+            title: 'New feature: the map is live',
+            summary: 'Explore other characters at work on the world map.',
+            body: 'The map view is now available from the nav bar.',
+            published_at: '2026-08-01T00:00:00Z',
+            created_at: '2026-08-01T00:00:00Z',
+            is_read: false,
+          },
+          {
+            id: 2,
+            title: 'Scheduled maintenance',
+            summary: 'Brief downtime overnight on Aug 20.',
+            body: 'We are upgrading database infrastructure.',
+            published_at: '2026-07-20T00:00:00Z',
+            created_at: '2026-07-20T00:00:00Z',
+            is_read: true,
+          },
+        ],
+      },
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Announcements' }));
+
+    await waitFor(async () => {
+      await expect(canvas.getByText('New feature: the map is live')).toBeVisible();
+    });
+  },
+};
+
+export const WithMapEnabled: Story = {
+  decorators: [withNavbarContext({ featureFlags: { map: 'all' } })],
+};

--- a/frontend/src/testUtils/mockAuthContext.ts
+++ b/frontend/src/testUtils/mockAuthContext.ts
@@ -1,0 +1,40 @@
+import type { AuthContextValue } from '../context/authContext';
+import type { User } from '../types';
+
+const mockUser: User = {
+  email: 'demo@example.com',
+  is_confirmed: true,
+  is_staff: false,
+  is_superuser: false,
+  date_of_birth: null,
+  timezone: 'UTC',
+};
+
+/**
+ * Minimal `AuthContextValue` for Storybook stories that read `useAuth()`
+ * directly (`Navbar`, `NavDrawer`, `Footer`). `authenticated: false` (the
+ * default) mirrors the real logged-out render - `AuthProvider` itself never
+ * calls the API when there are no stored tokens, so it doesn't need a mock.
+ * `authenticated: true` covers the logged-in nav state without a real
+ * session. Pass `overrides` for anything else (e.g. `user: { is_staff: true }`).
+ */
+export function mockAuthContextValue(
+  overrides: Partial<AuthContextValue> & { authenticated?: boolean } = {}
+): AuthContextValue {
+  const { authenticated = false, ...rest } = overrides;
+
+  return {
+    accessToken: authenticated ? 'mock-access-token' : null,
+    refreshToken: authenticated ? 'mock-refresh-token' : null,
+    isAuthenticated: authenticated,
+    user: authenticated ? mockUser : null,
+    setUser: () => {},
+    login: async () => null,
+    logout: () => {},
+    authFetch: async () => {
+      throw new Error('authFetch is not mocked in Storybook');
+    },
+    loading: false,
+    ...rest,
+  };
+}

--- a/frontend/src/testUtils/mockGameContext.ts
+++ b/frontend/src/testUtils/mockGameContext.ts
@@ -1,0 +1,56 @@
+import type { GameContextValue } from '../context/gameContext';
+
+/**
+ * Minimal `GameContextValue` covering only what story-ready components
+ * actually read (currently `player`, via `useFeatureFlag`). The rest are
+ * stubs so the object satisfies the full interface without pulling in
+ * `GameProvider`'s real bootstrap/fetch logic - extend as more components
+ * that read other fields get storied.
+ *
+ * Used by Storybook stories that mount `GameContext.Provider` directly
+ * (`.storybook/decorators/withGameContext.tsx`, `EntitySearchInput.stories.tsx`).
+ */
+export const mockGameContextValue: GameContextValue = {
+  player: null,
+  setPlayer: () => {},
+  character: null,
+  setCharacter: () => {},
+  xpMods: [],
+  setXpMods: () => {},
+  fetchPlayerAndCharacter: async () => {},
+  activityTimer: {
+    status: 'empty',
+    elapsed: 0,
+    duration: 0,
+    limitSeconds: null,
+    limitReached: false,
+    autoStopCompletion: null,
+    currentActivity: null,
+    startActivity: async () => null,
+    labelActivity: async () => null,
+    stop: async () => null,
+    loadFromServer: () => {},
+    clearAutoStopCompletion: () => {},
+  },
+  playerActivities: [],
+  characterActivities: [],
+  fetchActivities: async () => {},
+  fetchCharacterCurrent: async () => null,
+  characterCurrentActivity: null,
+  setCharacterCurrentActivity: () => {},
+  populationCentre: null,
+  fetchPopulationCentre: async () => {
+    throw new Error('fetchPopulationCentre is not mocked in Storybook');
+  },
+  loginState: 'none',
+  loginStreak: 0,
+  loginEventAt: null,
+  loginRewardXp: 0,
+  announcementUnreadCount: 0,
+  setAnnouncementUnreadCount: () => {},
+  loading: false,
+  buildNumber: false,
+  freeTimerLimitSeconds: 1800,
+  gameSettings: null,
+  initialOnlineCount: 0,
+};


### PR DESCRIPTION
## Summary

Implements the first two stages of #749's suggested approach:

1. **Bucket 1** (pure, prop-driven components): `PlayerItemList`, `List`/`Li`, `Achievements`, `ModeSwitcher`, `EntitySearchInput`, `TutorialModal`, `WaitlistForm`, `StaticBanner`, `BackToTopButton`, `ToastManager`.
2. **Layout chrome** (bucket 3): `Navbar`, `NavDrawer`, `Footer`, `Infobar`.

`ActivityInput` was deliberately excluded from bucket 1 — it depends on `useGame()`, `useSupportFlow`, `useFeatureFlag`, `useEntitySearchCache`, live timer state, `sessionStorage`, `AlertDialog`, and `SupportFlowModal`, far more than the issue's "prop-driven, no context" characterization suggested.

## Infra added

- `.storybook/preview.tsx`: global `withQueryClient` decorator (fresh, retry-disabled `QueryClient` per story) so any TanStack Query hook — direct or transitive — doesn't crash.
- `context/gameContext.ts` / `context/authContext.ts`: raw contexts extracted from `GameContext.tsx`/`AuthContext.tsx` (the latter split as part of this PR, mirroring the former) so stories can mount `<Context.Provider>` directly without the real providers' bootstrap/fetch logic.
- `testUtils/mockGameContext.ts`, `testUtils/mockAuthContext.ts`: minimal mock values satisfying each context's full interface.
- `.storybook/decorators/withGameContext.tsx`, `withAuthContext.tsx`: reusable decorators built on the mocks above.

Per-story decorators seed exact TanStack Query cache keys (`queryClient.setQueryData(...)`) to control loading/empty/populated states without hitting the real API.

## Verification

- `npx eslint` — clean on all new/changed files.
- `npx tsc --noEmit` — clean.
- `npx storybook build` — compiles all story files without errors.
- `npx vitest run` — existing unit tests for `AuthContext`, `Navbar`, `NavDrawer` (24 tests) still pass after the context split.
- **Not run**: `test:storybook` (Playwright-driven play functions + a11y checks) — this sandbox has no sudo to install Chromium's system deps. Should be run locally/CI before merging.

## Remaining gap (per #749)

Bucket 2 — data-fetching panels (`CategoriesPanel`, `ProjectsPanel`, `SkillsPanel`, `TasksPanel`, `ActivitiesPanel`, `ComingSoonPanel`, `NotesPanel`, `DetailSurface`, `SupportFlow` screens, `UnifiedTimerHome`, `ActivityTimeline`, `CurrentActivity`, `CharacterCurrentActivity`) — and `ActivityInput`. Per the issue's own plan (step 5), worth revisiting whether these need their own stories given `PlayerItemList`'s existing coverage, as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>