### PR TITLE
feat: replace Radix DropdownMenu/Accordion/Popover in Navbar (#586)

### DIFF
--- a/frontend/src/components/Accordion/Accordion.tsx
+++ b/frontend/src/components/Accordion/Accordion.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Accordion as AccordionPrimitive } from 'tamagui';
+
+/**
+ * Tamagui's Accordion (built on its Collapsible primitive) already mirrors
+ * Radix's Root/Item/Header/Trigger/Content shape and its `type`/`value`/
+ * `defaultValue`/`onValueChange` API almost exactly ("adapted from
+ * radix-ui accordion" per its own source) - unlike Popover/DropdownMenu,
+ * every part here renders as a genuine Tamagui host element rather than
+ * `asChild`-wrapping one of our own plain components, so there's no
+ * onPress/onClick gap to work around. This wrapper just applies `unstyled`
+ * by default so call sites don't have to repeat it, and keeps the import
+ * local rather than reaching into `tamagui` directly from feature code.
+ */
+
+interface AccordionRootProps {
+  children: React.ReactNode;
+  type: 'single' | 'multiple';
+  className?: string;
+  value?: string | string[];
+  defaultValue?: string | string[];
+  onValueChange?: (value: string | string[]) => void;
+}
+
+function Root(props: AccordionRootProps): React.ReactElement {
+  // Tamagui's `Root` distinguishes single/multiple by the *shape* of
+  // value/defaultValue (string vs string[]) rather than reading `type`
+  // itself for that, but still requires `type` for its own validation -
+  // passing everything straight through keeps both satisfied.
+  return <AccordionPrimitive {...(props as React.ComponentProps<typeof AccordionPrimitive>)} />;
+}
+
+interface AccordionItemProps {
+  children: React.ReactNode;
+  value: string;
+  className?: string;
+}
+
+function Item({ children, ...rest }: AccordionItemProps): React.ReactElement {
+  return <AccordionPrimitive.Item {...rest}>{children}</AccordionPrimitive.Item>;
+}
+
+interface AccordionHeaderProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function Header({ children, ...rest }: AccordionHeaderProps): React.ReactElement {
+  return <AccordionPrimitive.Header {...rest}>{children}</AccordionPrimitive.Header>;
+}
+
+interface AccordionTriggerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function Trigger({ children, ...rest }: AccordionTriggerProps): React.ReactElement {
+  return (
+    <AccordionPrimitive.Trigger unstyled {...rest}>
+      {children}
+    </AccordionPrimitive.Trigger>
+  );
+}
+
+interface AccordionContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function Content({ children, ...rest }: AccordionContentProps): React.ReactElement {
+  return (
+    <AccordionPrimitive.Content unstyled {...rest}>
+      {children}
+    </AccordionPrimitive.Content>
+  );
+}
+
+const Accordion = { Root, Item, Header, Trigger, Content };
+
+export default Accordion;

--- a/frontend/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/frontend/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TamaguiProvider } from 'tamagui';
+import DropdownMenu from './DropdownMenu';
+import tamaguiConfig from '../../../tamagui.config';
+
+// Tamagui's Menu (#586) needs a TamaguiProvider ancestor - unlike Radix's
+// DropdownMenu.Root, it isn't usable standalone. The app root (src/main.tsx)
+// provides this in production; tests need their own.
+function renderWithProvider(ui: React.ReactElement) {
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
+      {ui}
+    </TamaguiProvider>
+  );
+}
+
+function renderMenu({
+  onAccountSelect,
+  onToggleSelect,
+}: { onAccountSelect?: () => void; onToggleSelect?: () => void } = {}) {
+  renderWithProvider(
+    <>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>Account menu</DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item onSelect={onToggleSelect}>Tutorial</DropdownMenu.Item>
+            <DropdownMenu.Item asChild onSelect={onAccountSelect}>
+              <a href="/account">Account</a>
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+      <button type="button">Elsewhere</button>
+    </>
+  );
+}
+
+describe('DropdownMenu', () => {
+  it('is closed by default and opens when the trigger is clicked', async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Account menu' }));
+    expect(await screen.findByRole('menu')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Tutorial' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Account' })).toBeInTheDocument();
+  });
+
+  it('exposes aria-haspopup/aria-expanded/aria-controls on the trigger', async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    const trigger = screen.getByRole('button', { name: 'Account menu' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(trigger);
+    const menu = await screen.findByRole('menu');
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).toHaveAttribute('aria-controls', menu.id);
+  });
+
+  it('navigates between items with arrow keys', async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole('button', { name: 'Account menu' }));
+    await screen.findByRole('menu');
+
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('menuitem', { name: 'Tutorial' })).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('menuitem', { name: 'Account' })).toHaveFocus();
+  });
+
+  it('closes on outside click and Escape', async () => {
+    // Tamagui's Menu is modal by default (matching Radix's DropdownMenu.Root
+    // default) and disables pointer events on the rest of the page while
+    // open - real browser behaviour, not a test artefact (AlertDialog's
+    // #582 test hit the same thing) - so skip userEvent's pointer-events
+    // guard to let the click still dispatch.
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderMenu();
+
+    await user.click(screen.getByRole('button', { name: 'Account menu' }));
+    await screen.findByRole('menu');
+    await user.click(screen.getByRole('button', { name: 'Elsewhere' }));
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Account menu' }));
+    await screen.findByRole('menu');
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+
+  it('returns focus to the trigger after Escape closes the menu', async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    const trigger = screen.getByRole('button', { name: 'Account menu' });
+    await user.click(trigger);
+    await screen.findByRole('menu');
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it('a plain item fires onSelect and closes the menu on click', async () => {
+    const user = userEvent.setup();
+    const onToggleSelect = vi.fn();
+    renderMenu({ onToggleSelect });
+
+    await user.click(screen.getByRole('button', { name: 'Account menu' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Tutorial' }));
+
+    expect(onToggleSelect).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+
+  it('an asChild link item navigates, fires onSelect, and closes the menu', async () => {
+    const user = userEvent.setup();
+    const onAccountSelect = vi.fn();
+    renderMenu({ onAccountSelect });
+
+    await user.click(screen.getByRole('button', { name: 'Account menu' }));
+    const link = screen.getByRole('menuitem', { name: 'Account' });
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/account');
+
+    await user.click(link);
+
+    expect(onAccountSelect).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+
+  it('an asChild link item also closes the menu via keyboard activation', async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole('button', { name: 'Account menu' }));
+    await user.keyboard('{ArrowDown}{ArrowDown}');
+    expect(screen.getByRole('menuitem', { name: 'Account' })).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/frontend/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { Menu as MenuPrimitive } from 'tamagui';
+
+interface DropdownMenuContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const DropdownMenuContext = React.createContext<DropdownMenuContextValue | null>(null);
+
+function useDropdownMenuContext(componentName: string): DropdownMenuContextValue {
+  const context = React.useContext(DropdownMenuContext);
+  if (!context) {
+    throw new Error(`DropdownMenu.${componentName} must be used within DropdownMenu.Root`);
+  }
+  return context;
+}
+
+type DropdownMenuSide = 'top' | 'bottom' | 'left' | 'right';
+type DropdownMenuAlign = 'start' | 'center' | 'end';
+
+// Radix positions via side/align/sideOffset on Content; Tamagui's Menu (like
+// Popover) resolves placement/offset up at the Root, so those props live on
+// Root here too.
+function toTamaguiPlacement(side: DropdownMenuSide, align: DropdownMenuAlign) {
+  return align === 'center' ? side : (`${side}-${align}` as const);
+}
+
+interface DropdownMenuRootProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  side?: DropdownMenuSide;
+  align?: DropdownMenuAlign;
+  sideOffset?: number;
+}
+
+// Unlike Popover, Tamagui's `Menu` root has no built-in uncontrolled mode of
+// its own (no `useControllableState` internally - it just takes `open` as a
+// plain boolean and proxies `onOpenChange` straight to the caller), so this
+// wrapper's own open-state management isn't optional here the way it was
+// optional-but-convenient for Popover.
+function Root({
+  children,
+  open: openProp,
+  defaultOpen = false,
+  onOpenChange,
+  side = 'bottom',
+  align = 'start',
+  sideOffset = 0,
+}: DropdownMenuRootProps): React.ReactElement {
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : uncontrolledOpen;
+
+  const setOpen = React.useCallback(
+    (value: boolean) => {
+      if (!isControlled) setUncontrolledOpen(value);
+      onOpenChange?.(value);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const contextValue = React.useMemo<DropdownMenuContextValue>(
+    () => ({ open, setOpen }),
+    [open, setOpen]
+  );
+
+  return (
+    <DropdownMenuContext.Provider value={contextValue}>
+      <MenuPrimitive
+        open={open}
+        onOpenChange={setOpen}
+        placement={toTamaguiPlacement(side, align)}
+        offset={sideOffset}
+      >
+        {children}
+      </MenuPrimitive>
+    </DropdownMenuContext.Provider>
+  );
+}
+
+type ClickableElement = React.ReactElement<
+  { onClick?: React.MouseEventHandler } & Record<string, unknown>
+>;
+
+interface DropdownMenuTriggerProps {
+  children: React.ReactNode;
+  className?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * Deliberately not `asChild`. Tamagui's Menu trigger fires through a real
+ * `onPointerDown`/`onClick` once mounted (RN's `onPress` only applies on
+ * native - see createNonNativeMenu's `pressEvent`), but merging that via
+ * `asChild` onto one of our own plain DOM elements (a raw `<button>`)
+ * silently breaks under a coarse-pointer/touch viewport - confirmed with a
+ * dedicated repro against real Playwright touch emulation, not just this
+ * one sandbox quirk, since real phones also report a coarse pointer: the
+ * merged `onClick` never attaches at all, so tapping the account menu
+ * button would do nothing on an actual phone. Rendering Tamagui's own
+ * trigger directly (no asChild) sidesteps it, since it then owns its own
+ * host element and wires onClick/onPress correctly regardless of pointer
+ * type. That host renders as a `<div role="button">`, not a real
+ * `<button>`, so `tabIndex={0}` is needed for keyboard reachability -
+ * Enter/Space activation, ArrowDown-opens-and-focuses-first-item, and
+ * aria-expanded/haspopup/controls are all already wired in correctly once
+ * the trigger owns its own element.
+ */
+function Trigger({ children, className, ...rest }: DropdownMenuTriggerProps): React.ReactElement {
+  return (
+    <MenuPrimitive.Trigger tabIndex={0} className={className} {...rest}>
+      {children}
+    </MenuPrimitive.Trigger>
+  );
+}
+
+interface DropdownMenuPortalProps {
+  children: React.ReactNode;
+}
+
+function Portal({ children }: DropdownMenuPortalProps): React.ReactElement {
+  return <MenuPrimitive.Portal>{children}</MenuPrimitive.Portal>;
+}
+
+interface DropdownMenuContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function Content({ children, className }: DropdownMenuContentProps): React.ReactElement {
+  return (
+    <MenuPrimitive.Content unstyled className={className}>
+      {children}
+    </MenuPrimitive.Content>
+  );
+}
+
+interface AsChildItemProps {
+  children: ClickableElement;
+  asChild: true;
+  className?: string;
+  onSelect?: () => void;
+}
+
+interface PlainItemProps {
+  children: React.ReactNode;
+  asChild?: false;
+  className?: string;
+  onSelect?: (event: { preventDefault: () => void }) => void;
+}
+
+type DropdownMenuItemProps = AsChildItemProps | PlainItemProps;
+
+/**
+ * Tamagui's own `Menu.Item` closes the menu (and fires `onSelect`) through
+ * `onPress` - fine for the plain-content case below, where `Menu.Item`
+ * renders its own real Tamagui host element and `onPress` works natively,
+ * but not for `asChild` wrapping one of our own links: the click/Enter/Space
+ * handling that gets composed onto the child (via `.click()`, so navigation
+ * itself always works) never reaches `onPress`, so the menu would silently
+ * never close and `onSelect` would never fire. `asChild` items bypass
+ * Tamagui's built-in select handling entirely and close through our own
+ * `onClick` instead - the same shape of fix Popover's Trigger/Close needed.
+ */
+function Item(props: DropdownMenuItemProps): React.ReactElement {
+  const { setOpen } = useDropdownMenuContext('Item');
+
+  if (props.asChild) {
+    const { children, className, onSelect } = props;
+    const handleClick = (event: React.MouseEvent) => {
+      children.props.onClick?.(event);
+      onSelect?.();
+      setOpen(false);
+    };
+
+    return (
+      <MenuPrimitive.Item asChild className={className}>
+        {React.cloneElement(children, { onClick: handleClick })}
+      </MenuPrimitive.Item>
+    );
+  }
+
+  const { children, className, onSelect } = props;
+
+  return (
+    <MenuPrimitive.Item unstyled className={className} onSelect={onSelect}>
+      {children}
+    </MenuPrimitive.Item>
+  );
+}
+
+const DropdownMenu = { Root, Trigger, Portal, Content, Item };
+
+export default DropdownMenu;

--- a/frontend/src/components/Popover/Popover.tsx
+++ b/frontend/src/components/Popover/Popover.tsx
@@ -120,6 +120,7 @@ function Trigger({ children, className }: PopoverTriggerProps): React.ReactEleme
 interface PopoverContentProps {
   children: React.ReactNode;
   className?: string;
+  'aria-label'?: string;
 }
 
 // Tamagui already assigns `role="dialog"` to the floating wrapper itself
@@ -127,11 +128,11 @@ interface PopoverContentProps {
 // setting it again here would just duplicate the landmark. `id` still needs
 // setting explicitly so Trigger's `aria-controls` below has something
 // stable to point at.
-function Content({ children, className }: PopoverContentProps): React.ReactElement {
+function Content({ children, ...rest }: PopoverContentProps): React.ReactElement {
   const { contentId } = usePopoverContext('Content');
 
   return (
-    <PopoverPrimitive.Content id={contentId} unstyled className={className}>
+    <PopoverPrimitive.Content id={contentId} unstyled {...rest}>
       {children}
     </PopoverPrimitive.Content>
   );

--- a/frontend/src/layout/Navbar/Announcements.tsx
+++ b/frontend/src/layout/Navbar/Announcements.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import * as Popover from "@radix-ui/react-popover";
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import * as Accordion from "@radix-ui/react-accordion";
+import Popover from "../../components/Popover/Popover";
+import DropdownMenu from "../../components/DropdownMenu/DropdownMenu";
+import Accordion from "../../components/Accordion/Accordion";
 import ReactMarkdown from "react-markdown";
 import Button from "../../components/Button/Button";
 import styles from "./Announcements.module.scss";
@@ -110,7 +110,7 @@ interface AnnouncementsBellProps extends AnnouncementsData {
 /** Desktop bell icon + unread badge that opens the announcements list in a popover. */
 export function AnnouncementsBell({ triggerClassName, ...data }: AnnouncementsBellProps) {
   return (
-    <Popover.Root>
+    <Popover.Root side="bottom" align="end" sideOffset={6}>
       <Popover.Trigger asChild>
         <Button
           className={`${triggerClassName} ${styles.trigger}`}
@@ -125,17 +125,9 @@ export function AnnouncementsBell({ triggerClassName, ...data }: AnnouncementsBe
           )}
         </Button>
       </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
-          className={styles.popoverContent}
-          side="bottom"
-          align="end"
-          sideOffset={6}
-          aria-label="Announcements"
-        >
-          <AnnouncementsListContent {...data} idPrefix="announcement-" />
-        </Popover.Content>
-      </Popover.Portal>
+      <Popover.Content className={styles.popoverContent} aria-label="Announcements">
+        <AnnouncementsListContent {...data} idPrefix="announcement-" />
+      </Popover.Content>
     </Popover.Root>
   );
 }

--- a/frontend/src/layout/Navbar/Navbar.test.tsx
+++ b/frontend/src/layout/Navbar/Navbar.test.tsx
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
+import { TamaguiProvider } from "tamagui";
 
 import Navbar from "./Navbar";
+import tamaguiConfig from "../../../tamagui.config";
 
 const mockUseAuth = vi.fn();
 const mockUseGame = vi.fn();
@@ -36,14 +38,19 @@ vi.mock("../../hooks/useAnnouncements", () => ({
   }),
 }));
 
+// Navbar's DropdownMenu/Popover/Accordion (#586) are backed by Tamagui,
+// which needs a TamaguiProvider ancestor - the app root (src/main.tsx)
+// provides this in production; tests need their own.
 function renderNavbar(
   props: Partial<React.ComponentProps<typeof Navbar>> = {},
   initialPath = "/"
 ) {
   return render(
-    <MemoryRouter initialEntries={[initialPath]}>
-      <Navbar {...props} />
-    </MemoryRouter>
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Navbar {...props} />
+      </MemoryRouter>
+    </TamaguiProvider>
   );
 }
 
@@ -233,6 +240,51 @@ describe("Navbar", () => {
     await user.click(screen.getByRole("button", { name: "Mark read" }));
 
     expect(markOneMutate).toHaveBeenCalledWith(42);
+  });
+
+  it("allows multiple announcement sections to be expanded at once", async () => {
+    const user = userEvent.setup();
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockUseFeatureFlag.mockReturnValue(true);
+    mockUseAnnouncements.mockReturnValue({
+      data: {
+        results: [
+          { id: 1, title: "First", summary: "", body: "First body", is_read: true },
+          { id: 2, title: "Second", summary: "", body: "Second body", is_read: true },
+        ],
+        unread_count: 0,
+      },
+      isLoading: false,
+    });
+    renderNavbar();
+
+    await user.click(screen.getByRole("button", { name: "Announcements" }));
+    await user.click(screen.getByText("First"));
+    await user.click(screen.getByText("Second"));
+
+    expect(screen.getByText("First body")).toBeInTheDocument();
+    expect(screen.getByText("Second body")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /First/ })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(screen.getByRole("button", { name: /Second/ })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("opens the mobile account menu and navigates via the account/logout links", async () => {
+    const user = userEvent.setup();
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    renderNavbar();
+
+    await user.click(screen.getByRole("button", { name: "Account menu", hidden: true }));
+
+    const accountLink = await screen.findByRole("menuitem", { name: /Account/ });
+    const logoutLink = screen.getByRole("menuitem", { name: /Log out/ });
+    expect(accountLink).toHaveAttribute("href", "/account");
+    expect(logoutLink).toHaveAttribute("href", "/logout");
   });
 
   it("highlights the timer button as primary on the timer page", () => {

--- a/frontend/src/layout/Navbar/Navbar.tsx
+++ b/frontend/src/layout/Navbar/Navbar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useLocation, Link } from "react-router";
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import DropdownMenu from "../../components/DropdownMenu/DropdownMenu";
 import styles from "./Navbar.module.scss";
 import Button from "../../components/Button/Button";
 import { AnnouncementsBell, MobileAnnouncements } from "./Announcements";
@@ -191,30 +191,24 @@ export default function Navbar({ onMenuClick, onHelpClick }: NavbarProps) {
                 </svg>
               </Link>
               <div className={styles.accountMenu}>
-                <DropdownMenu.Root>
-                  <DropdownMenu.Trigger asChild>
-                    <button
-                      className={styles.accountTrigger}
-                      aria-label="Account menu"
+                <DropdownMenu.Root align="end" sideOffset={4}>
+                  <DropdownMenu.Trigger
+                    className={styles.accountTrigger}
+                    aria-label="Account menu"
+                  >
+                    <svg
+                      className={styles.personIcon}
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                      focusable="false"
                     >
-                      <svg
-                        className={styles.personIcon}
-                        viewBox="0 0 24 24"
-                        aria-hidden="true"
-                        focusable="false"
-                      >
-                        <circle cx="12" cy="8" r="4" />
-                        <path d="M4 20c0-4.4 3.6-8 8-8s8 3.6 8 8" />
-                      </svg>
-                    </button>
+                      <circle cx="12" cy="8" r="4" />
+                      <path d="M4 20c0-4.4 3.6-8 8-8s8 3.6 8 8" />
+                    </svg>
                   </DropdownMenu.Trigger>
 
                   <DropdownMenu.Portal>
-                    <DropdownMenu.Content
-                      className={styles.accountDropdownContent}
-                      align="end"
-                      sideOffset={4}
-                    >
+                    <DropdownMenu.Content className={styles.accountDropdownContent}>
                       {onHelpClick && (
                         <DropdownMenu.Item
                           className={styles.accountDropdownItem}


### PR DESCRIPTION
## Summary

Implements #586: replaces all three Radix packages `Navbar.tsx`/`Announcements.tsx` import directly (`@radix-ui/react-dropdown-menu`, `@radix-ui/react-accordion`, `@radix-ui/react-popover`) with Tamagui-backed equivalents. Branched off #797 (#585's Popover/FeedbackWidget branch), continuing the migration chain (#580→#581→#582→#583→#584→#585→this). This is the last item in #578.

### Pre-existing work this builds on

The announcements-accordion **duplication** the issue calls out ("worth fixing first") was already resolved by a prior refactor (`dd2e6be`, merged before this session started) - `AnnouncementsBell` (desktop popover) and `MobileAnnouncements` (mobile dropdown panel) already share a single `AnnouncementsListContent`. No further extraction was needed here.

### New wrappers

- **`components/Accordion/Accordion.tsx`** - thin passthrough over Tamagui's `Accordion`, which already mirrors Radix's `Root`/`Item`/`Header`/`Trigger`/`Content` shape and `type="single"|"multiple"` API almost exactly ("adapted from radix-ui accordion" per its own source). Every part renders as a genuine Tamagui host element rather than `asChild`-wrapping one of our own components, so there's no `onPress`/`onClick` gap to work around.
- **`components/DropdownMenu/DropdownMenu.tsx`** - backed by Tamagui's `Menu`.
  - `Item`'s `asChild` path (wrapping our own `Link`s for Account/Logout) bypasses Tamagui's `onPress`-driven select/close handling in favor of a composed `onClick` - the same class of fix Popover's Trigger/Close needed for #585.
  - **`Trigger` needed more than that.** `asChild`-wrapping a plain DOM `<button>` silently fails to open the menu *at all* once `useIsTouchDevice()` resolves true (a coarse-pointer/touch viewport) - I isolated this with a dedicated real-browser repro (Playwright, pinned executable, touch-emulated context) down to exactly `asChild` + a raw DOM child under that one branch (confirmed via `git bisect`-style toggling: non-`asChild` works, `asChild` + touch doesn't, `asChild` + no-touch does). Real phones report a coarse pointer too, so this isn't a sandbox-only artifact - it would have broken the mobile account menu for actual touch users, silently. Fixed by rendering Tamagui's `Trigger` directly (no `asChild`) with an explicit `tabIndex={0}` for keyboard reachability. Re-verified with the same repro: click/tap-to-open, `aria-expanded`, keyboard Tab→Enter, and Escape-with-focus-return all now work correctly, on both a plain and a touch-emulated context.

### Navbar/NavDrawer convergence - explicitly not converging

They serve different purposes: `NavDrawer` is primary site navigation (Timer/Library/Map/Home/Login/Register), the account `DropdownMenu` is account-scoped actions (Tutorial/Announcements/Account/Logout) - and different interaction models (persistent overlay drawer vs. a transient dropdown). No shared structure worth merging; recording this per the issue's acceptance criterion rather than leaving it ambiguous.

## Acceptance criteria

- [x] Announcements accordion exists in exactly one place, used by both desktop and mobile (pre-existing, see above)
- [x] No `@radix-ui/react-dropdown-menu`, `@radix-ui/react-accordion`, or `@radix-ui/react-popover` import remains in `Navbar.tsx` (or `Announcements.tsx`)
- [x] Mobile account menu keyboard-navigable: arrow keys move between items, Escape closes, focus returns to trigger
- [x] Menu items rendered as links/buttons keep correct menu-item semantics (Account/Logout are still real `<a>` tags, verified via a dedicated repro that they navigate + close the menu on both click and Enter)
- [x] Announcements accordion supports multiple sections open at once (`type="multiple"`) with correct `aria-expanded` per section
- [x] Desktop announcements panel positioning and dismissal behaviour preserved (reuses the `Popover` wrapper from #585)
- [x] Decision recorded on Navbar/NavDrawer convergence (deferred, with reasoning - see above)
- [x] `Navbar.test.tsx` passes (extended with multiple-open-accordion and mobile-menu-navigation coverage)
- [ ] `npm run test:a11y` - blocked by this sandbox having no backend to authenticate against (`ECONNREFUSED 127.0.0.1:8000`), same limitation as #582/#583/#585
- [x] Verified by keyboard only, and via Playwright's touch/mobile emulation for the mobile menu (a **real physical touch device** is out of reach in this sandbox - flagging this explicitly since it's the one criterion I can't fully close; would appreciate a manual pass on an actual phone before merging, given the touch-specific bug this PR just found and fixed)

## Test plan

- [x] `npm run test` - all relevant tests pass (590/591 across the full suite); the one failure (`UnifiedTimerHome.test.tsx`) is the pre-existing, unrelated flake #793/#797 already documented
- [x] `npm run lint` / `tsc --noEmit` - clean across `src`
- [x] `npm run build:production` - succeeds
- [x] New `DropdownMenu.test.tsx` (8 tests: open/close, aria-expanded/haspopup/controls, arrow-key nav, Escape + focus return, plain-item `onSelect`, `asChild` link item navigates+closes via both click and keyboard)
- [x] `Navbar.test.tsx` extended (14 tests total, up from 12) with multiple-open-accordion and mobile-account-menu-navigation coverage
- [x] Manual verification against a real Chromium browser (Playwright, pinned executable, isolated harness): desktop positioning/typeahead/Escape+focus-return for the account menu, multiple accordion sections open simultaneously with correct `aria-expanded`, and a touch-emulated pass confirming tap-to-open/tap-outside-to-close/tap-on-link-closes-menu all work post-fix
- [ ] `npm run test:storybook` / `npm run test:a11y` - blocked by the same pre-existing sandbox limitations #582/#583/#585 documented (Playwright headless-shell version mismatch; no backend for a11y auth)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCkpqepd3zYccf9bwNBhZH)_