### PR TITLE
chore: remove unused Radix packages, document a11y parity checklist (#587)

### DIFF
--- a/frontend/docs/RADIX_TO_TAMAGUI_A11Y_CHECKLIST.md
+++ b/frontend/docs/RADIX_TO_TAMAGUI_A11Y_CHECKLIST.md
@@ -1,0 +1,176 @@
+# Radix → Tamagui migration: accessibility parity checklist
+
+Tracks the accessibility verification for #578 (epic: replace Radix UI with
+Tamagui) per #587's acceptance criteria. Captures what was checked, how, and
+what's explicitly deferred - not a rubber stamp. Reusable as a template for
+the styling and routing migrations that follow (#587's own ask); copy the
+table structure and re-run the same passes.
+
+## Status
+
+**Not fully closed.** Two things block full closure, both explained below
+rather than silently absorbed:
+
+1. `DetailSurface.tsx` (Map entity detail cards) still imports
+   `@radix-ui/react-dialog` directly - out of scope for this pass, tracked
+   in [#799](https://github.com/progressrpg/ProgressRPG/issues/799) (see
+   [Remaining Radix usage](#remaining-radix-usage)).
+2. Several verification steps this checklist calls for need infrastructure
+   this sandbox doesn't have (a running Django backend, a real touch
+   device, a screen reader, a matching Playwright browser build for
+   Storybook's a11y addon) - marked **Not run here** below, with what *was*
+   possible run in its place.
+
+## Dependency removal
+
+Nine `@radix-ui/*` packages before this migration started. Current state:
+
+| Package | Status |
+|---|---|
+| `@radix-ui/react-toast` | Removed (#581) |
+| `@radix-ui/react-alert-dialog` | Removed (#582) |
+| `@radix-ui/react-tooltip` | Removed (#583) |
+| `@radix-ui/react-tabs` | Removed (#584) |
+| `@radix-ui/react-progress` | Removed (prior to this migration's sub-issues, per `package.json` history) |
+| `@radix-ui/react-accordion` | Removed (this PR - unused since #586) |
+| `@radix-ui/react-dropdown-menu` | Removed (this PR - unused since #586) |
+| `@radix-ui/react-popover` | Removed (this PR - unused since #585/#586) |
+| `@radix-ui/react-dialog` | **Still installed** - `DetailSurface.tsx` only, see below |
+
+`grep -rn "@radix-ui" frontend/src` returns exactly two hits: a comment in
+`Tabs.tsx` (documents what shape it mirrors, not an import) and the real
+import in `DetailSurface.tsx`.
+
+### Bundle-size delta
+
+Removing the three unused packages (`react-accordion`, `react-dropdown-menu`,
+`react-popover`) changed `npm run build:production`'s output by **0 bytes**
+(`dist/` total and gzip size identical before/after, measured directly).
+Expected: none of the three were imported by any code after #585/#586, so
+Vite's bundler was already excluding them from the shipped bundle - removing
+them from `package.json` is a dependency-hygiene and `npm ci` cleanliness
+win, not a bundle-size one. The real bundle cost of the Tamagui migration
+was already measured and recorded in #629 (+383 kB raw / +102 kB gzip fixed
+cost from wiring in the provider, before any primitive was ported) - nothing
+in this PR changes that number.
+
+## Toolchain
+
+The `@tamagui/vite-plugin` config this migration settled on (per #629,
+finalized rather than the abandoned `@rn-primitives` toolchain #579
+originally scoped for):
+
+- `@tamagui/vite-plugin` wired into `vite.config.ts` (`tamaguiPlugin({config: './tamagui.config.ts', components: ['tamagui']})`)
+- `tamagui.config.ts` at the repo root
+- `<TamaguiProvider>` mounted at the app root (`src/main.tsx`)
+- `.tamagui/` (compiler cache) already in both `.gitignore` and
+  `eslint.config.js`'s `globalIgnores`
+
+No further action needed here - already finalized, not a leftover
+`@rn-primitives`-era workaround.
+
+Final Tamagui dependency set, confirmed present in `package.json`:
+`tamagui`, `@tamagui/core`, `@tamagui/config`, `@tamagui/vite-plugin`,
+`react-native-web` - matching #587's own list.
+
+## Remaining Radix usage
+
+**`frontend/src/components/DetailSurface/DetailSurface.tsx`** - the Map
+entity detail card's dialog primitive (`Root`/`Portal`/`Overlay`/`Content`/
+`Title`), used by both `MapDetailCard` call sites in `Map.tsx`. Its own
+header comment already anticipated this exact migration reaching it.
+
+**Why it's deferred rather than migrated here:** both call sites always pass
+a `container` prop (an arbitrary `HTMLElement`) so the detail panel portals
+into the map's own wrapper instead of `document.body` - needed so the
+non-modal docked panel positions relative to the map, not the viewport.
+Tamagui's web `Portal` (`@tamagui/portal`) hardcodes
+`createPortal(children, document.body)` with no per-instance override, and
+`Dialog.Portal`'s frame carries exit-animation timing, z-index stacking, and
+native-`<dialog>` `show()`/`close()` wiring that a hand-rolled replacement
+portal would need to reproduce correctly - on a component that renders
+inside MapLibre and can't be meaningfully verified in this sandbox (no map
+tiles/API access). Filed as
+[#799](https://github.com/progressrpg/ProgressRPG/issues/799) rather than
+risking a live map feature on an unverified custom-portal reimplementation.
+
+## Known, recorded gaps
+
+Two gaps #587 asked to be confirmed one way or the other, not silently
+inherited:
+
+- **Tamagui's own `Button` sets `aria-disabled` but not the native
+  `disabled` attribute.** Doesn't apply here - grepped `frontend/src` for
+  any import of Tamagui's `Button` and found none. Every component in this
+  app (`AlertDialog`, `Modal`, `Popover`, `DropdownMenu`, etc.) uses this
+  app's own `components/Button/Button.tsx`, which sets both `disabled` (the
+  real DOM attribute, for `as="button"`) and `aria-disabled` correctly.
+- **Tooltip's focus-to-open gap** ([tamagui/tamagui#4152](https://github.com/tamagui/tamagui/issues/4152))
+  - resolved with a workaround, not upstream-fixed: `Tooltip.tsx`'s
+  `handleFocusCapture` intercepts in the capture phase specifically because
+  Tamagui's own bubble-phase `onFocus` is broken (see the comment there,
+  which cites both #583 and the upstream issue). Popover and DropdownMenu
+  share `@tamagui/popper` for positioning but not the hover/focus
+  interaction code the bug is in - neither uses hover-to-open, both are
+  click-driven - so the same bug doesn't reach them; nothing to work around
+  there.
+
+## Per-component verification
+
+Legend: ✅ verified in this sandbox · 📝 verified via reasoning/code
+inspection (see linked PR/component for detail) · ⛔ not runnable here, see
+[What couldn't be verified here](#what-couldnt-be-verified-here).
+
+| Component | Keyboard pass | Focus restore | Screen reader | Touch | Notes |
+|---|---|---|---|---|---|
+| Toast (#581) | 📝 (own PR) | n/a (non-modal) | ⛔ | n/a | See PR #702 |
+| AlertDialog/Modal (#582) | ✅ `AlertDialog.test.tsx`/`Modal.test.tsx` | ✅ (`useReturnFocusOnClose`, tested) | ⛔ | n/a | |
+| Tooltip (#583) | ✅ `Tooltip.test.tsx` | n/a (no trap) | ⛔ | ✅ click/tap-to-toggle, tested | Focus-to-open gap, see above |
+| Tabs (#584) | ✅ roving tabindex, real-browser verified per PR #793 | n/a | ⛔ | n/a | |
+| Popover/FeedbackWidget (#585) | ✅ `Popover.test.tsx` | ✅ tested | ⛔ | ✅ real-browser harness, PR #797 | |
+| Popover/Accordion/DropdownMenu in Navbar (#586) | ✅ `DropdownMenu.test.tsx`, `Navbar.test.tsx` (arrow keys, Escape, multi-open accordion) | ✅ tested | ⛔ | ✅ real-browser touch-emulated harness, PR #798 - found and fixed a real tap-to-open bug (`asChild` + coarse pointer) | Flagged in PR #798 for a real-phone check given the bug found there |
+| ProgressBar | 📝 no interactive semantics to trap/restore | n/a | ⛔ | n/a | |
+
+## What couldn't be verified here
+
+Recorded explicitly per #587's own ask ("any accepted regression recorded
+explicitly with reasoning, rather than silently absorbed") - these aren't
+skipped by choice, they're infrastructure this sandbox doesn't have:
+
+- **`npm run test:a11y`** (axe-core via Playwright) - blocked by no running
+  Django backend to authenticate against (`ECONNREFUSED 127.0.0.1:8000`).
+  Same limitation documented in #582/#583/#585/#586.
+- **`npm run test:storybook`** (Storybook's a11y addon, run via Vitest
+  browser mode) - blocked by a pre-existing Playwright headless-shell
+  version mismatch in this sandbox's browser install, unrelated to this
+  migration. Same limitation documented in #582/#583/#584.
+- **Screen-reader pass** (NVDA/JAWS/VoiceOver/Orca) over toasts, dialogs,
+  tabs, accordion - no screen reader available in this sandbox. ARIA
+  attributes for each (role, aria-expanded/selected/live, etc.) were
+  verified via jsdom + real-browser DOM inspection instead (see each
+  component's own PR), which catches incorrect/missing attributes but not
+  announcement politeness or phrasing.
+- **Real touch-device pass** - no physical touch hardware in this sandbox.
+  Playwright's touch/mobile emulation was used instead (see #585/#586 PRs)
+  and, in #586's case, caught a real bug emulation-only testing would have
+  otherwise missed if taken as sufficient on its own - which is exactly why
+  this row stays ⛔ rather than being upgraded to ✅ on emulation alone.
+
+## Reusing this checklist
+
+For a future migration (styling, routing, or otherwise):
+
+1. Copy the "Per-component verification" table, one row per component
+   touched.
+2. For each: run its unit tests (keyboard, focus restore), grep for the
+   library being replaced to confirm the swap is complete, and do a
+   real-browser pass (Playwright with the pinned executable if
+   `test:storybook`/`test:a11y` aren't runnable) for anything jsdom can't
+   observe - positioning, touch/pointer-type-conditional behaviour, real
+   focus movement.
+3. Record every gap found against the library being replaced explicitly,
+   even ones judged safe to accept - this doc's "Known, recorded gaps"
+   section is the model.
+4. Update the "What couldn't be verified here" section for whatever
+   infrastructure is actually available in the environment you're running
+   in - it won't always be the same gaps.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,7 @@
       "name": "frontend",
       "version": "0.12.0",
       "dependencies": {
-        "@radix-ui/react-accordion": "^1.2.15",
         "@radix-ui/react-dialog": "^1.1.14",
-        "@radix-ui/react-dropdown-menu": "^2.1.19",
-        "@radix-ui/react-popover": "^1.1.18",
         "@tamagui/config": "^2.7.6",
         "@tamagui/core": "^2.7.6",
         "@tamagui/vite-plugin": "^2.7.6",
@@ -2102,116 +2099,6 @@
       "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
       "license": "MIT"
     },
-    "node_modules/@radix-ui/react-accordion": {
-      "version": "1.2.20",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.20.tgz",
-      "integrity": "sha512-jDhG9FvAEnlhnjrsINbNXcUa4G+L1KqSkJSunkbKEzFRcAb52jvM0PjPxPRvhe1HNc5F5yc0yzzWeeqlH4yBIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collapsible": "1.1.20",
-        "@radix-ui/react-collection": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.6"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-arrow": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
-      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.20.tgz",
-      "integrity": "sha512-mcGesGplBnzN2sbvJETzpCNfSMyPnb29q1GRLU+Ib7bJrpIG2ywmRoh2V5VbA2uNvKikKUlVbAPks7JDjz4A8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-presence": "1.1.10",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
-      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-slot": "1.3.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
@@ -2279,21 +2166,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-direction": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
-      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
@@ -2305,35 +2177,6 @@
         "@radix-ui/react-primitive": "2.1.10",
         "@radix-ui/react-use-callback-ref": "1.1.4",
         "@radix-ui/react-use-effect-event": "0.0.5"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
-      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-menu": "2.1.24",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2408,115 +2251,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
-      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.19",
-        "@radix-ui/react-focus-guards": "1.1.6",
-        "@radix-ui/react-focus-scope": "1.1.16",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-popper": "1.3.7",
-        "@radix-ui/react-portal": "1.1.17",
-        "@radix-ui/react-presence": "1.1.10",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-roving-focus": "1.1.19",
-        "@radix-ui/react-slot": "1.3.3",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.7.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popover": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.23.tgz",
-      "integrity": "sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-dismissable-layer": "1.1.19",
-        "@radix-ui/react-focus-guards": "1.1.6",
-        "@radix-ui/react-focus-scope": "1.1.16",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-popper": "1.3.7",
-        "@radix-ui/react-portal": "1.1.17",
-        "@radix-ui/react-presence": "1.1.10",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-slot": "1.3.3",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.7.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popper": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
-      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.0.0",
-        "@radix-ui/react-arrow": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-layout-effect": "1.1.4",
-        "@radix-ui/react-use-rect": "1.1.4",
-        "@radix-ui/react-use-size": "1.1.4",
-        "@radix-ui/rect": "1.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.17",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
@@ -2571,39 +2305,6 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.3.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
-      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "@radix-ui/react-use-is-hydrated": "0.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2691,21 +2392,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
-      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
@@ -2720,48 +2406,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@radix-ui/react-use-rect": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
-      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/rect": "1.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-size": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
-      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/rect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
-      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
-      "license": "MIT"
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.86.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,10 +23,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@radix-ui/react-accordion": "^1.2.15",
     "@radix-ui/react-dialog": "^1.1.14",
-    "@radix-ui/react-dropdown-menu": "^2.1.19",
-    "@radix-ui/react-popover": "^1.1.18",
     "@tamagui/config": "^2.7.6",
     "@tamagui/core": "^2.7.6",
     "@tamagui/vite-plugin": "^2.7.6",


### PR DESCRIPTION
## Summary

Progresses #587, the closing item of the #578 Radix→Tamagui epic. Branched off #798 (#586's Navbar branch), continuing the migration chain (#580→...→#586→this).

**This PR does not fully close #587** - it makes the honest, verifiable progress available right now and documents everything that's blocked, rather than claiming closure on criteria this sandbox (or the current state of the epic) can't actually satisfy. See the [status section](https://github.com/progressrpg/ProgressRPG/blob/claude/issue-587-implementation-r8k3wt/frontend/docs/RADIX_TO_TAMAGUI_A11Y_CHECKLIST.md#status) of the new checklist doc for the two blockers in full.

### What this does

1. **Removes 3 of the remaining 4 `@radix-ui/*` packages** from `package.json`: `react-accordion`, `react-dropdown-menu`, `react-popover` - all unused since #585/#586 (verified by grep). `npm install` cleanly drops 14 packages. Bundle size unaffected (measured a 0-byte delta in `npm run build:production` output before/after) - expected, since Vite was already excluding unused imports from the shipped bundle.
2. **Leaves `@radix-ui/react-dialog` installed.** `DetailSurface.tsx` (the Map entity detail cards) still imports it directly, and isn't covered by any of #578's existing sub-issues - filed as #799 rather than attempting an unverified fix. See that issue for the full technical blocker (Tamagui's web `Portal` has no equivalent to Radix's `container` prop, and both `DetailSurface` call sites depend on it to dock the panel inside the map wrapper rather than `document.body`).
3. **Adds `frontend/docs/RADIX_TO_TAMAGUI_A11Y_CHECKLIST.md`** - the repeatable checklist #587 explicitly asks to have "committed to the repo... reusable for the styling and routing migrations that follow." Covers:
   - Per-component verification table (Toast, AlertDialog/Modal, Tooltip, Tabs, Popover, DropdownMenu/Accordion, ProgressBar)
   - The two specific gaps #587 asked to be confirmed one way or the other: Tamagui's `Button` `aria-disabled`-not-`disabled` gap (doesn't apply - this app never imports Tamagui's own `Button`, always uses its own wrapper, which sets both correctly) and Tooltip's focus-to-open gap ([tamagui/tamagui#4152](https://github.com/tamagui/tamagui/issues/4152) - already worked around in `Tooltip.tsx`, confirmed not to reach Popover/DropdownMenu since neither uses hover-to-open)
   - Toolchain finalization confirmation (#629's vite-plugin config, `.tamagui/` ignores, final dependency set)
   - An honest list of what this sandbox can't verify (`test:a11y` - no backend; `test:storybook` - pre-existing headless-shell mismatch; screen reader and real touch device passes - no hardware)

## Acceptance criteria

- [ ] All nine `@radix-ui/*` packages removed - **8 of 9 done**; `react-dialog` blocked on #799
- [x] `grep` for `@radix-ui` across `frontend/` - down to two hits: a comment in `Tabs.tsx` (not an import) and `DetailSurface.tsx`'s real one (#799)
- [x] Production build succeeds; bundle-size delta recorded (0 bytes for this PR's removals - see checklist)
- [x] `npm run lint`, `npm run test` pass (`npx playwright test`/`npm run test:a11y` blocked here, see below)
- [ ] All Storybook stories render with the a11y addon reporting clean - blocked, pre-existing sandbox limitation (see checklist)
- [x] Documented keyboard-only pass over every replaced component, against the pre-migration baseline (checklist table, backed by each component's own PR)
- [ ] Documented screen-reader pass - blocked, no screen reader available here (recorded as such, not silently skipped)
- [x] Touch-device pass over tooltips and the mobile nav menu (Playwright touch emulation, per #585/#586 - #586 found and fixed a real bug this way)
- [x] Every accepted regression/gap recorded explicitly with reasoning (checklist "Known, recorded gaps" + "What couldn't be verified here")
- [x] The a11y checklist committed to the repo
- [x] Toolchain workarounds finalized (confirmed in checklist, nothing left from the abandoned `@rn-primitives` approach)

## Test plan

- [x] `npm run lint` / `tsc --noEmit` - clean
- [x] `npm run test` - 590/591 passing; the one failure (`UnifiedTimerHome.test.tsx`) is the same pre-existing, unrelated flake #793 first documented
- [x] `npm run build:production` - succeeds; bundle size delta measured directly (before/after `dist/` size + gzip, byte-identical)
- [x] `grep -rn "@radix-ui" frontend/src` - down to the two expected hits
- [ ] `npm run test:a11y` / `npm run test:storybook` - blocked by this sandbox's pre-existing limitations (no backend; Playwright headless-shell version mismatch), documented in the checklist rather than skipped silently

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCkpqepd3zYccf9bwNBhZH)_