### PR TITLE
feat: replace Radix Tabs with Tamagui (#584)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,6 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.19",
         "@radix-ui/react-popover": "^1.1.18",
-        "@radix-ui/react-tabs": "^1.1.16",
         "@tamagui/config": "^2.7.6",
         "@tamagui/core": "^2.7.6",
         "@tamagui/vite-plugin": "^2.7.6",
@@ -2635,36 +2634,6 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-tabs": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.21.tgz",
-      "integrity": "sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-presence": "1.1.10",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-roving-focus": "1.1.19",
-        "@radix-ui/react-use-controllable-state": "1.2.6"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,6 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.19",
     "@radix-ui/react-popover": "^1.1.18",
-    "@radix-ui/react-tabs": "^1.1.16",
     "@tamagui/config": "^2.7.6",
     "@tamagui/core": "^2.7.6",
     "@tamagui/vite-plugin": "^2.7.6",

--- a/frontend/src/components/SupportFlow/screens/ActivityInputScreen.test.tsx
+++ b/frontend/src/components/SupportFlow/screens/ActivityInputScreen.test.tsx
@@ -1,0 +1,83 @@
+// SupportFlow/screens/ActivityInputScreen.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render as rtlRender, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TamaguiProvider } from "tamagui";
+import ActivityInputScreen from "./ActivityInputScreen";
+import tamaguiConfig from "../../../../tamagui.config";
+
+// ActivityInputScreen renders Tabs (#584), which needs a TamaguiProvider
+// ancestor - unlike Radix's Tabs.Root, it isn't usable standalone. The app
+// root (src/main.tsx) provides this in production; tests need their own.
+function render(...args: Parameters<typeof rtlRender>) {
+  const [ui, options] = args;
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
+        {children}
+      </TamaguiProvider>
+    ),
+    ...options,
+  });
+}
+
+const mockUseFeatureFlag = vi.fn();
+
+vi.mock("../../../hooks/useFeatureFlag", () => ({
+  useFeatureFlag: (flag: string) => mockUseFeatureFlag(flag),
+}));
+
+vi.mock("../../../hooks/useTasks", () => ({
+  useTasks: () => ({
+    data: [
+      { id: 1, name: "Water the plants", is_complete: false, completed_at: null },
+      { id: 2, name: "Reply to email", is_complete: false, completed_at: null },
+    ],
+  }),
+}));
+
+describe("ActivityInputScreen", () => {
+  describe("priority_three preset, with the tasks feature enabled", () => {
+    beforeEach(() => {
+      mockUseFeatureFlag.mockReturnValue(true);
+    });
+
+    it("defaults to the 'From memory' tab", () => {
+      render(<ActivityInputScreen activityPresetId="priority_three" />);
+
+      expect(screen.getByRole("tab", { name: "From memory" })).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByRole("tab", { name: "My tasks" })).toHaveAttribute("aria-selected", "false");
+      expect(screen.getByLabelText("Task option 1")).toBeInTheDocument();
+    });
+
+    it("switches to the 'My tasks' tab, showing incomplete tasks and hiding the memory panel", async () => {
+      const user = userEvent.setup();
+      render(<ActivityInputScreen activityPresetId="priority_three" />);
+
+      await user.click(screen.getByRole("tab", { name: "My tasks" }));
+
+      expect(screen.getByRole("tab", { name: "My tasks" })).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByText("Water the plants")).toBeInTheDocument();
+      expect(screen.getByText("Reply to email")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Task option 1")).not.toBeInTheDocument();
+    });
+
+    it("wires the ARIA tab/tabpanel relationship", () => {
+      render(<ActivityInputScreen activityPresetId="priority_three" />);
+
+      const tab = screen.getByRole("tab", { name: "From memory" });
+      const panel = screen.getByRole("tabpanel");
+
+      expect(tab.getAttribute("aria-controls")).toBe(panel.getAttribute("id"));
+      expect(panel.getAttribute("aria-labelledby")).toBe(tab.getAttribute("id"));
+    });
+  });
+
+  it("does not render tabs when the tasks feature is disabled", () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+
+    render(<ActivityInputScreen activityPresetId="priority_three" />);
+
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SupportFlow/screens/ActivityInputScreen.tsx
+++ b/frontend/src/components/SupportFlow/screens/ActivityInputScreen.tsx
@@ -1,6 +1,6 @@
 // SupportFlow/screens/ActivityInputScreen.tsx
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import * as Tabs from "@radix-ui/react-tabs";
+import * as Tabs from "../../Tabs/Tabs";
 import Button from "../../Button/Button";
 import ButtonFrame from "../../Button/ButtonFrame";
 import { ACTIVITY_PRESETS } from "../supportFlowReducer";

--- a/frontend/src/components/Tabs/Tabs.tsx
+++ b/frontend/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { Tabs as TabsPrimitive } from 'tamagui';
+
+interface TabsRootProps {
+  children: React.ReactNode;
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  className?: string;
+}
+
+interface TabsListProps {
+  children: React.ReactNode;
+  className?: string;
+  'aria-label'?: string;
+}
+
+interface TabsTriggerProps {
+  children: React.ReactNode;
+  value: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+interface TabsContentProps {
+  children: React.ReactNode;
+  value: string;
+  className?: string;
+}
+
+// Tracks which value is active so Trigger (below) can compute its own
+// roving-tabindex - see the comment there for why that can't just be left
+// to Tamagui. Resolved here (rather than left to Tamagui's own internal
+// useControllableState) so both Root and Trigger read the same source of
+// truth regardless of whether the caller uses controlled (`value`) or
+// uncontrolled (`defaultValue`) mode.
+const TabsActiveValueContext = React.createContext('');
+
+function useResolvedValue(
+  value: string | undefined,
+  defaultValue: string | undefined,
+  onValueChange: ((value: string) => void) | undefined
+) {
+  const [uncontrolledValue, setUncontrolledValue] = React.useState(defaultValue ?? '');
+  const isControlled = value !== undefined;
+  const resolvedValue = isControlled ? value : uncontrolledValue;
+  const setValue = React.useCallback(
+    (next: string) => {
+      if (!isControlled) setUncontrolledValue(next);
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange]
+  );
+  return [resolvedValue, setValue] as const;
+}
+
+/**
+ * Thin wrapper over Tamagui's `Tabs`, mirroring the four-part
+ * Root/List/Trigger/Content shape `@radix-ui/react-tabs` exposed so call
+ * sites only need to swap the import - props are unchanged. `unstyled`
+ * everywhere it's recognised (Root, List, Trigger - Content has no
+ * `unstyled` variant of its own to consume it, see below), like
+ * `Modal`/`Tooltip`, so consumer CSS modules stay the only source of
+ * visuals; Tamagui sets `data-state="active"/"inactive"` on triggers just
+ * like Radix did, so existing `[data-state='active']` selectors carry over
+ * unchanged.
+ *
+ * `activationMode="automatic"` overrides Tamagui's own default ("manual")
+ * to match Radix's default behaviour: arrow-key focus movement between
+ * tabs (via Tamagui's roving-focus-group-backed `List`) activates the
+ * focused tab immediately, rather than requiring a separate Enter/Space.
+ */
+export function Root({
+  children,
+  value,
+  defaultValue,
+  onValueChange,
+  className,
+}: TabsRootProps): React.ReactElement {
+  const [resolvedValue, setValue] = useResolvedValue(value, defaultValue, onValueChange);
+  return (
+    <TabsActiveValueContext.Provider value={resolvedValue}>
+      <TabsPrimitive
+        unstyled
+        value={resolvedValue}
+        onValueChange={setValue}
+        activationMode="automatic"
+        className={className}
+      >
+        {children}
+      </TabsPrimitive>
+    </TabsActiveValueContext.Provider>
+  );
+}
+
+export function List({ children, className, ...rest }: TabsListProps): React.ReactElement {
+  return (
+    <TabsPrimitive.List unstyled className={className} {...rest}>
+      {children}
+    </TabsPrimitive.List>
+  );
+}
+
+export function Trigger({ children, value, className, disabled }: TabsTriggerProps): React.ReactElement {
+  const activeValue = React.useContext(TabsActiveValueContext);
+  return (
+    <TabsPrimitive.Trigger
+      unstyled
+      value={value}
+      disabled={disabled}
+      className={className}
+      // @tamagui/roving-focus@2.7.6's RovingFocusGroupItem computes
+      // `isCurrentTabStop` but never actually uses it to set `tabIndex` -
+      // every focusable trigger ends up with `tabIndex=0` (confirmed by
+      // reading node_modules/@tamagui/roving-focus's source and verifying
+      // in a real browser: without this, all three LibraryPage tabs land
+      // in the sequential Tab order simultaneously). Radix's real roving
+      // tabindex only ever puts the *active* tab in the tab order. This
+      // explicit `tabIndex` wins the asChild prop merge (child value beats
+      // the Slot's default, verified manually), restoring that behaviour
+      // without patching the library.
+      tabIndex={activeValue === value ? 0 : -1}
+    >
+      {children}
+    </TabsPrimitive.Trigger>
+  );
+}
+
+export function Content({ children, value, className }: TabsContentProps): React.ReactElement {
+  return (
+    // No `unstyled` here (unlike the other three) - DefaultTabsContentFrame
+    // (@tamagui/tabs's Tabs.mjs) is a bare `styled(ThemeableStack, {name:
+    // CONTENT_NAME})` with no variants block at all, so it never declares
+    // an `unstyled` variant to consume one - passed anyway, it leaks
+    // through as a literal (invalid) boolean DOM attribute, the same class
+    // of issue #582/#583 hit with asChild prop merges. Harmless to omit:
+    // with no variants, the frame has no default visual styles to cancel
+    // in the first place.
+    <TabsPrimitive.Content value={value} className={className}>
+      {children}
+    </TabsPrimitive.Content>
+  );
+}

--- a/frontend/src/pages/LibraryPage/LibraryPage.test.tsx
+++ b/frontend/src/pages/LibraryPage/LibraryPage.test.tsx
@@ -1,8 +1,25 @@
-import { render, screen } from "@testing-library/react";
+import { render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TamaguiProvider } from "tamagui";
 
 import LibraryPage from "./LibraryPage";
+import tamaguiConfig from "../../../tamagui.config";
+
+// LibraryPage renders Tabs (#584), which needs a TamaguiProvider ancestor -
+// unlike Radix's Tabs.Root, it isn't usable standalone. The app root
+// (src/main.tsx) provides this in production; tests need their own.
+function render(...args: Parameters<typeof rtlRender>) {
+  const [ui, options] = args;
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
+        {children}
+      </TamaguiProvider>
+    ),
+    ...options,
+  });
+}
 
 const mockUseFeatureFlag = vi.fn();
 

--- a/frontend/src/pages/LibraryPage/LibraryPage.tsx
+++ b/frontend/src/pages/LibraryPage/LibraryPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import * as Tabs from "@radix-ui/react-tabs";
+import * as Tabs from "../../components/Tabs/Tabs";
 
 import TasksPanel from "../../components/TasksPanel/TasksPanel";
 import ActivitiesPanel from "../../components/ActivitiesPanel/ActivitiesPanel";


### PR DESCRIPTION
## Summary

Implements #584: replaces `@radix-ui/react-tabs` with Tamagui's `Tabs` primitive, part of epic #578. Branched off #791 (#583's Tooltip/Tamagui branch) since Tabs is the next Radix package in the same migration chain, per the pattern #580→#581→#582→#583 established.

`Tabs` was one of four Radix packages imported directly in pages/components with no local wrapper. Per the issue's guidance ("wrapping as a separate step would be make-work for Tabs"), this lands the wrapper and the Tamagui implementation in one commit, then migrates both call sites (`LibraryPage.tsx`, `ActivityInputScreen.tsx`) - each needed only an import swap, since `components/Tabs/Tabs.tsx` mirrors `@radix-ui/react-tabs`'s `Root`/`List`/`Trigger`/`Content` shape exactly.

### Key implementation notes

Two upstream Tamagui gaps needed workarounds, found via manual real-browser verification (Playwright, pinned executable - this sandbox has no backend for `test:a11y` and a pre-existing headless-shell version mismatch blocks `test:storybook`, same limitations #582/#583 documented):

- **`@tamagui/roving-focus@2.7.6`'s `RovingFocusGroupItem` computes `isCurrentTabStop` but never uses it to set `tabIndex`** - every focusable trigger ended up with `tabIndex=0`, so all three `LibraryPage` tabs (not just the active one) landed in the page's sequential Tab order simultaneously, unlike Radix's true roving tabindex. Fixed by having `Tabs.Root` resolve the active value itself (supporting both controlled `value`/`onValueChange` and uncontrolled `defaultValue`) and having `Tabs.Trigger` read it via context to set an explicit `tabIndex` - which wins the `asChild` prop merge over the library's own default (verified manually: a bare Tab press from the active tab now skips straight past the other tabs to the next real focusable element, matching Radix).
- **`@tamagui/tabs`'s `DefaultTabsContentFrame` declares no `unstyled` variant** (unlike the Root/Trigger frames, which do), so passing `unstyled` to `Tabs.Content` leaked through as a literal, invalid boolean DOM attribute - the same class of `asChild`/variant-gap issue #582/#583 hit elsewhere. Dropped `unstyled` there; the frame has no default styles to cancel anyway (bare `styled(ThemeableStack, {...})`, no variants block).

`Tabs.Root`/`List`/`Trigger` still use `unstyled` (all recognise the variant), so consumer CSS modules stay the only source of visuals - Tamagui sets `data-state="active"/"inactive"` on triggers just like Radix did, so `LibraryPage.module.scss`'s existing `[data-state='active']` selector carries over unchanged. `activationMode="automatic"` is passed explicitly to override Tamagui's own default (`"manual"`), matching Radix's default: arrow-key focus movement between tabs activates the focused tab immediately.

`@radix-ui/react-tabs` is fully uninstalled from `package.json` - it was the last direct-import Radix package under #578's Tabs scope, so no wrapper-internals-still-Radix intermediate step was needed.

## Acceptance criteria

- [x] No `@radix-ui/react-tabs` import remains (uninstalled from `package.json`)
- [x] Both call sites migrated; controlled and uncontrolled modes both supported (`Tabs.Root` accepts both `value`/`onValueChange` and `defaultValue`) and controlled mode exercised by both call sites
- [x] `aria-label` on the LibraryPage tab list preserved
- [x] Full tab/panel ARIA relationships intact (`tablist`/`tab`/`tabpanel`, `aria-selected`, `aria-controls`/`aria-labelledby`) - verified via tests + real browser
- [x] Arrow-key navigation between tabs works, with correct tab-order behaviour - roving tabindex fixed (see above), verified manually in a real browser
- [x] `LibraryPage.test.tsx` passes (updated to wrap renders in `TamaguiProvider`, same pattern `Tooltip.test.tsx`/`SupportFlowModal.test.tsx` use); added `ActivityInputScreen.test.tsx` (none existed before)
- [ ] `npm run test:a11y` - blocked by this sandbox having no backend to authenticate against (`ECONNREFUSED 127.0.0.1:8000`), same limitation as #582/#583
- [x] Confirmed Tamagui's `Tabs` supports controlled `value`/`onValueChange` for `ActivityInputScreen` (it does natively, via `useControllableState`; verified with a dedicated test)

## Test plan

- [x] `npm run test` - 570/571 passing (1 pre-existing, unrelated flake in `UnifiedTimerHome.test.tsx`, confirmed on the base branch too, doesn't render Tabs or Tooltip)
- [x] `npm run lint` / `tsc --noEmit` - clean
- [x] `npm run build:production` - succeeds
- [x] Manual verification against a real Chromium browser (Playwright, pinned executable) covering: click switches tabs, `ArrowRight` moves focus and auto-activates, roving tabindex (only the active tab is in the page's Tab order), `aria-controls`/`aria-labelledby` pairing on mounted panels
- [ ] `npm run test:storybook` / `npm run test:a11y` - blocked by the same pre-existing sandbox limitations #582/#583 documented (Playwright browser version mismatch; no backend for a11y auth)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vv4NCmVNRqm9ubQeUSgkAb)_