### PR TITLE
feat: migrate DetailSurface off Radix Dialog, remove last @radix-ui package (#799)

### DIFF
--- a/frontend/docs/RADIX_TO_TAMAGUI_A11Y_CHECKLIST.md
+++ b/frontend/docs/RADIX_TO_TAMAGUI_A11Y_CHECKLIST.md
@@ -8,18 +8,16 @@ table structure and re-run the same passes.
 
 ## Status
 
-**Not fully closed.** Two things block full closure, both explained below
-rather than silently absorbed:
+**Dependency removal is complete** - all nine `@radix-ui/*` packages are
+gone, including `react-dialog` (`DetailSurface.tsx`, per the plan at
+`.claude/plans/issue-799-detailsurface-tamagui-plan.md` and
+[#799](https://github.com/progressrpg/ProgressRPG/issues/799)).
 
-1. `DetailSurface.tsx` (Map entity detail cards) still imports
-   `@radix-ui/react-dialog` directly - out of scope for this pass, tracked
-   in [#799](https://github.com/progressrpg/ProgressRPG/issues/799) (see
-   [Remaining Radix usage](#remaining-radix-usage)).
-2. Several verification steps this checklist calls for need infrastructure
-   this sandbox doesn't have (a running Django backend, a real touch
-   device, a screen reader, a matching Playwright browser build for
-   Storybook's a11y addon) - marked **Not run here** below, with what *was*
-   possible run in its place.
+**Still not fully closed** on the verification half: several steps this
+checklist calls for need infrastructure this sandbox doesn't have (a
+running Django backend, a real touch device, a screen reader, a matching
+Playwright browser build for Storybook's a11y addon) - marked **Not run
+here** below, with what *was* possible run in its place.
 
 ## Dependency removal
 
@@ -32,27 +30,35 @@ Nine `@radix-ui/*` packages before this migration started. Current state:
 | `@radix-ui/react-tooltip` | Removed (#583) |
 | `@radix-ui/react-tabs` | Removed (#584) |
 | `@radix-ui/react-progress` | Removed (prior to this migration's sub-issues, per `package.json` history) |
-| `@radix-ui/react-accordion` | Removed (this PR - unused since #586) |
-| `@radix-ui/react-dropdown-menu` | Removed (this PR - unused since #586) |
-| `@radix-ui/react-popover` | Removed (this PR - unused since #585/#586) |
-| `@radix-ui/react-dialog` | **Still installed** - `DetailSurface.tsx` only, see below |
+| `@radix-ui/react-accordion` | Removed (#587 - unused since #586) |
+| `@radix-ui/react-dropdown-menu` | Removed (#587 - unused since #586) |
+| `@radix-ui/react-popover` | Removed (#587 - unused since #585/#586) |
+| `@radix-ui/react-dialog` | Removed (#799 - `DetailSurface.tsx` ported to Tamagui's `Dialog`) |
 
-`grep -rn "@radix-ui" frontend/src` returns exactly two hits: a comment in
-`Tabs.tsx` (documents what shape it mirrors, not an import) and the real
-import in `DetailSurface.tsx`.
+`grep -rn "@radix-ui" frontend/src` now returns exactly one hit: a comment
+in `Tabs.tsx` that documents what shape it mirrors, not an import.
 
 ### Bundle-size delta
 
-Removing the three unused packages (`react-accordion`, `react-dropdown-menu`,
-`react-popover`) changed `npm run build:production`'s output by **0 bytes**
-(`dist/` total and gzip size identical before/after, measured directly).
-Expected: none of the three were imported by any code after #585/#586, so
-Vite's bundler was already excluding them from the shipped bundle - removing
-them from `package.json` is a dependency-hygiene and `npm ci` cleanliness
-win, not a bundle-size one. The real bundle cost of the Tamagui migration
-was already measured and recorded in #629 (+383 kB raw / +102 kB gzip fixed
-cost from wiring in the provider, before any primitive was ported) - nothing
-in this PR changes that number.
+Two separate measurements, both direct (`dist/` total + gzip size,
+before/after, same build):
+
+- **#587** (removing `react-accordion`, `react-dropdown-menu`,
+  `react-popover`): **0 bytes**. Expected - none of the three were imported
+  by any code after #585/#586, so Vite's bundler was already excluding them
+  from the shipped bundle; removing them from `package.json` was a
+  dependency-hygiene and `npm ci` cleanliness win, not a bundle-size one.
+- **#799** (removing `react-dialog`, the last of the nine, after porting
+  `DetailSurface.tsx` to Tamagui's `Dialog`): **-36,496 bytes raw / -12,180
+  bytes gzip**. This one *was* actually bundled (it was genuinely imported),
+  so removing it produced a real, reproducible reduction - unlike #587's
+  zero-byte result.
+
+The real bundle cost of the Tamagui migration itself was already measured
+and recorded in #629 (+383 kB raw / +102 kB gzip fixed cost from wiring in
+the provider, before any primitive was ported) - neither of the
+measurements above changes that number; they're just the Radix-removal
+side of the ledger.
 
 ## Toolchain
 
@@ -75,24 +81,30 @@ Final Tamagui dependency set, confirmed present in `package.json`:
 
 ## Remaining Radix usage
 
-**`frontend/src/components/DetailSurface/DetailSurface.tsx`** - the Map
-entity detail card's dialog primitive (`Root`/`Portal`/`Overlay`/`Content`/
-`Title`), used by both `MapDetailCard` call sites in `Map.tsx`. Its own
-header comment already anticipated this exact migration reaching it.
+None. `frontend/src/components/DetailSurface/DetailSurface.tsx` - the Map
+entity detail card's dialog primitive, used by both `MapDetailCard` call
+sites in `Map.tsx` - was the last one, resolved in #799.
 
-**Why it's deferred rather than migrated here:** both call sites always pass
-a `container` prop (an arbitrary `HTMLElement`) so the detail panel portals
-into the map's own wrapper instead of `document.body` - needed so the
-non-modal docked panel positions relative to the map, not the viewport.
-Tamagui's web `Portal` (`@tamagui/portal`) hardcodes
-`createPortal(children, document.body)` with no per-instance override, and
-`Dialog.Portal`'s frame carries exit-animation timing, z-index stacking, and
-native-`<dialog>` `show()`/`close()` wiring that a hand-rolled replacement
-portal would need to reproduce correctly - on a component that renders
-inside MapLibre and can't be meaningfully verified in this sandbox (no map
-tiles/API access). Filed as
-[#799](https://github.com/progressrpg/ProgressRPG/issues/799) rather than
-risking a live map feature on an unverified custom-portal reimplementation.
+**What made it harder than the other eight**: both `MapDetailCard` call
+sites always pass a `container` prop (the map's own wrapper element) so the
+detail panel portals there instead of `document.body` - needed for the
+non-modal docked panel to position relative to the map (`position: absolute`
+against `.mapWrapper`'s `position: relative`), not the viewport. Tamagui's
+web `Portal` hardcodes `createPortal(children, document.body)` with no
+per-instance override, unlike Radix's `Dialog.Portal`. Resolved by bypassing
+`Dialog.Portal` only when a `container` is supplied, portaling
+`Dialog.Content` there directly via `ReactDOM.createPortal` (still a React
+context descendant of `<Dialog>`, so open/close/dismiss wiring keeps
+working), gated on `open` in `DetailSurface`'s own code - `Dialog.Content`
+doesn't gate its own mounting on `open` (that's `Dialog.Portal`'s job
+internally), so skipping `Portal` without adding that gate back would have
+left the docked panel sitting in the DOM at all times, non-interactive but
+still visible. Caught and fixed before merging, not after - see the plan
+doc (`.claude/plans/issue-799-detailsurface-tamagui-plan.md`) for the full
+reasoning and alternatives considered, and #799's own PR for the real-browser
+verification (DOM containment, correct docked positioning, and correct
+unmount-on-close, confirmed against a harness reproducing `.mapWrapper`'s
+actual CSS).
 
 ## Known, recorded gaps
 
@@ -130,6 +142,7 @@ inspection (see linked PR/component for detail) · ⛔ not runnable here, see
 | Popover/FeedbackWidget (#585) | ✅ `Popover.test.tsx` | ✅ tested | ⛔ | ✅ real-browser harness, PR #797 | |
 | Popover/Accordion/DropdownMenu in Navbar (#586) | ✅ `DropdownMenu.test.tsx`, `Navbar.test.tsx` (arrow keys, Escape, multi-open accordion) | ✅ tested | ⛔ | ✅ real-browser touch-emulated harness, PR #798 - found and fixed a real tap-to-open bug (`asChild` + coarse pointer) | Flagged in PR #798 for a real-phone check given the bug found there |
 | ProgressBar | 📝 no interactive semantics to trap/restore | n/a | ⛔ | n/a | |
+| DetailSurface/DetailCard/MapDetailCard (#799) | ✅ `DetailSurface.test.tsx`, `DetailCard.test.tsx` (Escape, outside-click gating by `modal`) | ✅ tested (`useReturnFocusOnClose`, reused from Modal/AlertDialog) | ⛔ | n/a (no touch-specific behaviour; container-portal positioning verified in a real browser instead, see below) | Real-browser harness confirmed the docked panel renders as a DOM descendant of a `.mapWrapper`-equivalent container, docks at the expected position (not the viewport), and correctly unmounts (not just goes non-interactive) on close - MapLibre itself still not renderable in this sandbox, so this used a harness reproducing the real CSS/positioning contract rather than the live Map page |
 
 ## What couldn't be verified here
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "frontend",
       "version": "0.12.0",
       "dependencies": {
-        "@radix-ui/react-dialog": "^1.1.14",
         "@tamagui/config": "^2.7.6",
         "@tamagui/core": "^2.7.6",
         "@tamagui/vite-plugin": "^2.7.6",
@@ -2092,320 +2091,6 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@radix-ui/primitive": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
-      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
-      "license": "MIT"
-    },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
-      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
-      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
-      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-dismissable-layer": "1.1.19",
-        "@radix-ui/react-focus-guards": "1.1.6",
-        "@radix-ui/react-focus-scope": "1.1.16",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-portal": "1.1.17",
-        "@radix-ui/react-presence": "1.1.10",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-slot": "1.3.3",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "@radix-ui/react-use-layout-effect": "1.1.4",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.7.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
-      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-effect-event": "0.0.5"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
-      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
-      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-id": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
-      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
-      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
-      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
-      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.3.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
-      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
-      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
-      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-use-effect-event": "0.0.5",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
-      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
-      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.86.2",
@@ -5181,7 +4866,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -5925,18 +5610,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
-    },
-    "node_modules/aria-hidden": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -6995,12 +6668,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-      "license": "MIT"
-    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -7906,15 +7573,6 @@
       "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/gl-matrix": {
@@ -11683,53 +11341,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-remove-scroll": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.7",
-        "react-style-singleton": "^2.2.3",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.3",
-        "use-sidecar": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-style-singleton": "^2.2.2",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-router": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
@@ -11747,28 +11358,6 @@
       },
       "peerDependenciesMeta": {
         "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
@@ -13373,49 +12962,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,6 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@radix-ui/react-dialog": "^1.1.14",
     "@tamagui/config": "^2.7.6",
     "@tamagui/core": "^2.7.6",
     "@tamagui/vite-plugin": "^2.7.6",

--- a/frontend/src/components/DetailCard/DetailCard.test.tsx
+++ b/frontend/src/components/DetailCard/DetailCard.test.tsx
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { TamaguiProvider } from 'tamagui';
 import DetailCard from './DetailCard';
+import tamaguiConfig from '../../../tamagui.config';
 
+// DetailCard's underlying DetailSurface (#799) needs a TamaguiProvider
+// ancestor - the app root (src/main.tsx) provides this in production;
+// tests need their own.
 function renderCard(overrides: Partial<React.ComponentProps<typeof DetailCard>> = {}) {
   const props = {
     open: true,
@@ -11,7 +16,11 @@ function renderCard(overrides: Partial<React.ComponentProps<typeof DetailCard>> 
     children: <p>Card content</p>,
     ...overrides,
   };
-  render(<DetailCard {...props} />);
+  render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
+      <DetailCard {...props} />
+    </TamaguiProvider>
+  );
   return props;
 }
 

--- a/frontend/src/components/DetailSurface/DetailSurface.test.tsx
+++ b/frontend/src/components/DetailSurface/DetailSurface.test.tsx
@@ -1,7 +1,21 @@
+import { useState } from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { TamaguiProvider } from 'tamagui';
 import DetailSurface from './DetailSurface';
+import tamaguiConfig from '../../../tamagui.config';
+
+// Tamagui's Dialog (#799) needs a TamaguiProvider ancestor - unlike Radix's
+// Dialog.Root, it isn't usable standalone. The app root (src/main.tsx)
+// provides this in production; tests need their own.
+function renderWithProvider(ui: React.ReactElement) {
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
+      {ui}
+    </TamaguiProvider>
+  );
+}
 
 function renderSurface(overrides: Partial<React.ComponentProps<typeof DetailSurface>> = {}) {
   const props = {
@@ -11,7 +25,7 @@ function renderSurface(overrides: Partial<React.ComponentProps<typeof DetailSurf
     children: <p>Card content</p>,
     ...overrides,
   };
-  render(<DetailSurface {...props} />);
+  renderWithProvider(<DetailSurface {...props} />);
   return props;
 }
 
@@ -37,5 +51,84 @@ describe('DetailSurface', () => {
     const { onOpenChange } = renderSurface();
     await user.keyboard('{Escape}');
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('restores focus to the previously focused element on close', async () => {
+    const user = userEvent.setup();
+
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open</button>
+          <DetailSurface
+            open={open}
+            onOpenChange={setOpen}
+            title="Alice"
+          >
+            <button onClick={() => setOpen(false)}>Close</button>
+          </DetailSurface>
+        </>
+      );
+    }
+
+    renderWithProvider(<Harness />);
+
+    const openButton = screen.getByRole('button', { name: 'Open' });
+    openButton.focus();
+    await user.click(openButton);
+
+    await user.click(await screen.findByRole('button', { name: 'Close' }));
+
+    await waitFor(() => expect(openButton).toHaveFocus());
+  });
+
+  describe('container', () => {
+    it('renders Dialog.Content as a descendant of the given container', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      renderSurface({ container });
+
+      await waitFor(() => {
+        expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+      });
+
+      document.body.removeChild(container);
+    });
+
+    it('does not render into the container when closed', () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      renderSurface({ container, open: false });
+
+      expect(container.querySelector('[role="dialog"]')).toBeNull();
+
+      document.body.removeChild(container);
+    });
+
+    it('falls back to the default portal when container is null', () => {
+      renderSurface({ container: null });
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('modal={false}', () => {
+    it('renders no overlay and does not dismiss on outside click', async () => {
+      const user = userEvent.setup();
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const { onOpenChange } = renderSurface({ modal: false, container });
+      await screen.findByRole('dialog');
+
+      await user.click(document.body);
+
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      document.body.removeChild(container);
+    });
   });
 });

--- a/frontend/src/components/DetailSurface/DetailSurface.tsx
+++ b/frontend/src/components/DetailSurface/DetailSurface.tsx
@@ -1,20 +1,21 @@
 import type React from "react";
-import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { createPortal } from "react-dom";
+import { Dialog } from "tamagui";
 import styles from "./DetailSurface.module.scss";
+import { useReturnFocusOnClose } from "../Overlay/useReturnFocusOnClose";
 
 // The one file in the map entity detail card (DetailSurface -> DetailCard
 // -> CharacterDetail/BuildingDetail, see MapTooltips.tsx/Map.tsx) allowed
 // to import a UI library primitive directly - everything above it works
 // against this component's plain open/onOpenChange/title/children props,
-// so swapping the overlay/sheet/dialog primitive underneath (e.g. once the
-// project's in-progress Radix -> Tamagui migration reaches this component)
-// only touches this file.
+// so swapping the overlay/sheet/dialog primitive underneath only touches
+// this file.
 interface DetailSurfaceProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** Accessible name for the surface - not rendered visually here (DetailCard
-   * renders its own visible title inside `children`); Radix requires every
-   * Dialog to have one for screen reader users. */
+   * renders its own visible title inside `children`); every Dialog needs
+   * one for screen reader users. */
   title: string;
   children: React.ReactNode;
   /** Modal (default): dimming overlay, focus trap, closes on outside click -
@@ -23,10 +24,13 @@ interface DetailSurfaceProps {
    * Map) stays fully interactive - for a docked side panel, which is meant
    * to keep browsing alongside rather than block it. */
   modal?: boolean;
-  /** DOM node to portal into instead of document.body (Radix's default) -
-   * e.g. Map's own wrapper element, so a non-modal docked panel (see
-   * MapDetailCard) positions relative to the map rather than the
-   * viewport. */
+  /** DOM node to portal into instead of document.body (Tamagui's
+   * `Dialog.Portal` default, unconditionally - unlike Radix, it has no
+   * per-instance container override) - e.g. Map's own wrapper element, so a
+   * non-modal docked panel (see MapDetailCard) positions relative to the map
+   * rather than the viewport. Bypasses `Dialog.Portal` entirely when set
+   * (see the manual `createPortal` below) since there's no way to redirect
+   * it otherwise; falsy falls back to `Dialog.Portal`'s own default. */
   container?: HTMLElement | null;
 }
 
@@ -38,20 +42,44 @@ export default function DetailSurface({
   modal = true,
   container,
 }: DetailSurfaceProps) {
+  const onCloseAutoFocus = useReturnFocusOnClose(open);
+
+  const content = (
+    <>
+      {modal && <Dialog.Overlay unstyled className={styles.overlay} />}
+      <Dialog.Content
+        unstyled
+        className={styles.content}
+        onCloseAutoFocus={onCloseAutoFocus}
+        onInteractOutside={(e: Event) => {
+          if (!modal) e.preventDefault();
+        }}
+      >
+        <Dialog.Title className="sr-only">{title}</Dialog.Title>
+        {children}
+      </Dialog.Content>
+    </>
+  );
+
   return (
-    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange} modal={modal}>
-      <DialogPrimitive.Portal container={container ?? undefined}>
-        {modal && <DialogPrimitive.Overlay className={styles.overlay} />}
-        <DialogPrimitive.Content
-          className={styles.content}
-          onInteractOutside={(e) => {
-            if (!modal) e.preventDefault();
-          }}
-        >
-          <DialogPrimitive.Title className="sr-only">{title}</DialogPrimitive.Title>
-          {children}
-        </DialogPrimitive.Content>
-      </DialogPrimitive.Portal>
-    </DialogPrimitive.Root>
+    <Dialog open={open} onOpenChange={onOpenChange} modal={modal}>
+      {container ? (
+        // Dialog.Content itself doesn't gate its own mounting on `open` -
+        // that's Dialog.Portal's job internally (it renders null while
+        // fully closed) - so bypassing Portal here means gating manually,
+        // otherwise the docked panel would sit in the DOM at all times,
+        // non-interactive (Content sets pointer-events: none while closed)
+        // but still visible.
+        open && createPortal(content, container)
+      ) : (
+        // role="presentation" strips the implicit ARIA `dialog` role the
+        // browser assigns to Portal's underlying <dialog> HTML tag -
+        // without it, this wrapper and Content above (which sets the real
+        // `role="dialog"`, wired to the actual title) both expose as
+        // "dialog" landmarks, so `getByRole('dialog')`/assistive tech see
+        // two nested dialogs for what's semantically one.
+        <Dialog.Portal role="presentation">{content}</Dialog.Portal>
+      )}
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Summary

Implements #799 (the last remaining Radix usage, found while scoping #587 - the closing item of the #578 Radix→Tamagui epic) per the plan at [`.claude/plans/issue-799-detailsurface-tamagui-plan.md`](https://github.com/progressrpg/ProgressRPG/blob/claude/issue-799-plan-w2n7qk/.claude/plans/issue-799-detailsurface-tamagui-plan.md) (PR #801). Branched off #801, continuing the migration chain.

**`@radix-ui/react-dialog` is now removed** - the last of the nine packages #587 set out to remove. `grep -rn "@radix-ui" frontend/src` returns only a comment in `Tabs.tsx`, no real imports.

### What changed

`DetailSurface.tsx` has two consumers with different needs:
- **`DetailCard`** (modal, no custom container) - direct port of the pattern already established twice (`Modal.tsx`, `AlertDialog.tsx`), reusing the existing `useReturnFocusOnClose` hook (no `Trigger` element in the tree, same reason Modal/AlertDialog needed it).
- **`MapDetailCard`** (always non-modal with a custom portal `container` - both live call sites in `Map.tsx` dock the panel inside the map wrapper via `position: absolute` against `.mapWrapper`'s `position: relative`) - needed real new engineering, since Tamagui's `Portal` hardcodes `createPortal` to `document.body` with no per-instance override. Bypasses `Dialog.Portal` only when a `container` is supplied, portaling `Dialog.Content` there directly (still a React context descendant of `Dialog`, so open/close/dismiss wiring keeps working through the portal boundary).

### A gap the plan flagged as a risk, found and fixed during implementation

The plan's biggest named risk was uncertainty about `Dialog.Portal`'s exit-animation timing. What actually turned up during implementation was more fundamental: **`Dialog.Content` doesn't gate its own mounting on `open` at all** - that's `Dialog.Portal`'s internal job (it renders `null` while fully closed). Bypassing `Dialog.Portal` for the container case without replacing that gate would have left the docked panel sitting in the DOM at all times - non-interactive (`pointer-events: none` while closed) but **still visible**. Fixed by gating the manual `createPortal` call on `open` directly in `DetailSurface`'s own code. Caught via a real-browser test before it could ship, not left for someone to notice later - one of the new `DetailSurface.test.tsx` cases (`does not render into the container when closed`) pins this down.

### Verification

Manual verification against a real Chromium browser (Playwright, pinned executable) against a harness reproducing `MapDetailCard`'s actual CSS contract (a `position: relative` wrapper standing in for `.mapWrapper`, since MapLibre itself can't render in this sandbox - no tile/API access): confirmed the docked panel renders as a DOM descendant of the container, docks at the correct position (not the viewport), and correctly unmounts (not just goes non-interactive) on close.

## Acceptance criteria (from #799)

- [x] `@radix-ui/react-dialog` fully removed from `frontend/package.json` and `frontend/`
- [x] `DetailSurface.tsx` ported to Tamagui's `Dialog`, following the established `Modal.tsx`/`AlertDialog.tsx` patterns (`role="presentation"` on the portal, avoiding `asChild` for click handlers our plain `Button` doesn't turn into real DOM events - N/A here, no Button-wrapped Radix-style triggers in this component)
- [x] Both `MapDetailCard` call sites verified against a real render (harness reproducing the actual CSS contract, not just unit tests - see above)
- [x] `modal={false}` behavior preserved: no overlay, no focus trap, outside clicks pass through (new test: `renders no overlay and does not dismiss on outside click`)
- [x] Decision recorded on container-targeting approach: manual `createPortal` bypassing `Dialog.Portal` only for the container case (see plan doc's Design Decision B for alternatives considered and why)

## Test plan

- [x] `npm run lint` / `tsc --noEmit` - clean
- [x] `npm run test` - 595/596 passing; the one failure (`UnifiedTimerHome.test.tsx`) is the same pre-existing, unrelated flake #793 first documented
- [x] `npm run build:production` - succeeds; bundle-size delta measured directly: **-36,496 bytes raw / -12,180 bytes gzip** (a real reduction, unlike #587's three removals which were already unused and tree-shaken out)
- [x] `DetailSurface.test.tsx` extended (4 → 9 tests): container-portal DOM descendance, no-render-into-container-when-closed, null-container fallback, non-modal outside-click, focus-restore
- [x] `DetailCard.test.tsx` updated only to add the `TamaguiProvider` wrapper its underlying `DetailSurface` now needs - all 4 existing assertions unchanged and passing
- [x] `Map.test.tsx` (44 tests) - unaffected, all still passing
- [x] Real-browser verification (see above)
- [ ] `npm run test:a11y` / `npm run test:storybook` - blocked by this sandbox's pre-existing limitations (no backend; Playwright headless-shell version mismatch), same as every other PR in this migration chain

Also updates `docs/RADIX_TO_TAMAGUI_A11Y_CHECKLIST.md` (from #587) to close the loop: marks dependency removal complete, records this PR's bundle delta, and adds a row for DetailSurface/DetailCard/MapDetailCard to the per-component verification table.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCkpqepd3zYccf9bwNBhZH)_