### PR TITLE
feat: replace Radix Popover with Tamagui (FeedbackWidget) (#585)

### DIFF
--- a/frontend/src/components/FeedbackWidget/FeedbackWidget.test.tsx
+++ b/frontend/src/components/FeedbackWidget/FeedbackWidget.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TamaguiProvider } from 'tamagui';
+import FeedbackWidget from './FeedbackWidget';
+import tamaguiConfig from '../../../tamagui.config';
+
+// The underlying Tamagui Popover (#585) needs a TamaguiProvider ancestor,
+// same as Tooltip (#583) and AlertDialog (#582) - the app root (src/main.tsx)
+// provides this in production; tests need their own.
+function renderWidget() {
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
+      <FeedbackWidget />
+    </TamaguiProvider>
+  );
+}
+
+describe('FeedbackWidget', () => {
+  it('does not show the feedback panel until the button is clicked', () => {
+    renderWidget();
+    expect(screen.queryByText('Help us improve Progress RPG')).not.toBeInTheDocument();
+  });
+
+  it('opens the feedback panel with both survey links on click', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await user.click(screen.getByRole('button', { name: '💬 Feedback' }));
+
+    expect(await screen.findByText('Help us improve Progress RPG')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Quick feedback/ })).toHaveAttribute(
+      'href',
+      'https://forms.gle/uCCg2grwzgVwwB617'
+    );
+    expect(screen.getByRole('link', { name: /First impressions/ })).toHaveAttribute(
+      'href',
+      'https://forms.gle/bHPqtd7ukbwF4WGu8'
+    );
+  });
+
+  it('closes the panel via the close button', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await user.click(screen.getByRole('button', { name: '💬 Feedback' }));
+    await screen.findByText('Help us improve Progress RPG');
+
+    await user.click(screen.getByRole('button', { name: 'Close feedback panel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Help us improve Progress RPG')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/frontend/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -1,50 +1,43 @@
 import React from "react";
-import * as Popover from "@radix-ui/react-popover";
+import Popover from "../Popover/Popover";
 import styles from "./FeedbackWidget.module.scss";
 import Button from "../Button/Button";
 
 const FeedbackWidget = () => {
   return (
     <div className={styles.feedbackWidget}>
-      <Popover.Root>
+      <Popover.Root side="top" align="end" sideOffset={8}>
         <Popover.Trigger asChild>
           <Button className={styles.feedbackButton}>💬 Feedback</Button>
         </Popover.Trigger>
 
-        <Popover.Portal>
-          <Popover.Content
-            className={styles.feedbackPanel}
-            side="top"
-            align="end"
-            sideOffset={8}
-          >
-            <Popover.Close asChild>
-              <Button className={styles.closeButton} ariaLabel="Close feedback panel">
-                ×
-              </Button>
-            </Popover.Close>
-            <h3>Help us improve Progress RPG</h3>
-            <p>Spotted a bug? Got an idea? Send us your feedback:</p>
-            <div className={styles.buttonGroup}>
-              <a
-                href="https://forms.gle/uCCg2grwzgVwwB617"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`${styles.modalButton} ${styles.form}`}
-              >
-                ⌚ Quick feedback (30 seconds)
-              </a>
-              <a
-                href="https://forms.gle/bHPqtd7ukbwF4WGu8"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`${styles.modalButton} ${styles.form}`}
-              >
-                💡 First impressions (5 minutes)
-              </a>
-            </div>
-          </Popover.Content>
-        </Popover.Portal>
+        <Popover.Content className={styles.feedbackPanel}>
+          <Popover.Close asChild>
+            <Button className={styles.closeButton} ariaLabel="Close feedback panel">
+              ×
+            </Button>
+          </Popover.Close>
+          <h3>Help us improve Progress RPG</h3>
+          <p>Spotted a bug? Got an idea? Send us your feedback:</p>
+          <div className={styles.buttonGroup}>
+            <a
+              href="https://forms.gle/uCCg2grwzgVwwB617"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${styles.modalButton} ${styles.form}`}
+            >
+              ⌚ Quick feedback (30 seconds)
+            </a>
+            <a
+              href="https://forms.gle/bHPqtd7ukbwF4WGu8"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${styles.modalButton} ${styles.form}`}
+            >
+              💡 First impressions (5 minutes)
+            </a>
+          </div>
+        </Popover.Content>
       </Popover.Root>
     </div>
   );

--- a/frontend/src/components/Popover/Popover.test.tsx
+++ b/frontend/src/components/Popover/Popover.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TamaguiProvider } from 'tamagui';
+import Popover from './Popover';
+import tamaguiConfig from '../../../tamagui.config';
+
+// Tamagui's Popover (#585) needs a TamaguiProvider ancestor - unlike Radix's
+// Popover.Root, it isn't usable standalone. The app root (src/main.tsx)
+// provides this in production; tests need their own.
+function renderWithProvider(ui: React.ReactElement) {
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
+      {ui}
+    </TamaguiProvider>
+  );
+}
+
+function renderPopover(props: Partial<React.ComponentProps<typeof Popover.Root>> = {}) {
+  renderWithProvider(
+    <>
+      <Popover.Root {...props}>
+        <Popover.Trigger asChild>
+          <button type="button">Trigger</button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Popover.Close asChild>
+            <button type="button">Close</button>
+          </Popover.Close>
+          <p>Panel content</p>
+        </Popover.Content>
+      </Popover.Root>
+      <button type="button">Elsewhere</button>
+    </>
+  );
+}
+
+describe('Popover', () => {
+  it('is closed by default and opens when the trigger is clicked', async () => {
+    const user = userEvent.setup();
+    renderPopover();
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Trigger' }));
+    expect(await screen.findByRole('dialog')).toHaveTextContent('Panel content');
+  });
+
+  it('toggles closed when the trigger is clicked again', async () => {
+    const user = userEvent.setup();
+    renderPopover();
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
+    await user.click(trigger);
+    await screen.findByRole('dialog');
+
+    await user.click(trigger);
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes via the Close button and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    renderPopover();
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
+    await user.click(trigger);
+    await user.click(await screen.findByRole('button', { name: 'Close' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveFocus();
+  });
+
+  it('closes on outside click', async () => {
+    const user = userEvent.setup();
+    renderPopover();
+
+    await user.click(screen.getByRole('button', { name: 'Trigger' }));
+    await screen.findByRole('dialog');
+
+    await user.click(screen.getByRole('button', { name: 'Elsewhere' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes on Escape', async () => {
+    const user = userEvent.setup();
+    renderPopover();
+
+    await user.click(screen.getByRole('button', { name: 'Trigger' }));
+    await screen.findByRole('dialog');
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('exposes aria-expanded and aria-controls on the trigger', async () => {
+    const user = userEvent.setup();
+    renderPopover();
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).not.toHaveAttribute('aria-controls');
+
+    await user.click(trigger);
+    await screen.findByRole('dialog');
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    const controlsId = trigger.getAttribute('aria-controls');
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId!)).toHaveTextContent('Panel content');
+  });
+
+  it('supports a controlled open state', async () => {
+    const onOpenChange = vi.fn();
+    renderPopover({ open: true, onOpenChange });
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Popover/Popover.tsx
+++ b/frontend/src/components/Popover/Popover.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { Popover as PopoverPrimitive } from 'tamagui';
+
+type PopoverSide = 'top' | 'bottom' | 'left' | 'right';
+type PopoverAlign = 'start' | 'center' | 'end';
+
+interface PopoverContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  contentId: string;
+}
+
+const PopoverContext = React.createContext<PopoverContextValue | null>(null);
+
+function usePopoverContext(componentName: string): PopoverContextValue {
+  const context = React.useContext(PopoverContext);
+  if (!context) {
+    throw new Error(`Popover.${componentName} must be used within Popover.Root`);
+  }
+  return context;
+}
+
+// Radix positions via side/align/sideOffset on Content; Tamagui's underlying
+// Popper resolves placement/offset up at the Root instead, so those props
+// live on Root here rather than Content.
+function toTamaguiPlacement(side: PopoverSide, align: PopoverAlign) {
+  return align === 'center' ? side : (`${side}-${align}` as const);
+}
+
+interface PopoverRootProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  side?: PopoverSide;
+  align?: PopoverAlign;
+  sideOffset?: number;
+}
+
+function Root({
+  children,
+  open: openProp,
+  defaultOpen = false,
+  onOpenChange,
+  side = 'top',
+  align = 'center',
+  sideOffset = 8,
+}: PopoverRootProps): React.ReactElement {
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : uncontrolledOpen;
+  const contentId = React.useId();
+
+  const setOpen = React.useCallback(
+    (value: boolean) => {
+      if (!isControlled) setUncontrolledOpen(value);
+      onOpenChange?.(value);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const contextValue = React.useMemo<PopoverContextValue>(
+    () => ({ open, setOpen, contentId }),
+    [open, setOpen, contentId]
+  );
+
+  return (
+    <PopoverContext.Provider value={contextValue}>
+      <PopoverPrimitive
+        open={open}
+        onOpenChange={setOpen}
+        placement={toTamaguiPlacement(side, align)}
+        offset={sideOffset}
+        allowFlip
+        stayInFrame={{ padding: 8 }}
+      >
+        {children}
+      </PopoverPrimitive>
+    </PopoverContext.Provider>
+  );
+}
+
+type ClickableElement = React.ReactElement<
+  { onClick?: React.MouseEventHandler } & Record<string, unknown>
+>;
+
+interface PopoverTriggerProps {
+  children: ClickableElement;
+  asChild?: boolean;
+  className?: string;
+}
+
+/**
+ * Tamagui's built-in click-to-toggle fires through `onPress`, which our
+ * plain (non-RN) `Button` never receives as a real DOM event - the same
+ * class of gap #582's AlertDialog hit with Cancel/Action. `disablePressTrigger`
+ * turns that off; toggling instead happens through a normal `onClick` we
+ * compose onto the child ourselves, matching Radix's own trigger (which used
+ * a real `onClick` too).
+ */
+function Trigger({ children, className }: PopoverTriggerProps): React.ReactElement {
+  const { open, setOpen, contentId } = usePopoverContext('Trigger');
+
+  const handleClick = (event: React.MouseEvent) => {
+    children.props.onClick?.(event);
+    setOpen(!open);
+  };
+
+  return (
+    <PopoverPrimitive.Trigger asChild disablePressTrigger className={className}>
+      {React.cloneElement(children, {
+        onClick: handleClick,
+        'aria-haspopup': 'dialog',
+        'aria-controls': open ? contentId : undefined,
+      })}
+    </PopoverPrimitive.Trigger>
+  );
+}
+
+interface PopoverContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+// Tamagui already assigns `role="dialog"` to the floating wrapper itself
+// (@tamagui/popover's useFloatingContext wires floating-ui's `useRole`) -
+// setting it again here would just duplicate the landmark. `id` still needs
+// setting explicitly so Trigger's `aria-controls` below has something
+// stable to point at.
+function Content({ children, className }: PopoverContentProps): React.ReactElement {
+  const { contentId } = usePopoverContext('Content');
+
+  return (
+    <PopoverPrimitive.Content id={contentId} unstyled className={className}>
+      {children}
+    </PopoverPrimitive.Content>
+  );
+}
+
+interface PopoverCloseProps {
+  children: ClickableElement;
+  asChild?: boolean;
+}
+
+/**
+ * Bypasses Tamagui's own `Popover.Close` for the same reason `Trigger` does:
+ * it composes onto `onPress`, which our `Button` never turns into a real
+ * click. Closing directly through our own `setOpen` sidesteps it.
+ */
+function Close({ children }: PopoverCloseProps): React.ReactElement {
+  const { setOpen } = usePopoverContext('Close');
+
+  const handleClick = (event: React.MouseEvent) => {
+    children.props.onClick?.(event);
+    setOpen(false);
+  };
+
+  return React.cloneElement(children, { onClick: handleClick });
+}
+
+const Popover = { Root, Trigger, Content, Close };
+
+export default Popover;


### PR DESCRIPTION
## Summary

Implements #585: introduces a local `Popover` wrapper (`Root`/`Trigger`/`Content`/`Close`) backed by Tamagui's `Popover`, and swaps `FeedbackWidget`'s direct `@radix-ui/react-popover` import for it. Branched off #793 (#584's Tabs/Tamagui branch), the next link in the migration chain (#580→#581→#582→#583→#584→this).

### Scope decision (per the issue's sequencing section)

Went with the **preferred** option: only `FeedbackWidget` is migrated here. The Navbar's announcements `Popover` (`Navbar.tsx:121-209`) stays on Radix - it's entangled with the `Accordion`/`DropdownMenu` rework, so untangling it here would just invite conflicts with the Navbar sub-issue that owns that work. `@radix-ui/react-popover` therefore stays installed (still used by `Navbar.tsx`); only the import in `FeedbackWidget.tsx` is gone.

### Key implementation notes

- **Tamagui's own `Trigger`/`Close` compose their click handling onto `onPress`, not `onClick`** - our plain (non-RN) `Button` component never turns that into a real DOM click, the same class of gap #582's `AlertDialog` hit with `Cancel`/`Action`. Fixed by passing `disablePressTrigger` (a prop Tamagui's `PopoverTrigger` exposes for exactly this) and toggling/closing through a normal `onClick` composed onto the child ourselves - matching what Radix's own trigger did (a real `onClick`, per its source).
- **Radix positions via `side`/`align`/`sideOffset` on `Content`; Tamagui's `Popper` resolves `placement`/`offset` up at the `Root`.** Rather than fight that with children-inspection tricks, `side`/`align`/`sideOffset` live on our `Popover.Root` instead (the only call site in scope is being edited anyway, so this isn't a "just swap the import" constraint like Tabs' two call sites had).
- **No `Popover.Portal` in the new API** - Tamagui's `Popover.Content` already portals internally, so a passthrough `Portal` would be dead weight. `FeedbackWidget` drops that layer.
- **`aria-controls`/`aria-haspopup` are wired manually on `Trigger`.** Tamagui's own `PopoverTrigger` has a `// TODO not matching` next to a commented-out `aria-controls` (a known, currently-unfixed gap in `@tamagui/popover`), so our wrapper sets `aria-haspopup="dialog"` and `aria-controls` itself, pointed at an id `Root` generates and `Content` applies.
- **No explicit `role="dialog"` on `Content`.** Tamagui already assigns that to the floating wrapper itself (`@tamagui/popover`'s `useFloatingContext` wires floating-ui's `useRole`) - adding it again on `Content` produced a second, duplicate `dialog` landmark in testing, so `Content` only sets `id` (needed for `aria-controls` to point at something).
- Everything else - focus moving into the panel on open, focus returning to the trigger on close, escape/outside-click dismissal - comes free from Tamagui's `Popover` (it wires `FocusScope` + `Dismissable` internally, "adapted from radix-ui popover" per its own source comment), unlike Tooltip (#583) which had to hand-roll all of that itself.

## Acceptance criteria

- [x] A local `Popover` wrapper exists and `FeedbackWidget` uses it with no direct Radix import
- [x] No `@radix-ui/react-popover` import remains in the sites migrated by this issue (`Navbar.tsx` still imports it - out of scope, see above)
- [x] Placement (`side`/`align`/`sideOffset`) and collision behaviour preserved (`allowFlip` + `stayInFrame`, same as Tooltip)
- [x] Focus moves into the panel on open and returns to the trigger on close
- [x] Click-outside and escape both dismiss
- [x] Trigger exposes correct expanded/controls state to screen readers (`aria-expanded`, `aria-controls`, `aria-haspopup`)
- [x] The `Popover.Close` affordance still works (FeedbackWidget's × button)
- [x] Scope decision on the Navbar Popover recorded in this PR description (see above)
- [ ] `npm run test:a11y` - blocked by this sandbox having no backend to authenticate against (`ECONNREFUSED 127.0.0.1:8000`), same limitation as #582/#583/#793

## Test plan

- [x] `npm run test` - all relevant tests pass (added `Popover.test.tsx` and `FeedbackWidget.test.tsx` - `FeedbackWidget` had no test before); the one failure in the full run is the pre-existing `UnifiedTimerHome.test.tsx` flake #793 already documented (doesn't render Popover/Tabs/Tooltip)
- [x] `npm run lint` / `tsc --noEmit` - clean
- [x] `npm run build:production` - succeeds
- [x] Manual verification against a real Chromium browser (Playwright, pinned executable, isolated harness outside the authenticated app shell): closed by default; click opens with correct `top`/`end`/`8px` placement; focus auto-moves to the close button on open; Escape closes and returns focus to the trigger; outside click closes; the close button closes and returns focus to the trigger; both survey links resolve to the correct URLs
- [ ] `npm run test:storybook` / `npm run test:a11y` - blocked by the same pre-existing sandbox limitations #582/#583/#793 documented (Playwright headless-shell version mismatch; no backend for a11y auth)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCkpqepd3zYccf9bwNBhZH)_