### PR TITLE
test: raise frontend unit-test coverage across api, context, utils, hooks, and components

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,6 +34,7 @@ playwright/.auth
 
 *storybook.log
 storybook-static
+coverage
 
 # Tamagui compiler cache
 .tamagui

--- a/frontend/src/api/activities.test.ts
+++ b/frontend/src/api/activities.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createActivity,
+  deleteActivity,
+  fetchActivities,
+  fetchActivity,
+  logOfflineActivity,
+  updateActivity,
+} from "./activities";
+import { apiFetch } from "../utils/api";
+import type { PlayerActivity } from "../types";
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchActivities", () => {
+  it("returns all results when there is a single page", async () => {
+    const activities = [{ id: 1 }, { id: 2 }] as PlayerActivity[];
+    mockedApiFetch.mockResolvedValueOnce({ results: activities, next: null });
+
+    const result = await fetchActivities();
+
+    expect(result).toEqual(activities);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(1);
+    expect(mockedApiFetch).toHaveBeenCalledWith("/player-activities/?page=1");
+  });
+
+  it("follows pagination across multiple pages", async () => {
+    const first = [{ id: 1 }] as PlayerActivity[];
+    const second = [{ id: 2 }] as PlayerActivity[];
+    mockedApiFetch
+      .mockResolvedValueOnce({ results: first, next: "https://api.example.com/?page=2" })
+      .mockResolvedValueOnce({ results: second, next: null });
+
+    const result = await fetchActivities();
+
+    expect(result).toEqual([...first, ...second]);
+    expect(mockedApiFetch).toHaveBeenNthCalledWith(1, "/player-activities/?page=1");
+    expect(mockedApiFetch).toHaveBeenNthCalledWith(2, "/player-activities/?page=2");
+  });
+
+  it("treats a missing results array as empty rather than throwing", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ next: null });
+
+    const result = await fetchActivities();
+
+    expect(result).toEqual([]);
+  });
+
+  it("stops once next is falsy even if results is empty", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ results: [], next: null });
+
+    const result = await fetchActivities();
+
+    expect(result).toEqual([]);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fetchActivity", () => {
+  it("fetches a single activity by id", async () => {
+    const activity = { id: 9 } as PlayerActivity;
+    mockedApiFetch.mockResolvedValueOnce(activity);
+
+    const result = await fetchActivity(9);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/player-activities/9/");
+    expect(result).toBe(activity);
+  });
+});
+
+describe("createActivity", () => {
+  it("posts activity data", async () => {
+    const created = { id: 1 } as PlayerActivity;
+    mockedApiFetch.mockResolvedValueOnce(created);
+
+    const result = await createActivity({ description: "test" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/player-activities/", {
+      method: "POST",
+      body: JSON.stringify({ description: "test" }),
+    });
+    expect(result).toBe(created);
+  });
+});
+
+describe("updateActivity", () => {
+  it("patches activity data by id", async () => {
+    const updated = { id: 2 } as PlayerActivity;
+    mockedApiFetch.mockResolvedValueOnce(updated);
+
+    const result = await updateActivity(2, { description: "updated" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/player-activities/2/", {
+      method: "PATCH",
+      body: JSON.stringify({ description: "updated" }),
+    });
+    expect(result).toBe(updated);
+  });
+});
+
+describe("deleteActivity", () => {
+  it("deletes an activity by id", async () => {
+    mockedApiFetch.mockResolvedValueOnce(undefined);
+
+    await deleteActivity(4);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/player-activities/4/", {
+      method: "DELETE",
+    });
+  });
+});
+
+describe("logOfflineActivity", () => {
+  it("posts the offline activity payload to the log_offline endpoint", async () => {
+    const response = { activity: { id: 1 } };
+    mockedApiFetch.mockResolvedValueOnce(response);
+    const payload = {
+      name: "Reading",
+      started_at: "2026-08-20T10:00:00Z",
+      completed_at: "2026-08-20T10:30:00Z",
+    };
+
+    const result = await logOfflineActivity(payload);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/player-activities/log_offline/", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    expect(result).toBe(response);
+  });
+});

--- a/frontend/src/api/announcements.test.ts
+++ b/frontend/src/api/announcements.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchAnnouncements,
+  fetchAnnouncementUnreadCount,
+  markAllAnnouncementsRead,
+  markAnnouncementRead,
+} from "./announcements";
+import { apiFetch } from "../utils/api";
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchAnnouncements", () => {
+  it("fetches the announcements list", async () => {
+    const response = { results: [] };
+    mockedApiFetch.mockResolvedValueOnce(response);
+
+    const result = await fetchAnnouncements();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/me/announcements/");
+    expect(result).toBe(response);
+  });
+});
+
+describe("fetchAnnouncementUnreadCount", () => {
+  it("fetches the unread count", async () => {
+    const response = { unread_count: 3 };
+    mockedApiFetch.mockResolvedValueOnce(response);
+
+    const result = await fetchAnnouncementUnreadCount();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/me/announcements_unread_count/");
+    expect(result).toBe(response);
+  });
+});
+
+describe("markAnnouncementRead", () => {
+  it("posts the announcement id to be marked read", async () => {
+    const response = { success: true };
+    mockedApiFetch.mockResolvedValueOnce(response);
+
+    const result = await markAnnouncementRead(42);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/me/mark_announcement_read/", {
+      method: "POST",
+      body: JSON.stringify({ announcement_id: 42 }),
+    });
+    expect(result).toBe(response);
+  });
+});
+
+describe("markAllAnnouncementsRead", () => {
+  it("posts to mark all announcements read", async () => {
+    const response = { success: true };
+    mockedApiFetch.mockResolvedValueOnce(response);
+
+    const result = await markAllAnnouncementsRead();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/me/mark_all_announcements_read/", {
+      method: "POST",
+    });
+    expect(result).toBe(response);
+  });
+});

--- a/frontend/src/api/appConfig.test.ts
+++ b/frontend/src/api/appConfig.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchAppConfig } from "./appConfig";
+import { apiFetch } from "../utils/api";
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchAppConfig", () => {
+  it("fetches the app config", async () => {
+    const config = { feature_flags: {} };
+    mockedApiFetch.mockResolvedValueOnce(config);
+
+    const result = await fetchAppConfig();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/app_config/");
+    expect(result).toBe(config);
+  });
+});

--- a/frontend/src/api/categories.test.ts
+++ b/frontend/src/api/categories.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createCategory,
+  deleteCategory,
+  fetchCategories,
+  fetchCategory,
+  updateCategory,
+} from "./categories";
+import { apiFetch } from "../utils/api";
+import type { Category } from "../types";
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchCategories", () => {
+  it("unwraps the paginated results", async () => {
+    const categories = [{ id: 1 }] as Category[];
+    mockedApiFetch.mockResolvedValueOnce({ results: categories });
+
+    const result = await fetchCategories();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/categories/");
+    expect(result).toBe(categories);
+  });
+});
+
+describe("fetchCategory", () => {
+  it("fetches a single category by id", async () => {
+    const category = { id: 5 } as Category;
+    mockedApiFetch.mockResolvedValueOnce(category);
+
+    const result = await fetchCategory(5);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/categories/5/");
+    expect(result).toBe(category);
+  });
+});
+
+describe("createCategory", () => {
+  it("posts category data", async () => {
+    const created = { id: 1 } as Category;
+    mockedApiFetch.mockResolvedValueOnce(created);
+
+    const result = await createCategory({ name: "New" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/categories/", {
+      method: "POST",
+      body: JSON.stringify({ name: "New" }),
+    });
+    expect(result).toBe(created);
+  });
+});
+
+describe("updateCategory", () => {
+  it("patches category data by id", async () => {
+    const updated = { id: 2 } as Category;
+    mockedApiFetch.mockResolvedValueOnce(updated);
+
+    const result = await updateCategory(2, { name: "Updated" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/categories/2/", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "Updated" }),
+    });
+    expect(result).toBe(updated);
+  });
+});
+
+describe("deleteCategory", () => {
+  it("deletes a category by id", async () => {
+    mockedApiFetch.mockResolvedValueOnce(undefined);
+
+    await deleteCategory(3);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/categories/3/", {
+      method: "DELETE",
+    });
+  });
+});

--- a/frontend/src/api/map.test.ts
+++ b/frontend/src/api/map.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchInitialMapCentre,
+  fetchMapCharacterDetail,
+  fetchMapViewport,
+  fetchMapWorldBounds,
+  fetchPopulationCentreMap,
+  fetchPopulationCentres,
+} from "./map";
+import { apiFetch } from "../utils/api";
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchInitialMapCentre", () => {
+  it("fetches the initial map centre", async () => {
+    const centre = { id: 1, name: "Village", bbox: [0, 0, 1, 1] };
+    mockedApiFetch.mockResolvedValueOnce(centre);
+
+    const result = await fetchInitialMapCentre();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/map/initial-centre/");
+    expect(result).toBe(centre);
+  });
+});
+
+describe("fetchPopulationCentres", () => {
+  it("unwraps a paginated {results} response", async () => {
+    const centres = [{ id: 1, name: "A", location: [1, 2] }];
+    mockedApiFetch.mockResolvedValueOnce({ results: centres });
+
+    const result = await fetchPopulationCentres();
+
+    expect(result).toEqual(centres);
+  });
+
+  it("accepts a bare array response", async () => {
+    const centres = [{ id: 1, name: "A", location: [1, 2] }];
+    mockedApiFetch.mockResolvedValueOnce(centres);
+
+    const result = await fetchPopulationCentres();
+
+    expect(result).toEqual(centres);
+  });
+
+  it("filters out centres with a missing location", async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      results: [
+        { id: 1, name: "Valid", location: [1, 2] },
+        { id: 2, name: "NoLocation" },
+      ],
+    });
+
+    const result = await fetchPopulationCentres();
+
+    expect(result).toEqual([{ id: 1, name: "Valid", location: [1, 2] }]);
+  });
+
+  it("filters out centres with a malformed location array", async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      results: [
+        { id: 1, name: "Valid", location: [1, 2] },
+        { id: 2, name: "TooShort", location: [1] },
+        { id: 3, name: "NonNumeric", location: [1, "y"] },
+        { id: 4, name: "NonFinite", location: [1, Infinity] },
+      ],
+    });
+
+    const result = await fetchPopulationCentres();
+
+    expect(result).toEqual([{ id: 1, name: "Valid", location: [1, 2] }]);
+  });
+
+  it("returns an empty array when the response has no results", async () => {
+    mockedApiFetch.mockResolvedValueOnce({});
+
+    const result = await fetchPopulationCentres();
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("fetchPopulationCentreMap", () => {
+  it("fetches map data for a population centre by id", async () => {
+    const data = { type: "FeatureCollection", features: [] };
+    mockedApiFetch.mockResolvedValueOnce(data);
+
+    const result = await fetchPopulationCentreMap(42);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/population-centres/42/map/");
+    expect(result).toBe(data);
+  });
+});
+
+describe("fetchMapViewport", () => {
+  it("URL-encodes the bbox query param", async () => {
+    const data = { type: "FeatureCollection", features: [] };
+    mockedApiFetch.mockResolvedValueOnce(data);
+
+    const result = await fetchMapViewport("0,0,100,100");
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/map/viewport/?bbox=0%2C0%2C100%2C100");
+    expect(result).toBe(data);
+  });
+});
+
+describe("fetchMapCharacterDetail", () => {
+  it("fetches character detail by id", async () => {
+    const detail = { id: 7, name: "Someone" };
+    mockedApiFetch.mockResolvedValueOnce(detail);
+
+    const result = await fetchMapCharacterDetail(7);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/map/characters/7/");
+    expect(result).toBe(detail);
+  });
+});
+
+describe("fetchMapWorldBounds", () => {
+  it("fetches the world bounds", async () => {
+    const bounds = { bbox: [0, 0, 1, 1] };
+    mockedApiFetch.mockResolvedValueOnce(bounds);
+
+    const result = await fetchMapWorldBounds();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/map/world-bounds/");
+    expect(result).toBe(bounds);
+  });
+});

--- a/frontend/src/api/notes.test.ts
+++ b/frontend/src/api/notes.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createNote, deleteNote, fetchNote, fetchNoteFor, fetchNotes, updateNote } from "./notes";
+import { apiFetch } from "../utils/api";
+import type { Note } from "../types";
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchNotes", () => {
+  it("unwraps the paginated results", async () => {
+    const notes = [{ id: 1 }] as Note[];
+    mockedApiFetch.mockResolvedValueOnce({ results: notes });
+
+    const result = await fetchNotes();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/notes/");
+    expect(result).toBe(notes);
+  });
+});
+
+describe("fetchNote", () => {
+  it("fetches a single note by id", async () => {
+    const note = { id: 5 } as Note;
+    mockedApiFetch.mockResolvedValueOnce(note);
+
+    const result = await fetchNote(5);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/notes/5/");
+    expect(result).toBe(note);
+  });
+});
+
+describe("fetchNoteFor", () => {
+  it("queries by task id when given a task link", async () => {
+    const note = { id: 1 } as Note;
+    mockedApiFetch.mockResolvedValueOnce({ results: [note] });
+
+    const result = await fetchNoteFor({ task: 10 });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/notes/?task=10");
+    expect(result).toBe(note);
+  });
+
+  it("queries by activity id when given an activity link", async () => {
+    const note = { id: 2 } as Note;
+    mockedApiFetch.mockResolvedValueOnce({ results: [note] });
+
+    const result = await fetchNoteFor({ activity: 20 });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/notes/?activity=20");
+    expect(result).toBe(note);
+  });
+
+  it("returns null when no note is linked", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ results: [] });
+
+    const result = await fetchNoteFor({ task: 10 });
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("createNote", () => {
+  it("posts note data", async () => {
+    const created = { id: 1 } as Note;
+    mockedApiFetch.mockResolvedValueOnce(created);
+
+    const result = await createNote({ body: "hi" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/notes/", {
+      method: "POST",
+      body: JSON.stringify({ body: "hi" }),
+    });
+    expect(result).toBe(created);
+  });
+});
+
+describe("updateNote", () => {
+  it("patches note data by id", async () => {
+    const updated = { id: 2 } as Note;
+    mockedApiFetch.mockResolvedValueOnce(updated);
+
+    const result = await updateNote(2, { body: "updated" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/notes/2/", {
+      method: "PATCH",
+      body: JSON.stringify({ body: "updated" }),
+    });
+    expect(result).toBe(updated);
+  });
+});
+
+describe("deleteNote", () => {
+  it("deletes a note by id", async () => {
+    mockedApiFetch.mockResolvedValueOnce(undefined);
+
+    await deleteNote(3);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/notes/3/", {
+      method: "DELETE",
+    });
+  });
+});

--- a/frontend/src/api/player.test.ts
+++ b/frontend/src/api/player.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { deleteAccount, downloadUserData, fetchDailyGoals, updatePlayer } from "./player";
+import { apiFetch } from "../utils/api";
+import type { Player } from "../types";
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+describe("updatePlayer", () => {
+  it("patches player data", async () => {
+    const player = { id: 1, level: 2 } as Player;
+    mockedApiFetch.mockResolvedValueOnce(player);
+
+    const result = await updatePlayer({ level: 2 });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/me/player/", {
+      method: "PATCH",
+      body: JSON.stringify({ level: 2 }),
+    });
+    expect(result).toBe(player);
+  });
+});
+
+describe("deleteAccount", () => {
+  it("issues a DELETE to the delete_account endpoint", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ deleted: true });
+
+    const result = await deleteAccount();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/delete_account/", {
+      method: "DELETE",
+    });
+    expect(result).toEqual({ deleted: true });
+  });
+});
+
+describe("fetchDailyGoals", () => {
+  it("fetches the daily goals summary", async () => {
+    const goals = { goals: null };
+    mockedApiFetch.mockResolvedValueOnce(goals);
+
+    const result = await fetchDailyGoals();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/me/daily_goals/");
+    expect(result).toBe(goals);
+  });
+});
+
+describe("downloadUserData", () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    vi.restoreAllMocks();
+  });
+
+  function mockRawResponse({
+    contentDisposition,
+  }: {
+    contentDisposition: string | null;
+  }) {
+    const blob = new Blob(["data"], { type: "application/json" });
+    mockedApiFetch.mockResolvedValueOnce({
+      blob: () => Promise.resolve(blob),
+      headers: {
+        get: (name: string) => (name === "Content-Disposition" ? contentDisposition : null),
+      },
+    });
+    return blob;
+  }
+
+  it("requests the raw response with the correct options", async () => {
+    URL.createObjectURL = vi.fn(() => "blob:mock-url");
+    URL.revokeObjectURL = vi.fn();
+    mockRawResponse({ contentDisposition: 'attachment; filename="export.json"' });
+
+    await downloadUserData();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/download_user_data/", {
+      method: "GET",
+      responseType: "raw",
+    });
+  });
+
+  it("triggers a download using the filename from Content-Disposition", async () => {
+    URL.createObjectURL = vi.fn(() => "blob:mock-url");
+    URL.revokeObjectURL = vi.fn();
+    mockRawResponse({ contentDisposition: 'attachment; filename="export.json"' });
+
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    const result = await downloadUserData();
+
+    expect(result).toEqual({ success: true });
+    expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("falls back to a dated filename when Content-Disposition is missing", async () => {
+    URL.createObjectURL = vi.fn(() => "blob:mock-url");
+    URL.revokeObjectURL = vi.fn();
+    mockRawResponse({ contentDisposition: null });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    const setAttributeSpy = vi.spyOn(HTMLAnchorElement.prototype, "setAttribute");
+
+    await downloadUserData();
+
+    const downloadCall = setAttributeSpy.mock.calls.find(([attr]) => attr === "download");
+    expect(downloadCall?.[1]).toMatch(/^user-data-\d{4}-\d{2}-\d{2}\.json$/);
+  });
+});

--- a/frontend/src/api/projects.test.ts
+++ b/frontend/src/api/projects.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createProject,
+  deleteProject,
+  fetchProject,
+  fetchProjects,
+  updateProject,
+} from "./projects";
+import { apiFetch } from "../utils/api";
+import type { Project } from "../types";
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchProjects", () => {
+  it("unwraps the paginated results", async () => {
+    const projects = [{ id: 1 }] as Project[];
+    mockedApiFetch.mockResolvedValueOnce({ results: projects });
+
+    const result = await fetchProjects();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/projects/");
+    expect(result).toBe(projects);
+  });
+});
+
+describe("fetchProject", () => {
+  it("fetches a single project by id", async () => {
+    const project = { id: 5 } as Project;
+    mockedApiFetch.mockResolvedValueOnce(project);
+
+    const result = await fetchProject(5);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/projects/5/");
+    expect(result).toBe(project);
+  });
+});
+
+describe("createProject", () => {
+  it("posts project data", async () => {
+    const created = { id: 1 } as Project;
+    mockedApiFetch.mockResolvedValueOnce(created);
+
+    const result = await createProject({ name: "New" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/projects/", {
+      method: "POST",
+      body: JSON.stringify({ name: "New" }),
+    });
+    expect(result).toBe(created);
+  });
+});
+
+describe("updateProject", () => {
+  it("patches project data by id", async () => {
+    const updated = { id: 2 } as Project;
+    mockedApiFetch.mockResolvedValueOnce(updated);
+
+    const result = await updateProject(2, { name: "Updated" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/projects/2/", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "Updated" }),
+    });
+    expect(result).toBe(updated);
+  });
+});
+
+describe("deleteProject", () => {
+  it("deletes a project by id", async () => {
+    mockedApiFetch.mockResolvedValueOnce(undefined);
+
+    await deleteProject(3);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/projects/3/", {
+      method: "DELETE",
+    });
+  });
+});

--- a/frontend/src/api/registrationStatus.test.ts
+++ b/frontend/src/api/registrationStatus.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchRegistrationStatus } from "./registrationStatus";
+import { API_BASE_URL } from "../config";
+
+const EXPECTED_URL = `${API_BASE_URL}/api/v1/registration_status/`;
+
+describe("fetchRegistrationStatus", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches the registration status endpoint and returns the parsed body", async () => {
+    const status = { open: true };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(status),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await fetchRegistrationStatus();
+
+    expect(mockFetch).toHaveBeenCalledWith(EXPECTED_URL);
+    expect(result).toEqual(status);
+  });
+
+  it("throws when the response is not ok", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await expect(fetchRegistrationStatus()).rejects.toThrow(
+      "Unable to fetch registration status"
+    );
+  });
+});

--- a/frontend/src/api/skills.test.ts
+++ b/frontend/src/api/skills.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createSkill, deleteSkill, fetchGroups, fetchSkill, fetchSkills, updateSkill } from "./skills";
+import { apiFetch } from "../utils/api";
+import type { PlayerSkill } from "../types";
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchGroups", () => {
+  it("fetches skill groups", async () => {
+    const groups = [{ id: 1, name: "Fitness" }];
+    mockedApiFetch.mockResolvedValueOnce(groups);
+
+    const result = await fetchGroups();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/groups/");
+    expect(result).toBe(groups);
+  });
+});
+
+describe("fetchSkills", () => {
+  it("unwraps the paginated results", async () => {
+    const skills = [{ id: 1 }] as PlayerSkill[];
+    mockedApiFetch.mockResolvedValueOnce({ results: skills });
+
+    const result = await fetchSkills();
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/skills/");
+    expect(result).toBe(skills);
+  });
+});
+
+describe("fetchSkill", () => {
+  it("fetches a single skill by id", async () => {
+    const skill = { id: 3 } as PlayerSkill;
+    mockedApiFetch.mockResolvedValueOnce(skill);
+
+    const result = await fetchSkill(3);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/skills/3/");
+    expect(result).toBe(skill);
+  });
+});
+
+describe("createSkill", () => {
+  it("posts skill data", async () => {
+    const created = { id: 1 } as PlayerSkill;
+    mockedApiFetch.mockResolvedValueOnce(created);
+
+    const result = await createSkill({ name: "New" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/skills/", {
+      method: "POST",
+      body: JSON.stringify({ name: "New" }),
+    });
+    expect(result).toBe(created);
+  });
+});
+
+describe("updateSkill", () => {
+  it("patches skill data by id", async () => {
+    const updated = { id: 2 } as PlayerSkill;
+    mockedApiFetch.mockResolvedValueOnce(updated);
+
+    const result = await updateSkill(2, { name: "Updated" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/skills/2/", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "Updated" }),
+    });
+    expect(result).toBe(updated);
+  });
+});
+
+describe("deleteSkill", () => {
+  it("deletes a skill by id", async () => {
+    mockedApiFetch.mockResolvedValueOnce(undefined);
+
+    await deleteSkill(4);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/skills/4/", {
+      method: "DELETE",
+    });
+  });
+});

--- a/frontend/src/api/tasks.test.ts
+++ b/frontend/src/api/tasks.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createTask, deleteTask, fetchTask, fetchTasks, updateTask } from "./tasks";
+import { apiFetch } from "../utils/api";
+import type { PaginatedResponse, Task } from "../types";
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function page(results: Task[], next: string | null): PaginatedResponse<Task> {
+  return { count: results.length, next, previous: null, results };
+}
+
+describe("fetchTasks", () => {
+  it("returns all results when there is a single page", async () => {
+    const tasks = [{ id: 1 }, { id: 2 }] as Task[];
+    mockedApiFetch.mockResolvedValueOnce(page(tasks, null));
+
+    const result = await fetchTasks();
+
+    expect(result).toEqual(tasks);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(1);
+    expect(mockedApiFetch).toHaveBeenCalledWith("/tasks/");
+  });
+
+  it("follows pagination, forwarding the next page's query params", async () => {
+    const first = [{ id: 1 }] as Task[];
+    const second = [{ id: 2 }] as Task[];
+    mockedApiFetch
+      .mockResolvedValueOnce(page(first, "https://api.example.com/api/v1/tasks/?page=2"))
+      .mockResolvedValueOnce(page(second, null));
+
+    const result = await fetchTasks();
+
+    expect(result).toEqual([...first, ...second]);
+    expect(mockedApiFetch).toHaveBeenNthCalledWith(1, "/tasks/");
+    expect(mockedApiFetch).toHaveBeenNthCalledWith(2, "/tasks/?page=2");
+  });
+
+  it("returns an empty array when the first page has no results", async () => {
+    mockedApiFetch.mockResolvedValueOnce(page([], null));
+
+    const result = await fetchTasks();
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("fetchTask", () => {
+  it("fetches a single task by id", async () => {
+    const task = { id: 5 } as Task;
+    mockedApiFetch.mockResolvedValueOnce(task);
+
+    const result = await fetchTask(5);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/tasks/5/");
+    expect(result).toBe(task);
+  });
+});
+
+describe("createTask", () => {
+  it("posts task data to the tasks endpoint", async () => {
+    const created = { id: 1, name: "New task" } as Task;
+    mockedApiFetch.mockResolvedValueOnce(created);
+
+    const result = await createTask({ name: "New task" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/tasks/", {
+      method: "POST",
+      body: JSON.stringify({ name: "New task" }),
+    });
+    expect(result).toBe(created);
+  });
+});
+
+describe("updateTask", () => {
+  it("patches task data by id", async () => {
+    const updated = { id: 3, name: "Updated" } as Task;
+    mockedApiFetch.mockResolvedValueOnce(updated);
+
+    const result = await updateTask(3, { name: "Updated" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/tasks/3/", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "Updated" }),
+    });
+    expect(result).toBe(updated);
+  });
+});
+
+describe("deleteTask", () => {
+  it("deletes a task by id", async () => {
+    mockedApiFetch.mockResolvedValueOnce(undefined);
+
+    await deleteTask(7);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith("/tasks/7/", {
+      method: "DELETE",
+    });
+  });
+});

--- a/frontend/src/components/BackToTopButton/BackToTopButton.test.tsx
+++ b/frontend/src/components/BackToTopButton/BackToTopButton.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import BackToTopButton from "./BackToTopButton";
+
+describe("BackToTopButton", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("scrolls smoothly to the top when clicked, by default", async () => {
+    const user = userEvent.setup();
+    const scrollTo = vi.fn();
+    vi.stubGlobal("scrollTo", scrollTo);
+    vi.spyOn(window, "matchMedia").mockReturnValue({
+      matches: false,
+    } as MediaQueryList);
+
+    render(<BackToTopButton />);
+    await user.click(screen.getByRole("button", { name: "Back to top" }));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "smooth" });
+  });
+
+  it("scrolls instantly when the user prefers reduced motion", async () => {
+    const user = userEvent.setup();
+    const scrollTo = vi.fn();
+    vi.stubGlobal("scrollTo", scrollTo);
+    vi.spyOn(window, "matchMedia").mockReturnValue({
+      matches: true,
+    } as MediaQueryList);
+
+    render(<BackToTopButton />);
+    await user.click(screen.getByRole("button", { name: "Back to top" }));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "auto" });
+  });
+});

--- a/frontend/src/components/MapDetailCard/MapDetailCard.test.tsx
+++ b/frontend/src/components/MapDetailCard/MapDetailCard.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TamaguiProvider } from "tamagui";
+import MapDetailCard from "./MapDetailCard";
+import tamaguiConfig from "../../../tamagui.config";
+
+// MapDetailCard's underlying DetailSurface needs a TamaguiProvider ancestor -
+// the app root (src/main.tsx) provides this in production; tests need their own.
+function renderCard(overrides: Partial<React.ComponentProps<typeof MapDetailCard>> = {}) {
+  const props = {
+    open: true,
+    title: "Riverside",
+    onClose: vi.fn(),
+    children: <p>Card content</p>,
+    ...overrides,
+  };
+  render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
+      <MapDetailCard {...props} />
+    </TamaguiProvider>
+  );
+  return props;
+}
+
+describe("MapDetailCard", () => {
+  it("renders the title and content when open", () => {
+    renderCard();
+    expect(screen.getByRole("dialog", { name: "Riverside" })).toBeInTheDocument();
+    expect(screen.getAllByText("Riverside").length).toBeGreaterThan(0);
+    expect(screen.getByText("Card content")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    renderCard({ open: false });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when the close button is clicked", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderCard();
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render a fly-to button when onFlyTo is omitted", () => {
+    renderCard();
+    expect(screen.queryByRole("button", { name: "Fly to" })).not.toBeInTheDocument();
+  });
+
+  it("calls onFlyTo when the fly-to button is clicked", async () => {
+    const user = userEvent.setup();
+    const onFlyTo = vi.fn();
+    renderCard({ onFlyTo });
+    await user.click(screen.getByRole("button", { name: "Fly to" }));
+    expect(onFlyTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderCard();
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders into the provided container instead of document.body", () => {
+    const container = document.createElement("div");
+    container.setAttribute("data-testid", "map-wrapper");
+    document.body.appendChild(container);
+
+    renderCard({ container });
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+
+    document.body.removeChild(container);
+  });
+});

--- a/frontend/src/components/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.test.tsx
@@ -101,4 +101,47 @@ describe('Tooltip', () => {
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     });
   });
+
+  it('renders only the trigger, with no tooltip behaviour, when disabled', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tooltip content="Helpful context" disabled>
+        <button type="button">Trigger</button>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
+    await user.click(trigger);
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it.each([null, undefined, false])(
+    'renders only the trigger when content is %s',
+    async (content) => {
+      const user = userEvent.setup();
+
+      render(
+        <Tooltip content={content}>
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+      await user.click(trigger);
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    }
+  );
+
+  it('TooltipProvider renders its children as a passthrough', () => {
+    render(
+      <TooltipProvider>
+        <span>Provider child</span>
+      </TooltipProvider>
+    );
+
+    expect(screen.getByText('Provider child')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -1,7 +1,7 @@
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { AuthProvider } from "./AuthContext";
+import { AuthProvider, useAuth } from "./AuthContext";
 import { apiFetch, setUnauthorizedHandler } from "../utils/api";
 import { clearAuthStorage, storeAuthTokens } from "../utils/authStorage";
 
@@ -88,5 +88,167 @@ describe("AuthProvider unauthorized-handler registration", () => {
     unmountFirst();
     expect(setUnauthorizedHandler).toHaveBeenLastCalledWith(null);
     expect(setUnauthorizedHandler).toHaveBeenCalledTimes(4);
+  });
+});
+
+function Consumer() {
+  const { isAuthenticated, user, loading, login, logout } = useAuth();
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="authenticated">{String(isAuthenticated)}</span>
+      <span data-testid="user">{user ? user.email : "none"}</span>
+      <button onClick={() => login("new-access", "new-refresh", { rememberMe: true })}>login</button>
+      <button onClick={() => logout()}>logout</button>
+    </div>
+  );
+}
+
+describe("AuthProvider session lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    clearAuthStorage();
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("resolves to unauthenticated without calling apiFetch when no tokens are stored", async () => {
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it("verifies stored tokens on mount and loads the current user", async () => {
+    storeAuthTokens("access-token", "refresh-token", true);
+    vi.mocked(apiFetch).mockResolvedValueOnce({ id: 1, email: "stored@example.com" });
+
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+    });
+    expect(screen.getByTestId("user")).toHaveTextContent("stored@example.com");
+  });
+
+  it("login() stores tokens and loads the user without a duplicate /me/ verification call", async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce({ id: 2, email: "login@example.com" });
+
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    await act(async () => {
+      screen.getByText("login").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+    });
+    expect(screen.getByTestId("user")).toHaveTextContent("login@example.com");
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem("authSession")).not.toBeNull();
+  });
+
+  it("login() leaves the user unauthenticated if fetching /me/ fails", async () => {
+    vi.mocked(apiFetch).mockRejectedValueOnce(new Error("network down"));
+
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    await act(async () => {
+      screen.getByText("login").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+  });
+
+  it("logout() clears storage and resets user/token state", async () => {
+    storeAuthTokens("access-token", "refresh-token", true);
+    vi.mocked(apiFetch).mockResolvedValueOnce({ id: 1, email: "stored@example.com" });
+
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+    });
+
+    act(() => {
+      screen.getByText("logout").click();
+    });
+
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+    expect(screen.getByTestId("user")).toHaveTextContent("none");
+    expect(localStorage.getItem("authSession")).toBeNull();
+  });
+
+  it("does not treat a service-unavailable error during verification as an invalid session", async () => {
+    storeAuthTokens("access-token", "refresh-token", true);
+    const { ApiFetchError } = await import("../utils/api");
+    vi.mocked(apiFetch).mockRejectedValueOnce(new ApiFetchError("service_unavailable", "down for maintenance"));
+
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+    // Tokens are untouched by a transient service outage - unlike an actual
+    // 401, this doesn't clear the stored session.
+    expect(localStorage.getItem("authSession")).not.toBeNull();
+  });
+});
+
+describe("useAuth", () => {
+  it("throws when used outside an AuthProvider", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    function BareConsumer() {
+      useAuth();
+      return null;
+    }
+
+    expect(() => render(<BareConsumer />)).toThrow(
+      "useAuth must be used within an AuthProvider",
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/frontend/src/context/GameContext.test.tsx
+++ b/frontend/src/context/GameContext.test.tsx
@@ -1,0 +1,182 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GameProvider } from "./GameContext";
+import { useGame } from "../hooks/useGame";
+import { useBootstrapGameData } from "../hooks/useBootstrapGameData";
+import { useAuth } from "./AuthContext";
+import { apiFetch } from "../utils/api";
+import type { ActivityTimerReturn, Player } from "../types";
+
+vi.mock("../hooks/useBootstrapGameData", () => ({
+  useBootstrapGameData: vi.fn(),
+}));
+
+vi.mock("./AuthContext", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../utils/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("../hooks/useActivityTimer", () => ({
+  default: vi.fn(),
+}));
+
+const mockedUseBootstrapGameData = useBootstrapGameData as ReturnType<typeof vi.fn>;
+const mockedUseAuth = useAuth as ReturnType<typeof vi.fn>;
+const mockedApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+const baseBootstrap = {
+  player: null,
+  character: null,
+  activityTimerInfo: null,
+  populationCentreInfo: null,
+  xpMods: [],
+  loginState: "none" as const,
+  loginStreak: 0,
+  loginEventAt: null,
+  loginRewardXp: 0,
+  announcementUnreadCount: 0,
+  loading: false,
+  error: null,
+  buildNumber: "abc123",
+  freeTimerLimitSeconds: 1800,
+  gameSettings: null,
+  onlineCount: 0,
+};
+
+const baseActivityTimer: ActivityTimerReturn = {
+  status: "empty",
+  elapsed: 0,
+  duration: 0,
+  limitSeconds: null,
+  limitReached: false,
+  canResume: false,
+  autoStopCompletion: null,
+  currentActivity: null,
+  startActivity: vi.fn(),
+  labelActivity: vi.fn(),
+  resume: vi.fn(),
+  discard: vi.fn(),
+  stop: vi.fn(),
+  loadFromServer: vi.fn(),
+} as unknown as ActivityTimerReturn;
+
+function Consumer() {
+  const { player, loginState, buildNumber } = useGame();
+  return (
+    <div>
+      <span data-testid="player">{player ? player.id : "no-player"}</span>
+      <span data-testid="login-state">{loginState}</span>
+      <span data-testid="build-number">{String(buildNumber)}</span>
+    </div>
+  );
+}
+
+function renderProvider() {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GameProvider>
+        <Consumer />
+      </GameProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("GameProvider", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a loading state while bootstrap data is loading", async () => {
+    mockedUseBootstrapGameData.mockReturnValue({ ...baseBootstrap, loading: true });
+    mockedUseAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+    const activityTimerModule = await import("../hooks/useActivityTimer");
+    vi.mocked(activityTimerModule.default).mockReturnValue(baseActivityTimer);
+
+    renderProvider();
+
+    expect(screen.getByText("Loading game data...")).toBeInTheDocument();
+  });
+
+  it("renders an error state when bootstrap fails", async () => {
+    mockedUseBootstrapGameData.mockReturnValue({
+      ...baseBootstrap,
+      error: "Something went wrong while loading game data.",
+    });
+    mockedUseAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+    const activityTimerModule = await import("../hooks/useActivityTimer");
+    vi.mocked(activityTimerModule.default).mockReturnValue(baseActivityTimer);
+
+    renderProvider();
+
+    expect(
+      screen.getByText("Error loading game: Something went wrong while loading game data.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders children with bootstrap-provided context values once loaded", async () => {
+    mockedUseBootstrapGameData.mockReturnValue({ ...baseBootstrap, loginState: "streak" });
+    mockedUseAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+    const activityTimerModule = await import("../hooks/useActivityTimer");
+    vi.mocked(activityTimerModule.default).mockReturnValue(baseActivityTimer);
+
+    renderProvider();
+
+    expect(screen.getByTestId("player")).toHaveTextContent("no-player");
+    expect(screen.getByTestId("login-state")).toHaveTextContent("streak");
+    expect(screen.getByTestId("build-number")).toHaveTextContent("abc123");
+  });
+
+  it("fetches player/character and activities once auth resolves as authenticated", async () => {
+    mockedUseBootstrapGameData.mockReturnValue(baseBootstrap);
+    mockedUseAuth.mockReturnValue({ isAuthenticated: true, loading: false });
+    const activityTimerModule = await import("../hooks/useActivityTimer");
+    vi.mocked(activityTimerModule.default).mockReturnValue(baseActivityTimer);
+    const player = { id: 1 } as Player;
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path.includes("/me/player/")) return Promise.resolve(player);
+      if (path.includes("player-activities")) return Promise.resolve({ results: [] });
+      if (path.includes("character-activities")) return Promise.resolve({ results: [] });
+      return Promise.resolve({});
+    });
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledWith("/me/player/");
+    });
+    expect(screen.getByTestId("player")).toHaveTextContent("1");
+  });
+
+  it("does not fetch player/character while auth is still loading", async () => {
+    mockedUseBootstrapGameData.mockReturnValue(baseBootstrap);
+    mockedUseAuth.mockReturnValue({ isAuthenticated: false, loading: true });
+    const activityTimerModule = await import("../hooks/useActivityTimer");
+    vi.mocked(activityTimerModule.default).mockReturnValue(baseActivityTimer);
+
+    renderProvider();
+
+    expect(mockedApiFetch).not.toHaveBeenCalledWith("/me/player/");
+  });
+});
+
+describe("useGame", () => {
+  it("throws when used outside a GameProvider", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    function BareConsumer() {
+      useGame();
+      return null;
+    }
+
+    expect(() => render(<BareConsumer />)).toThrow(
+      "useGame must be used within a GameProvider"
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/context/MaintenanceContext.test.tsx
+++ b/frontend/src/context/MaintenanceContext.test.tsx
@@ -1,0 +1,68 @@
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MaintenanceProvider, useMaintenanceContext } from "./MaintenanceContext";
+
+function Consumer() {
+  const { maintenance, setMaintenance } = useMaintenanceContext();
+  return (
+    <div>
+      <span data-testid="active">{String(maintenance.active)}</span>
+      <span data-testid="details">{maintenance.details?.name ?? "none"}</span>
+      <button
+        onClick={() =>
+          setMaintenance({
+            active: true,
+            details: { name: "Scheduled downtime" },
+          })
+        }
+      >
+        trigger
+      </button>
+    </div>
+  );
+}
+
+describe("MaintenanceProvider", () => {
+  it("provides the default (inactive) maintenance state", () => {
+    render(
+      <MaintenanceProvider>
+        <Consumer />
+      </MaintenanceProvider>
+    );
+
+    expect(screen.getByTestId("active")).toHaveTextContent("false");
+    expect(screen.getByTestId("details")).toHaveTextContent("none");
+  });
+
+  it("updates the maintenance state via setMaintenance", () => {
+    render(
+      <MaintenanceProvider>
+        <Consumer />
+      </MaintenanceProvider>
+    );
+
+    act(() => {
+      screen.getByText("trigger").click();
+    });
+
+    expect(screen.getByTestId("active")).toHaveTextContent("true");
+    expect(screen.getByTestId("details")).toHaveTextContent("Scheduled downtime");
+  });
+});
+
+describe("useMaintenanceContext", () => {
+  it("throws when used outside a MaintenanceProvider", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    function BareConsumer() {
+      useMaintenanceContext();
+      return null;
+    }
+
+    expect(() => render(<BareConsumer />)).toThrow(
+      "useMaintenanceContext must be used within a MaintenanceProvider"
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/context/OnlineCountContext.test.tsx
+++ b/frontend/src/context/OnlineCountContext.test.tsx
@@ -1,0 +1,65 @@
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OnlineCountProvider, useOnlineCount } from "./OnlineCountContext";
+import { useGame } from "../hooks/useGame";
+
+vi.mock("../hooks/useGame", () => ({ useGame: vi.fn() }));
+
+const mockedUseGame = useGame as ReturnType<typeof vi.fn>;
+
+function Consumer() {
+  const { onlinePlayerCount, setOnlinePlayerCount } = useOnlineCount();
+  return (
+    <div>
+      <span data-testid="count">{onlinePlayerCount}</span>
+      <button onClick={() => setOnlinePlayerCount(42)}>set</button>
+    </div>
+  );
+}
+
+describe("OnlineCountProvider", () => {
+  it("initializes from useGame's initialOnlineCount", () => {
+    mockedUseGame.mockReturnValue({ initialOnlineCount: 9 });
+
+    render(
+      <OnlineCountProvider>
+        <Consumer />
+      </OnlineCountProvider>
+    );
+
+    expect(screen.getByTestId("count")).toHaveTextContent("9");
+  });
+
+  it("updates the count via setOnlinePlayerCount", () => {
+    mockedUseGame.mockReturnValue({ initialOnlineCount: 0 });
+
+    render(
+      <OnlineCountProvider>
+        <Consumer />
+      </OnlineCountProvider>
+    );
+
+    act(() => {
+      screen.getByText("set").click();
+    });
+
+    expect(screen.getByTestId("count")).toHaveTextContent("42");
+  });
+});
+
+describe("useOnlineCount", () => {
+  it("throws when used outside an OnlineCountProvider", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    function BareConsumer() {
+      useOnlineCount();
+      return null;
+    }
+
+    expect(() => render(<BareConsumer />)).toThrow(
+      "useOnlineCount must be used within an OnlineCountProvider"
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/context/ToastContext.test.tsx
+++ b/frontend/src/context/ToastContext.test.tsx
@@ -1,0 +1,99 @@
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ToastProvider } from "./ToastContext";
+import { useToast } from "../hooks/useToast";
+import { useFeatureFlag } from "../hooks/useFeatureFlag";
+
+vi.mock("../hooks/useFeatureFlag", () => ({ useFeatureFlag: vi.fn() }));
+vi.mock("../components/Toast/ToastManager", () => ({
+  default: ({ messages }: { messages: { id: string; message: string }[] }) => (
+    <div data-testid="toast-manager">{messages.map((m) => m.message).join(",")}</div>
+  ),
+}));
+
+const mockedUseFeatureFlag = useFeatureFlag as ReturnType<typeof vi.fn>;
+
+function Consumer() {
+  const { toasts, showToast } = useToast();
+  return (
+    <div>
+      <span data-testid="count">{toasts.length}</span>
+      <button onClick={() => showToast("hello")}>show</button>
+    </div>
+  );
+}
+
+describe("ToastProvider", () => {
+  it("starts with no toasts", () => {
+    mockedUseFeatureFlag.mockReturnValue(false);
+
+    render(
+      <ToastProvider>
+        <Consumer />
+      </ToastProvider>
+    );
+
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it("adds a toast via showToast", () => {
+    mockedUseFeatureFlag.mockReturnValue(false);
+
+    render(
+      <ToastProvider>
+        <Consumer />
+      </ToastProvider>
+    );
+
+    act(() => {
+      screen.getByText("show").click();
+    });
+
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+  });
+
+  it("does not render ToastManager when the toastsFeature flag is off", () => {
+    mockedUseFeatureFlag.mockReturnValue(false);
+
+    render(
+      <ToastProvider>
+        <Consumer />
+      </ToastProvider>
+    );
+
+    expect(screen.queryByTestId("toast-manager")).not.toBeInTheDocument();
+  });
+
+  it("renders ToastManager with active toasts when the toastsFeature flag is on", () => {
+    mockedUseFeatureFlag.mockReturnValue(true);
+
+    render(
+      <ToastProvider>
+        <Consumer />
+      </ToastProvider>
+    );
+
+    act(() => {
+      screen.getByText("show").click();
+    });
+
+    expect(screen.getByTestId("toast-manager")).toHaveTextContent("hello");
+  });
+});
+
+describe("useToast", () => {
+  it("throws when used outside a ToastProvider", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    function BareConsumer() {
+      useToast();
+      return null;
+    }
+
+    expect(() => render(<BareConsumer />)).toThrow(
+      "useToast must be used within a ToastProvider"
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/context/WebSocketContext.test.tsx
+++ b/frontend/src/context/WebSocketContext.test.tsx
@@ -1,0 +1,234 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WebSocketProvider } from "./WebSocketContext";
+import { useWebSocket } from "../hooks/useWebSocket";
+import { useGame } from "../hooks/useGame";
+import { useOnlineCount } from "./OnlineCountContext";
+import { useAuth } from "./AuthContext";
+import { useToast } from "../hooks/useToast";
+import { useMaintenanceStatus } from "../hooks/useMaintenanceStatus";
+import { useMaintenanceContext } from "./MaintenanceContext";
+import { useWebSocketConnection } from "../hooks/useWebSocketConnection";
+import { handleGlobalWebSocketEvent } from "../websockets/handleGlobalWebSocketEvent";
+import type { IncomingWebSocketMessage } from "../types";
+
+vi.mock("../hooks/useGame", () => ({ useGame: vi.fn() }));
+vi.mock("./OnlineCountContext", async () => {
+  const actual = await vi.importActual<typeof import("./OnlineCountContext")>("./OnlineCountContext");
+  return { ...actual, useOnlineCount: vi.fn() };
+});
+vi.mock("./AuthContext", () => ({ useAuth: vi.fn() }));
+vi.mock("../hooks/useToast", () => ({ useToast: vi.fn() }));
+vi.mock("../hooks/useMaintenanceStatus", () => ({ useMaintenanceStatus: vi.fn() }));
+vi.mock("./MaintenanceContext", async () => {
+  const actual = await vi.importActual<typeof import("./MaintenanceContext")>("./MaintenanceContext");
+  return { ...actual, useMaintenanceContext: vi.fn() };
+});
+vi.mock("../hooks/useWebSocketConnection", () => ({ useWebSocketConnection: vi.fn() }));
+vi.mock("../websockets/handleGlobalWebSocketEvent", () => ({
+  handleGlobalWebSocketEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockedUseGame = useGame as ReturnType<typeof vi.fn>;
+const mockedUseOnlineCount = useOnlineCount as ReturnType<typeof vi.fn>;
+const mockedUseAuth = useAuth as ReturnType<typeof vi.fn>;
+const mockedUseToast = useToast as ReturnType<typeof vi.fn>;
+const mockedUseMaintenanceStatus = useMaintenanceStatus as ReturnType<typeof vi.fn>;
+const mockedUseMaintenanceContext = useMaintenanceContext as ReturnType<typeof vi.fn>;
+const mockedUseWebSocketConnection = useWebSocketConnection as ReturnType<typeof vi.fn>;
+const mockedHandleGlobalWebSocketEvent = handleGlobalWebSocketEvent as ReturnType<typeof vi.fn>;
+
+function setup({
+  isAuthenticated = true,
+  authLoading = false,
+  playerId,
+}: { isAuthenticated?: boolean; authLoading?: boolean; playerId?: number } = {}) {
+  const setOnlinePlayerCount = vi.fn();
+  const loadFromServer = vi.fn();
+  const showToast = vi.fn();
+  const maintenanceRefetch = vi.fn();
+  const setMaintenance = vi.fn();
+  const send = vi.fn();
+  const disconnect = vi.fn();
+
+  mockedUseGame.mockReturnValue({
+    player: playerId !== undefined ? { id: playerId, is_premium: false } : null,
+    activityTimer: { loadFromServer },
+    freeTimerLimitSeconds: 1800,
+  });
+  mockedUseOnlineCount.mockReturnValue({ setOnlinePlayerCount });
+  mockedUseAuth.mockReturnValue({ isAuthenticated, loading: authLoading });
+  mockedUseToast.mockReturnValue({ showToast });
+  mockedUseMaintenanceStatus.mockReturnValue({ refetch: maintenanceRefetch });
+  mockedUseMaintenanceContext.mockReturnValue({ setMaintenance });
+  mockedUseWebSocketConnection.mockReturnValue({ send, isConnected: true, disconnect });
+
+  return { setOnlinePlayerCount, loadFromServer, showToast, maintenanceRefetch, setMaintenance, send, disconnect };
+}
+
+function renderProvider(children: React.ReactNode) {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <WebSocketProvider>{children}</WebSocketProvider>
+    </QueryClientProvider>
+  );
+}
+
+function Consumer() {
+  const ctx = useWebSocket();
+  return <span data-testid="connected">{String(ctx.isConnected)}</span>;
+}
+
+describe("WebSocketProvider", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enables the connection once auth resolves as authenticated with a linked player", () => {
+    setup({ isAuthenticated: true, authLoading: false, playerId: 7 });
+
+    renderProvider(<Consumer />);
+
+    const [playerId, , , , , shouldConnect] = mockedUseWebSocketConnection.mock.calls[0];
+    expect(playerId).toBe(7);
+    expect(shouldConnect).toBe(true);
+  });
+
+  it("disables the connection while auth is still loading", () => {
+    setup({ isAuthenticated: true, authLoading: true, playerId: 7 });
+
+    renderProvider(<Consumer />);
+
+    const [, , , , , shouldConnect] = mockedUseWebSocketConnection.mock.calls[0];
+    expect(shouldConnect).toBe(false);
+  });
+
+  it("disables the connection when there is no linked player", () => {
+    setup({ isAuthenticated: true, authLoading: false, playerId: undefined });
+
+    renderProvider(<Consumer />);
+
+    const [, , , , , shouldConnect] = mockedUseWebSocketConnection.mock.calls[0];
+    expect(shouldConnect).toBe(false);
+  });
+
+  it("updates the online count and delegates to handleGlobalWebSocketEvent on message", () => {
+    const { setOnlinePlayerCount } = setup({ playerId: 1 });
+
+    renderProvider(<Consumer />);
+
+    const onMessage = mockedUseWebSocketConnection.mock.calls[0][1];
+    const message: IncomingWebSocketMessage = { type: "online_count", count: 5 } as IncomingWebSocketMessage;
+
+    act(() => {
+      onMessage(message);
+    });
+
+    expect(setOnlinePlayerCount).toHaveBeenCalledWith(5);
+    expect(mockedHandleGlobalWebSocketEvent).toHaveBeenCalledWith(
+      message,
+      expect.objectContaining({
+        showToast: expect.any(Function),
+        maintenanceRefetch: expect.any(Function),
+        setMaintenance: expect.any(Function),
+        onActivityTimerUpdate: expect.any(Function),
+        onAnnouncementPublished: expect.any(Function),
+      })
+    );
+  });
+
+  it("notifies handlers registered via addEventHandler, and unregisters them on cleanup", () => {
+    setup({ playerId: 1 });
+    const handler = vi.fn();
+
+    function HandlerConsumer() {
+      const { addEventHandler } = useWebSocket();
+      addEventHandler(handler);
+      return null;
+    }
+
+    renderProvider(<HandlerConsumer />);
+
+    const onMessage = mockedUseWebSocketConnection.mock.calls[0][1];
+    const message: IncomingWebSocketMessage = { type: "pong" } as IncomingWebSocketMessage;
+
+    act(() => {
+      onMessage(message);
+    });
+
+    expect(handler).toHaveBeenCalledWith(message);
+  });
+
+  it("reconciles the activity timer and invalidates announcement queries via the callbacks passed to handleGlobalWebSocketEvent", () => {
+    const { loadFromServer } = setup({ playerId: 1 });
+
+    renderProvider(<Consumer />);
+
+    // Trigger a message so handleGlobalWebSocketEvent gets called with the
+    // provider's callbacks as its options argument.
+    const onMessage = mockedUseWebSocketConnection.mock.calls[0][1];
+    act(() => {
+      onMessage({ type: "pong" } as IncomingWebSocketMessage);
+    });
+    const { onActivityTimerUpdate, onAnnouncementPublished } =
+      mockedHandleGlobalWebSocketEvent.mock.calls[0][1];
+
+    const timerData = { status: "active" } as never;
+    onActivityTimerUpdate(timerData);
+    expect(loadFromServer).toHaveBeenCalledWith(timerData, { limitSeconds: 1800 });
+
+    expect(() => onAnnouncementPublished()).not.toThrow();
+  });
+
+  it("logs on connection error and close", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    setup({ playerId: 1 });
+
+    renderProvider(<Consumer />);
+
+    const [, , onError, onClose] = mockedUseWebSocketConnection.mock.calls[0];
+    onError();
+    onClose();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith("WebSocket connection error");
+    expect(consoleWarnSpy).toHaveBeenCalledWith("WebSocket disconnected");
+
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("exposes send/isConnected/disconnect from useWebSocketConnection", () => {
+    const { send } = setup({ playerId: 1 });
+
+    function SendConsumer() {
+      const ctx = useWebSocket();
+      ctx.send({ type: "ping" } as never);
+      return <span data-testid="connected">{String(ctx.isConnected)}</span>;
+    }
+
+    renderProvider(<SendConsumer />);
+
+    expect(screen.getByTestId("connected")).toHaveTextContent("true");
+    expect(send).toHaveBeenCalledWith({ type: "ping" });
+  });
+});
+
+describe("useWebSocket", () => {
+  it("throws when used outside a WebSocketProvider", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    function BareConsumer() {
+      useWebSocket();
+      return null;
+    }
+
+    expect(() => render(<BareConsumer />)).toThrow(
+      "useWebSocket must be used within a WebSocketProvider"
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/useActivities.test.tsx
+++ b/frontend/src/hooks/useActivities.test.tsx
@@ -1,0 +1,152 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useActivities,
+  useChangeActivitySkill,
+  useChangeActivityTask,
+  useCreateActivity,
+  useDeleteActivity,
+  useLogOfflineActivity,
+  useUpdateActivity,
+} from "./useActivities";
+import type { PlayerActivity } from "../types";
+
+const mockFetchActivities = vi.fn();
+const mockCreateActivity = vi.fn();
+const mockUpdateActivity = vi.fn();
+const mockDeleteActivity = vi.fn();
+const mockLogOfflineActivity = vi.fn();
+
+vi.mock("../api/activities", () => ({
+  fetchActivities: (...args: unknown[]) => mockFetchActivities(...args),
+  createActivity: (...args: unknown[]) => mockCreateActivity(...args),
+  updateActivity: (...args: unknown[]) => mockUpdateActivity(...args),
+  deleteActivity: (...args: unknown[]) => mockDeleteActivity(...args),
+  logOfflineActivity: (...args: unknown[]) => mockLogOfflineActivity(...args),
+}));
+
+const activity = (id: number): PlayerActivity => ({ id, name: `Activity ${id}` } as PlayerActivity);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+describe("useActivities", () => {
+  beforeEach(() => {
+    mockFetchActivities.mockReset();
+    mockCreateActivity.mockReset();
+    mockUpdateActivity.mockReset();
+    mockDeleteActivity.mockReset();
+    mockLogOfflineActivity.mockReset();
+  });
+
+  it("fetches activities", async () => {
+    mockFetchActivities.mockResolvedValue([activity(1)]);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useActivities(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([activity(1)]);
+  });
+
+  it("invalidates activities after creating one", async () => {
+    mockCreateActivity.mockResolvedValue(activity(2));
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateActivity(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ name: "New" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["activities"] });
+  });
+
+  it("invalidates both activities and tasks after logging an offline activity", async () => {
+    mockLogOfflineActivity.mockResolvedValue(activity(3));
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useLogOfflineActivity(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ started_at: "2026-01-01T00:00:00Z", completed_at: "2026-01-01T00:10:00Z" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["activities"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["tasks"] });
+  });
+
+  it("passes activityId and data through to updateActivity", async () => {
+    mockUpdateActivity.mockResolvedValue(activity(1));
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useUpdateActivity(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ activityId: 1, data: { name: "Renamed" } });
+    });
+
+    expect(mockUpdateActivity).toHaveBeenCalledWith(1, { name: "Renamed" });
+  });
+
+  it("changes an activity's skill via updateActivity", async () => {
+    mockUpdateActivity.mockResolvedValue(activity(1));
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useChangeActivitySkill(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ activityId: 1, skillId: 9 });
+    });
+
+    expect(mockUpdateActivity).toHaveBeenCalledWith(1, { skill_id: 9 });
+  });
+
+  it("changes an activity's task via updateActivity, including clearing it to null", async () => {
+    mockUpdateActivity.mockResolvedValue(activity(1));
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useChangeActivityTask(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ activityId: 1, taskId: null });
+    });
+
+    expect(mockUpdateActivity).toHaveBeenCalledWith(1, { task_id: null });
+  });
+
+  it("optimistically removes a deleted activity and rolls back on failure", async () => {
+    mockDeleteActivity.mockRejectedValue(new Error("boom"));
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["activities"], [activity(1), activity(2)]);
+
+    const { result } = renderHook(() => useDeleteActivity(), { wrapper });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(1);
+      } catch {
+        // expected
+      }
+    });
+
+    expect(queryClient.getQueryData(["activities"])).toEqual([activity(1), activity(2)]);
+  });
+
+  it("keeps an optimistically deleted activity removed on success", async () => {
+    mockDeleteActivity.mockResolvedValue(undefined);
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["activities"], [activity(1), activity(2)]);
+
+    const { result } = renderHook(() => useDeleteActivity(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync(1);
+    });
+
+    expect(queryClient.getQueryData(["activities"])).toEqual([activity(2)]);
+  });
+});

--- a/frontend/src/hooks/useAnnouncements.test.tsx
+++ b/frontend/src/hooks/useAnnouncements.test.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useAnnouncements,
+  useAnnouncementUnreadCount,
+  useMarkAllAnnouncementsRead,
+  useMarkAnnouncementRead,
+} from "./useAnnouncements";
+
+const mockFetchAnnouncements = vi.fn();
+const mockFetchAnnouncementUnreadCount = vi.fn();
+const mockMarkAnnouncementRead = vi.fn();
+const mockMarkAllAnnouncementsRead = vi.fn();
+
+vi.mock("../api/announcements", () => ({
+  fetchAnnouncements: (...args: unknown[]) => mockFetchAnnouncements(...args),
+  fetchAnnouncementUnreadCount: (...args: unknown[]) => mockFetchAnnouncementUnreadCount(...args),
+  markAnnouncementRead: (...args: unknown[]) => mockMarkAnnouncementRead(...args),
+  markAllAnnouncementsRead: (...args: unknown[]) => mockMarkAllAnnouncementsRead(...args),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+describe("useAnnouncements", () => {
+  beforeEach(() => {
+    mockFetchAnnouncements.mockReset();
+    mockFetchAnnouncementUnreadCount.mockReset();
+    mockMarkAnnouncementRead.mockReset();
+    mockMarkAllAnnouncementsRead.mockReset();
+  });
+
+  it("fetches announcements when enabled (default)", async () => {
+    mockFetchAnnouncements.mockResolvedValue([{ id: 1 }]);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useAnnouncements(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: 1 }]);
+  });
+
+  it("does not fetch announcements when explicitly disabled", () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useAnnouncements(false), { wrapper });
+    expect(mockFetchAnnouncements).not.toHaveBeenCalled();
+  });
+
+  it("fetches the unread count", async () => {
+    mockFetchAnnouncementUnreadCount.mockResolvedValue(3);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useAnnouncementUnreadCount(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(3);
+  });
+
+  it("invalidates both announcements and unread count after marking one read", async () => {
+    mockMarkAnnouncementRead.mockResolvedValue(undefined);
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useMarkAnnouncementRead(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync(1);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["announcements"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["announcements", "unreadCount"] });
+  });
+
+  it("invalidates both announcements and unread count after marking all read", async () => {
+    mockMarkAllAnnouncementsRead.mockResolvedValue(undefined);
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useMarkAllAnnouncementsRead(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["announcements"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["announcements", "unreadCount"] });
+  });
+});

--- a/frontend/src/hooks/useBootstrapGameData.test.ts
+++ b/frontend/src/hooks/useBootstrapGameData.test.ts
@@ -1,0 +1,118 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useBootstrapGameData } from "./useBootstrapGameData";
+
+const mockUseAuth = vi.fn();
+const mockApiFetch = vi.fn();
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("../utils/api", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+describe("useBootstrapGameData", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    mockApiFetch.mockReset();
+  });
+
+  it("stays loading while auth is still resolving, without fetching", () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, loading: true });
+
+    const { result } = renderHook(() => useBootstrapGameData());
+
+    expect(result.current.loading).toBe(true);
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it("resets to logged-out defaults when not authenticated", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+
+    const { result } = renderHook(() => useBootstrapGameData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.loginState).toBe("none");
+    expect(result.current.loginStreak).toBe(0);
+    expect(result.current.loginEventAt).toBeNull();
+    expect(result.current.loginRewardXp).toBe(0);
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it("populates game data from /fetch_info/ when authenticated", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, loading: false });
+    mockApiFetch.mockResolvedValue({
+      player: { id: 1 },
+      character: { id: 2 },
+      activity_timer: { id: 3 },
+      population_centre: { id: 4 },
+      xp_mods: [{ id: 5 }],
+      login_state: "streak",
+      login_streak: "7",
+      login_event_at: "2026-01-01T00:00:00Z",
+      login_reward_xp: "50",
+      announcement_unread_count: "2",
+      build_number: "abc123",
+      game_settings: { free_timer_limit_seconds: 900 },
+      online_count: "12",
+    });
+
+    const { result } = renderHook(() => useBootstrapGameData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockApiFetch).toHaveBeenCalledWith("/fetch_info/");
+    expect(result.current.player).toEqual({ id: 1 });
+    expect(result.current.character).toEqual({ id: 2 });
+    expect(result.current.loginState).toBe("streak");
+    expect(result.current.loginStreak).toBe(7);
+    expect(result.current.loginRewardXp).toBe(50);
+    expect(result.current.announcementUnreadCount).toBe(2);
+    expect(result.current.onlineCount).toBe(12);
+    expect(result.current.freeTimerLimitSeconds).toBe(900);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("falls back to the top-level free timer limit when game_settings omits it", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, loading: false });
+    mockApiFetch.mockResolvedValue({
+      player: null,
+      character: null,
+      activity_timer: null,
+      population_centre: null,
+      free_timer_limit_seconds: 600,
+    });
+
+    const { result } = renderHook(() => useBootstrapGameData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.freeTimerLimitSeconds).toBe(600);
+  });
+
+  it("uses the default free timer limit when neither source provides one", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, loading: false });
+    mockApiFetch.mockResolvedValue({ player: null, character: null, activity_timer: null, population_centre: null });
+
+    const { result } = renderHook(() => useBootstrapGameData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.freeTimerLimitSeconds).toBe(1800);
+  });
+
+  it("sets an error and stops loading when the fetch fails", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, loading: false });
+    mockApiFetch.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useBootstrapGameData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Something went wrong while loading game data.");
+  });
+});

--- a/frontend/src/hooks/useCategories.test.tsx
+++ b/frontend/src/hooks/useCategories.test.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCategories, useCreateCategory, useDeleteCategory, useUpdateCategory } from "./useCategories";
+import type { Category } from "../types";
+
+const mockFetchCategories = vi.fn();
+const mockCreateCategory = vi.fn();
+const mockUpdateCategory = vi.fn();
+const mockDeleteCategory = vi.fn();
+
+vi.mock("../api/categories", () => ({
+  fetchCategories: (...args: unknown[]) => mockFetchCategories(...args),
+  createCategory: (...args: unknown[]) => mockCreateCategory(...args),
+  updateCategory: (...args: unknown[]) => mockUpdateCategory(...args),
+  deleteCategory: (...args: unknown[]) => mockDeleteCategory(...args),
+}));
+
+const category = (id: number): Category => ({ id, name: `Category ${id}` } as Category);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+describe("useCategories", () => {
+  beforeEach(() => {
+    mockFetchCategories.mockReset();
+    mockCreateCategory.mockReset();
+    mockUpdateCategory.mockReset();
+    mockDeleteCategory.mockReset();
+  });
+
+  it("fetches categories", async () => {
+    mockFetchCategories.mockResolvedValue([category(1)]);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useCategories(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([category(1)]);
+  });
+
+  it("invalidates categories after creating one", async () => {
+    mockCreateCategory.mockResolvedValue(category(2));
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateCategory(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ name: "New" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["categories"] });
+  });
+
+  it("passes id and data through to updateCategory", async () => {
+    mockUpdateCategory.mockResolvedValue(category(1));
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useUpdateCategory(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 1, data: { name: "Renamed" } });
+    });
+
+    expect(mockUpdateCategory).toHaveBeenCalledWith(1, { name: "Renamed" });
+  });
+
+  it("optimistically removes a deleted category and rolls back on failure", async () => {
+    mockDeleteCategory.mockRejectedValue(new Error("boom"));
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["categories"], [category(1), category(2)]);
+
+    const { result } = renderHook(() => useDeleteCategory(), { wrapper });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(1);
+      } catch {
+        // expected
+      }
+    });
+
+    expect(queryClient.getQueryData(["categories"])).toEqual([category(1), category(2)]);
+  });
+
+  it("keeps an optimistically deleted category removed on success", async () => {
+    mockDeleteCategory.mockResolvedValue(undefined);
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["categories"], [category(1), category(2)]);
+
+    const { result } = renderHook(() => useDeleteCategory(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync(1);
+    });
+
+    expect(queryClient.getQueryData(["categories"])).toEqual([category(2)]);
+  });
+});

--- a/frontend/src/hooks/useEntitySearchCache.test.tsx
+++ b/frontend/src/hooks/useEntitySearchCache.test.tsx
@@ -1,0 +1,169 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEntitySearchCache } from "./useEntitySearchCache";
+
+const mockFetchActivities = vi.fn();
+const mockFetchTasks = vi.fn();
+const mockUseFeatureFlag = vi.fn();
+
+vi.mock("../api/activities", () => ({
+  fetchActivities: () => mockFetchActivities(),
+}));
+
+vi.mock("../api/tasks", () => ({
+  fetchTasks: () => mockFetchTasks(),
+}));
+
+vi.mock("./useFeatureFlag", () => ({
+  useFeatureFlag: () => mockUseFeatureFlag(),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+describe("useEntitySearchCache", () => {
+  beforeEach(() => {
+    mockFetchActivities.mockReset();
+    mockFetchTasks.mockReset();
+    mockUseFeatureFlag.mockReset();
+    mockUseFeatureFlag.mockReturnValue(false);
+  });
+
+  it("throws for an unsupported entity type", () => {
+    const { wrapper } = makeWrapper();
+    expect(() =>
+      renderHook(() => useEntitySearchCache("bogus" as never), { wrapper })
+    ).toThrow("Unsupported entity search type: bogus");
+  });
+
+  it("normalizes, dedupes, and sorts activities by frequency then recency", async () => {
+    mockFetchActivities.mockResolvedValue([
+      { id: 1, name: "  write report  ", completed_at: "2026-01-01T00:00:00Z" },
+      { id: 2, name: "Write Report", completed_at: "2026-01-05T00:00:00Z" },
+      { id: 3, name: "Read book", completed_at: "2026-01-03T00:00:00Z" },
+      { id: 4, name: "" },
+    ]);
+    mockFetchTasks.mockResolvedValue([]);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntitySearchCache("activity"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.entities).toHaveLength(2);
+    expect(result.current.entities[0].name).toBe("Write Report");
+    expect(result.current.entities[1].name).toBe("Read book");
+  });
+
+  it("includes completed tasks when fetching for the task type directly", async () => {
+    mockFetchTasks.mockResolvedValue([
+      { id: 1, name: "Open task", is_complete: false, completed_at: null },
+      { id: 2, name: "Done task", is_complete: true, completed_at: "2026-01-01T00:00:00Z" },
+    ]);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntitySearchCache("task"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const names = result.current.entities.map((e) => e.name).sort();
+    expect(names).toEqual(["Done task", "Open task"]);
+  });
+
+  it("merges task suggestions into activity entities when the tasks feature flag is enabled", async () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    mockFetchActivities.mockResolvedValue([{ id: 1, name: "Write report", completed_at: "2026-01-01T00:00:00Z" }]);
+    mockFetchTasks.mockResolvedValue([{ id: 5, name: "Plan trip", is_complete: false, completed_at: null }]);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntitySearchCache("activity"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() =>
+      expect(result.current.entities.some((e) => e.name === "Plan trip")).toBe(true)
+    );
+
+    const names = result.current.entities.map((e) => e.name);
+    expect(names).toContain("Write report");
+    expect(names).toContain("Plan trip");
+  });
+
+  it("does not fetch task suggestions when the tasks feature flag is disabled", async () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+    mockFetchActivities.mockResolvedValue([]);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntitySearchCache("activity"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFetchTasks).not.toHaveBeenCalled();
+  });
+
+  it("adds an optimistic entity to the activity cache, incrementing frequency on repeat inserts", async () => {
+    mockFetchActivities.mockResolvedValue([]);
+
+    const { queryClient, wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntitySearchCache("activity"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    act(() => {
+      result.current.addEntityToCache("New activity");
+    });
+    let cached = queryClient.getQueryData<{ name: string; isOptimistic: boolean; frequency: number }[]>([
+      "entity-search",
+      "activity",
+      "activities",
+    ]);
+    expect(cached).toHaveLength(1);
+    expect(cached?.[0]).toMatchObject({ name: "New activity", isOptimistic: true, frequency: 0 });
+
+    act(() => {
+      result.current.addEntityToCache("New activity");
+    });
+    cached = queryClient.getQueryData(["entity-search", "activity", "activities"]);
+    expect(cached).toHaveLength(1);
+    expect(cached?.[0].frequency).toBe(1);
+  });
+
+  it("returns null from addEntityToCache for the task entity type", async () => {
+    mockFetchTasks.mockResolvedValue([]);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntitySearchCache("task"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    let added;
+    act(() => {
+      added = result.current.addEntityToCache("Ignored");
+    });
+    expect(added).toBeNull();
+  });
+
+  it("returns null from addEntityToCache when the normalized name is empty", async () => {
+    mockFetchActivities.mockResolvedValue([]);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntitySearchCache("activity"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    let added;
+    act(() => {
+      added = result.current.addEntityToCache("   ");
+    });
+    expect(added).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useEventCallback.test.ts
+++ b/frontend/src/hooks/useEventCallback.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useEventCallback } from "./useEventCallback";
+
+describe("useEventCallback", () => {
+  it("returns a stable function identity across re-renders", () => {
+    const { result, rerender } = renderHook(({ fn }) => useEventCallback(fn), {
+      initialProps: { fn: () => 1 },
+    });
+
+    const first = result.current;
+    rerender({ fn: () => 2 });
+
+    expect(result.current).toBe(first);
+  });
+
+  it("always invokes the latest function passed in, even after the identity is captured", () => {
+    const { result, rerender } = renderHook(({ fn }) => useEventCallback(fn), {
+      initialProps: { fn: (n: number) => n + 1 },
+    });
+
+    const stable = result.current;
+    expect(stable(1)).toBe(2);
+
+    rerender({ fn: (n: number) => n * 10 });
+
+    expect(stable(1)).toBe(10);
+  });
+});

--- a/frontend/src/hooks/useLogin.test.ts
+++ b/frontend/src/hooks/useLogin.test.ts
@@ -1,0 +1,130 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import useLogin from "./useLogin";
+
+function jsonResponse(body: unknown, { ok = true, status = 200, url = "http://localhost:8000/api/v1/auth/jwt/create/" } = {}) {
+  const text = JSON.stringify(body);
+  return {
+    ok,
+    status,
+    url,
+    headers: { get: () => "application/json" },
+    text: async () => text,
+  } as unknown as Response;
+}
+
+describe("useLogin", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns tokens on a successful login", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ access_token: "access-1", refresh_token: "refresh-1" }))
+    );
+
+    const { result } = renderHook(() => useLogin());
+
+    let loginResult;
+    await act(async () => {
+      loginResult = await result.current("a@b.com", "pw");
+    });
+
+    expect(loginResult).toEqual({
+      success: true,
+      tokens: { access_token: "access-1", refresh_token: "refresh-1" },
+    });
+  });
+
+  it("accepts the access/refresh field aliases", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ access: "access-2", refresh: "refresh-2" })));
+
+    const { result } = renderHook(() => useLogin());
+
+    let loginResult;
+    await act(async () => {
+      loginResult = await result.current("a@b.com", "pw");
+    });
+
+    expect(loginResult).toEqual({
+      success: true,
+      tokens: { access_token: "access-2", refresh_token: "refresh-2" },
+    });
+  });
+
+  it("fails with a generic message when the response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        url: "http://localhost:8000/api/v1/auth/jwt/create/",
+        headers: { get: () => "application/json" },
+        text: async () => "bad request",
+      } as unknown as Response)
+    );
+
+    const { result } = renderHook(() => useLogin());
+
+    let loginResult;
+    await act(async () => {
+      loginResult = await result.current("a@b.com", "pw");
+    });
+
+    expect(loginResult).toEqual({ success: false, error: "Login failed. Please try again." });
+  });
+
+  it("fails with a specific message when the server reports no active account", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        url: "http://localhost:8000/api/v1/auth/jwt/create/",
+        headers: { get: () => "application/json" },
+        text: async () => "No active account found with the given credentials",
+      } as unknown as Response)
+    );
+
+    const { result } = renderHook(() => useLogin());
+
+    let loginResult;
+    await act(async () => {
+      loginResult = await result.current("a@b.com", "wrong-pw");
+    });
+
+    expect(loginResult).toEqual({ success: false, error: "Invalid email or password; please try again." });
+  });
+
+  it("fails with a server-unavailable message on a network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+    const { result } = renderHook(() => useLogin());
+
+    let loginResult;
+    await act(async () => {
+      loginResult = await result.current("a@b.com", "pw");
+    });
+
+    expect(loginResult).toEqual({
+      success: false,
+      error: "The server is unavailable. Please try again in a moment.",
+    });
+  });
+
+  it("fails when the response body is missing tokens", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({})));
+
+    const { result } = renderHook(() => useLogin());
+
+    let loginResult;
+    await act(async () => {
+      loginResult = await result.current("a@b.com", "pw");
+    });
+
+    expect(loginResult).toEqual({ success: false, error: "Login failed. Please try again." });
+  });
+});

--- a/frontend/src/hooks/useMaintenanceStatus.test.tsx
+++ b/frontend/src/hooks/useMaintenanceStatus.test.tsx
@@ -1,0 +1,97 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useMaintenanceStatus } from "./useMaintenanceStatus";
+
+const mockUseMaintenanceContext = vi.fn();
+const mockApiFetch = vi.fn();
+
+vi.mock("../context/MaintenanceContext", () => ({
+  useMaintenanceContext: () => mockUseMaintenanceContext(),
+}));
+
+vi.mock("../utils/api", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+describe("useMaintenanceStatus", () => {
+  const setMaintenance = vi.fn();
+
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+    setMaintenance.mockReset();
+    mockUseMaintenanceContext.mockReturnValue({
+      maintenance: { active: false, details: null },
+      setMaintenance,
+    });
+  });
+
+  it("sets active maintenance details when the API reports maintenance is active", async () => {
+    mockApiFetch.mockResolvedValue({
+      maintenance_active: true,
+      name: "Scheduled upgrade",
+      description: "DB migration",
+      start_time: "2026-01-01T00:00:00Z",
+      end_time: "2026-01-01T01:00:00Z",
+    });
+
+    const { result } = renderHook(() => useMaintenanceStatus());
+
+    let status;
+    await act(async () => {
+      status = await result.current.refetch();
+    });
+
+    const expected = {
+      active: true,
+      details: {
+        name: "Scheduled upgrade",
+        description: "DB migration",
+        startTime: "2026-01-01T00:00:00Z",
+        endTime: "2026-01-01T01:00:00Z",
+      },
+    };
+    expect(status).toEqual(expected);
+    expect(setMaintenance).toHaveBeenCalledWith(expected);
+  });
+
+  it("clears maintenance details when the API reports maintenance is inactive", async () => {
+    mockApiFetch.mockResolvedValue({ maintenance_active: false });
+
+    const { result } = renderHook(() => useMaintenanceStatus());
+
+    let status;
+    await act(async () => {
+      status = await result.current.refetch();
+    });
+
+    expect(status).toEqual({ active: false, details: null });
+    expect(setMaintenance).toHaveBeenCalledWith({ active: false, details: null });
+  });
+
+  it("falls back to inactive when the request fails", async () => {
+    mockApiFetch.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useMaintenanceStatus());
+
+    let status;
+    await act(async () => {
+      status = await result.current.refetch();
+    });
+
+    expect(status).toEqual({ active: false, details: null });
+    expect(setMaintenance).toHaveBeenCalledWith({ active: false, details: null });
+  });
+
+  it("spreads the current maintenance state from context", () => {
+    mockUseMaintenanceContext.mockReturnValue({
+      maintenance: { active: true, details: { name: "X" } },
+      setMaintenance,
+    });
+
+    const { result } = renderHook(() => useMaintenanceStatus());
+
+    expect(result.current.active).toBe(true);
+    expect(result.current.details).toEqual({ name: "X" });
+  });
+});

--- a/frontend/src/hooks/useMap.test.tsx
+++ b/frontend/src/hooks/useMap.test.tsx
@@ -1,0 +1,126 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useInitialMapCentre,
+  useMapCharacterDetail,
+  useMapViewport,
+  useMapWorldBounds,
+  usePopulationCentres,
+  useTargetCentreMap,
+} from "./useMap";
+
+const mockFetchInitialMapCentre = vi.fn();
+const mockFetchMapCharacterDetail = vi.fn();
+const mockFetchMapViewport = vi.fn();
+const mockFetchMapWorldBounds = vi.fn();
+const mockFetchPopulationCentreMap = vi.fn();
+const mockFetchPopulationCentres = vi.fn();
+
+vi.mock("../api/map", () => ({
+  fetchInitialMapCentre: (...args: unknown[]) => mockFetchInitialMapCentre(...args),
+  fetchMapCharacterDetail: (...args: unknown[]) => mockFetchMapCharacterDetail(...args),
+  fetchMapViewport: (...args: unknown[]) => mockFetchMapViewport(...args),
+  fetchMapWorldBounds: (...args: unknown[]) => mockFetchMapWorldBounds(...args),
+  fetchPopulationCentreMap: (...args: unknown[]) => mockFetchPopulationCentreMap(...args),
+  fetchPopulationCentres: (...args: unknown[]) => mockFetchPopulationCentres(...args),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return wrapper;
+}
+
+describe("useMap", () => {
+  beforeEach(() => {
+    mockFetchInitialMapCentre.mockReset();
+    mockFetchMapCharacterDetail.mockReset();
+    mockFetchMapViewport.mockReset();
+    mockFetchMapWorldBounds.mockReset();
+    mockFetchPopulationCentreMap.mockReset();
+    mockFetchPopulationCentres.mockReset();
+  });
+
+  it("fetches the initial map centre", async () => {
+    mockFetchInitialMapCentre.mockResolvedValue({ id: 1 });
+    const wrapper = makeWrapper();
+
+    const { result } = renderHook(() => useInitialMapCentre(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ id: 1 });
+  });
+
+  it("fetches world bounds", async () => {
+    mockFetchMapWorldBounds.mockResolvedValue({ bbox: "0,0,1,1" });
+    const wrapper = makeWrapper();
+
+    const { result } = renderHook(() => useMapWorldBounds(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ bbox: "0,0,1,1" });
+  });
+
+  it("fetches all population centres", async () => {
+    mockFetchPopulationCentres.mockResolvedValue([{ id: 1 }]);
+    const wrapper = makeWrapper();
+
+    const { result } = renderHook(() => usePopulationCentres(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: 1 }]);
+  });
+
+  it("does not fetch the target centre map when centreId is null", () => {
+    const wrapper = makeWrapper();
+    renderHook(() => useTargetCentreMap(null), { wrapper });
+    expect(mockFetchPopulationCentreMap).not.toHaveBeenCalled();
+  });
+
+  it("fetches the target centre map when centreId is provided", async () => {
+    mockFetchPopulationCentreMap.mockResolvedValue({ id: 5 });
+    const wrapper = makeWrapper();
+
+    const { result } = renderHook(() => useTargetCentreMap(5), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockFetchPopulationCentreMap).toHaveBeenCalledWith(5);
+  });
+
+  it("does not fetch the map viewport when bbox is null", () => {
+    const wrapper = makeWrapper();
+    renderHook(() => useMapViewport(null), { wrapper });
+    expect(mockFetchMapViewport).not.toHaveBeenCalled();
+  });
+
+  it("fetches the map viewport when bbox is provided", async () => {
+    mockFetchMapViewport.mockResolvedValue({ characters: [] });
+    const wrapper = makeWrapper();
+
+    const { result } = renderHook(() => useMapViewport("0,0,1,1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockFetchMapViewport).toHaveBeenCalledWith("0,0,1,1");
+  });
+
+  it("does not fetch character detail when characterId is null", () => {
+    const wrapper = makeWrapper();
+    renderHook(() => useMapCharacterDetail(null), { wrapper });
+    expect(mockFetchMapCharacterDetail).not.toHaveBeenCalled();
+  });
+
+  it("fetches character detail when characterId is provided", async () => {
+    mockFetchMapCharacterDetail.mockResolvedValue({ id: 9 });
+    const wrapper = makeWrapper();
+
+    const { result } = renderHook(() => useMapCharacterDetail(9), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockFetchMapCharacterDetail).toHaveBeenCalledWith(9);
+  });
+});

--- a/frontend/src/hooks/useNotes.test.tsx
+++ b/frontend/src/hooks/useNotes.test.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCreateNote, useDeleteNote, useNotes, useUpdateNote } from "./useNotes";
+import type { Note } from "../types";
+
+const mockFetchNotes = vi.fn();
+const mockCreateNote = vi.fn();
+const mockUpdateNote = vi.fn();
+const mockDeleteNote = vi.fn();
+
+vi.mock("../api/notes", () => ({
+  fetchNotes: (...args: unknown[]) => mockFetchNotes(...args),
+  createNote: (...args: unknown[]) => mockCreateNote(...args),
+  updateNote: (...args: unknown[]) => mockUpdateNote(...args),
+  deleteNote: (...args: unknown[]) => mockDeleteNote(...args),
+}));
+
+const note = (id: number): Note => ({ id, text: `Note ${id}` } as unknown as Note);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+describe("useNotes", () => {
+  beforeEach(() => {
+    mockFetchNotes.mockReset();
+    mockCreateNote.mockReset();
+    mockUpdateNote.mockReset();
+    mockDeleteNote.mockReset();
+  });
+
+  it("fetches notes by default", async () => {
+    mockFetchNotes.mockResolvedValue([note(1)]);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useNotes(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([note(1)]);
+  });
+
+  it("does not fetch when disabled via options", () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useNotes({ enabled: false }), { wrapper });
+    expect(mockFetchNotes).not.toHaveBeenCalled();
+  });
+
+  it("invalidates notes after creating one", async () => {
+    mockCreateNote.mockResolvedValue(note(2));
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateNote(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ text: "New" } as unknown as Partial<Note>);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["notes"] });
+  });
+
+  it("passes id and data through to updateNote", async () => {
+    mockUpdateNote.mockResolvedValue(note(1));
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useUpdateNote(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 1, data: { text: "Renamed" } as unknown as Partial<Note> });
+    });
+
+    expect(mockUpdateNote).toHaveBeenCalledWith(1, { text: "Renamed" });
+  });
+
+  it("optimistically removes a deleted note and rolls back on failure", async () => {
+    mockDeleteNote.mockRejectedValue(new Error("boom"));
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["notes"], [note(1), note(2)]);
+
+    const { result } = renderHook(() => useDeleteNote(), { wrapper });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(1);
+      } catch {
+        // expected
+      }
+    });
+
+    expect(queryClient.getQueryData(["notes"])).toEqual([note(1), note(2)]);
+  });
+
+  it("keeps an optimistically deleted note removed on success", async () => {
+    mockDeleteNote.mockResolvedValue(undefined);
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["notes"], [note(1), note(2)]);
+
+    const { result } = renderHook(() => useDeleteNote(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync(1);
+    });
+
+    expect(queryClient.getQueryData(["notes"])).toEqual([note(2)]);
+  });
+});

--- a/frontend/src/hooks/useOnboarding.test.ts
+++ b/frontend/src/hooks/useOnboarding.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import useOnboarding from "./useOnboarding";
+
+const mockUseGame = vi.fn();
+const mockApiFetch = vi.fn();
+
+vi.mock("./useGame", () => ({
+  useGame: () => mockUseGame(),
+}));
+
+vi.mock("../utils/api", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+describe("useOnboarding", () => {
+  const fetchPlayerAndCharacter = vi.fn();
+
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+    fetchPlayerAndCharacter.mockReset();
+  });
+
+  it("is undefined when there is no player yet", () => {
+    mockUseGame.mockReturnValue({ player: null, loading: true, fetchPlayerAndCharacter });
+
+    const { result } = renderHook(() => useOnboarding());
+
+    expect(result.current.completed).toBeUndefined();
+  });
+
+  it("reflects the player's onboarding_completed flag", () => {
+    mockUseGame.mockReturnValue({ player: { onboarding_completed: true }, loading: false, fetchPlayerAndCharacter });
+
+    const { result } = renderHook(() => useOnboarding());
+
+    expect(result.current.completed).toBe(true);
+  });
+
+  it("posts to complete onboarding and refetches player data on success", async () => {
+    mockUseGame.mockReturnValue({ player: { onboarding_completed: false }, loading: false, fetchPlayerAndCharacter });
+    mockApiFetch.mockResolvedValue(undefined);
+    fetchPlayerAndCharacter.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useOnboarding());
+
+    let success;
+    await act(async () => {
+      success = await result.current.completeOnboarding();
+    });
+
+    expect(mockApiFetch).toHaveBeenCalledWith("/me/complete_onboarding/", { method: "POST" });
+    expect(fetchPlayerAndCharacter).toHaveBeenCalled();
+    expect(success).toBe(true);
+    expect(result.current.error).toBe("");
+  });
+
+  it("sets an error message and returns false when the request fails", async () => {
+    mockUseGame.mockReturnValue({ player: { onboarding_completed: false }, loading: false, fetchPlayerAndCharacter });
+    mockApiFetch.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useOnboarding());
+
+    let success;
+    await act(async () => {
+      success = await result.current.completeOnboarding();
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe("boom");
+  });
+
+  it("falls back to a generic error message when the thrown error has no message", async () => {
+    mockUseGame.mockReturnValue({ player: { onboarding_completed: false }, loading: false, fetchPlayerAndCharacter });
+    mockApiFetch.mockRejectedValue(null);
+
+    const { result } = renderHook(() => useOnboarding());
+
+    await act(async () => {
+      await result.current.completeOnboarding();
+    });
+
+    expect(result.current.error).toBe("Failed to complete onboarding.");
+  });
+});

--- a/frontend/src/hooks/usePasswordReset.test.ts
+++ b/frontend/src/hooks/usePasswordReset.test.ts
@@ -1,0 +1,137 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import usePasswordReset from "./usePasswordReset";
+
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, json: async () => body } as unknown as Response;
+}
+
+describe("usePasswordReset", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("requestPasswordReset", () => {
+    it("returns a default success message when the server omits detail", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({})));
+
+      const { result } = renderHook(() => usePasswordReset());
+      let out;
+      await act(async () => {
+        out = await result.current.requestPasswordReset("a@b.com");
+      });
+
+      expect(out).toEqual({
+        success: true,
+        message: "If an account exists for that email, a password reset link has been sent.",
+      });
+    });
+
+    it("uses the server-provided detail message on success", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ detail: "Check your inbox" })));
+
+      const { result } = renderHook(() => usePasswordReset());
+      let out;
+      await act(async () => {
+        out = await result.current.requestPasswordReset("a@b.com");
+      });
+
+      expect(out).toEqual({ success: true, message: "Check your inbox" });
+    });
+
+    it("returns an extracted error message when the response is not ok", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ detail: "Too many requests" }, false)));
+
+      const { result } = renderHook(() => usePasswordReset());
+      let out;
+      await act(async () => {
+        out = await result.current.requestPasswordReset("a@b.com");
+      });
+
+      expect(out).toEqual({
+        success: false,
+        errors: { detail: "Too many requests" },
+        errorMessage: "Too many requests",
+      });
+    });
+
+    it("returns a generic error when the request throws", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+      const { result } = renderHook(() => usePasswordReset());
+      let out;
+      await act(async () => {
+        out = await result.current.requestPasswordReset("a@b.com");
+      });
+
+      expect(out).toEqual({
+        success: false,
+        errors: null,
+        errorMessage: "Unable to send a reset link right now.",
+      });
+    });
+  });
+
+  describe("confirmPasswordReset", () => {
+    it("returns a default success message when the server omits detail", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({})));
+
+      const { result } = renderHook(() => usePasswordReset());
+      let out;
+      await act(async () => {
+        out = await result.current.confirmPasswordReset({
+          uid: "u1",
+          token: "t1",
+          password1: "pw",
+          password2: "pw",
+        });
+      });
+
+      expect(out).toEqual({ success: true, message: "Your password has been reset successfully." });
+    });
+
+    it("returns an extracted error message when the response is not ok", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ token: ["Invalid token"] }, false)));
+
+      const { result } = renderHook(() => usePasswordReset());
+      let out;
+      await act(async () => {
+        out = await result.current.confirmPasswordReset({
+          uid: "u1",
+          token: "bad",
+          password1: "pw",
+          password2: "pw",
+        });
+      });
+
+      expect(out).toEqual({
+        success: false,
+        errors: { token: ["Invalid token"] },
+        errorMessage: "Invalid token",
+      });
+    });
+
+    it("returns a generic error when the request throws", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+      const { result } = renderHook(() => usePasswordReset());
+      let out;
+      await act(async () => {
+        out = await result.current.confirmPasswordReset({
+          uid: "u1",
+          token: "t1",
+          password1: "pw",
+          password2: "pw",
+        });
+      });
+
+      expect(out).toEqual({
+        success: false,
+        errors: null,
+        errorMessage: "Unable to reset your password.",
+      });
+    });
+  });
+});

--- a/frontend/src/hooks/usePlayer.test.tsx
+++ b/frontend/src/hooks/usePlayer.test.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDailyGoals, useDeleteAccount, useDownloadUserData, useUpdatePlayer } from "./usePlayer";
+
+const mockUseAuth = vi.fn();
+const mockNavigate = vi.fn();
+const mockFetchDailyGoals = vi.fn();
+const mockUpdatePlayer = vi.fn();
+const mockDownloadUserData = vi.fn();
+const mockDeleteAccount = vi.fn();
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("../api/player", () => ({
+  fetchDailyGoals: () => mockFetchDailyGoals(),
+  updatePlayer: (...args: unknown[]) => mockUpdatePlayer(...args),
+  downloadUserData: (...args: unknown[]) => mockDownloadUserData(...args),
+  deleteAccount: (...args: unknown[]) => mockDeleteAccount(...args),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+describe("useDailyGoals", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    mockFetchDailyGoals.mockReset();
+  });
+
+  it("does not fetch when the user is not authenticated", () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false });
+    const { wrapper } = makeWrapper();
+
+    renderHook(() => useDailyGoals(), { wrapper });
+
+    expect(mockFetchDailyGoals).not.toHaveBeenCalled();
+  });
+
+  it("fetches daily goals when authenticated", async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockFetchDailyGoals.mockResolvedValue({ completed: 2, target: 5 });
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useDailyGoals(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ completed: 2, target: 5 });
+  });
+});
+
+describe("useUpdatePlayer", () => {
+  beforeEach(() => {
+    mockUpdatePlayer.mockReset();
+  });
+
+  it("invalidates the user query on success", async () => {
+    mockUpdatePlayer.mockResolvedValue({ id: 1 });
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdatePlayer(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "New" });
+    });
+
+    expect(mockUpdatePlayer).toHaveBeenCalledWith({ name: "New" }, expect.anything());
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["user"] });
+  });
+});
+
+describe("useDownloadUserData", () => {
+  it("calls downloadUserData via mutate", async () => {
+    mockDownloadUserData.mockResolvedValue({ url: "http://example.com/data.zip" });
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useDownloadUserData(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(undefined);
+    });
+
+    expect(mockDownloadUserData).toHaveBeenCalled();
+  });
+});
+
+describe("useDeleteAccount", () => {
+  beforeEach(() => {
+    mockDeleteAccount.mockReset();
+    mockNavigate.mockReset();
+    localStorage.setItem("leftover", "1");
+    sessionStorage.setItem("leftover", "1");
+  });
+
+  it("clears storage and navigates home on success", async () => {
+    mockDeleteAccount.mockResolvedValue(undefined);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(undefined);
+    });
+
+    expect(localStorage.getItem("leftover")).toBeNull();
+    expect(sessionStorage.getItem("leftover")).toBeNull();
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+});

--- a/frontend/src/hooks/useProjects.test.tsx
+++ b/frontend/src/hooks/useProjects.test.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCreateProject, useDeleteProject, useProjects, useUpdateProject } from "./useProjects";
+import type { Project } from "../types";
+
+const mockFetchProjects = vi.fn();
+const mockCreateProject = vi.fn();
+const mockUpdateProject = vi.fn();
+const mockDeleteProject = vi.fn();
+
+vi.mock("../api/projects", () => ({
+  fetchProjects: (...args: unknown[]) => mockFetchProjects(...args),
+  createProject: (...args: unknown[]) => mockCreateProject(...args),
+  updateProject: (...args: unknown[]) => mockUpdateProject(...args),
+  deleteProject: (...args: unknown[]) => mockDeleteProject(...args),
+}));
+
+const project = (id: number): Project => ({ id, name: `Project ${id}` } as Project);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+describe("useProjects", () => {
+  beforeEach(() => {
+    mockFetchProjects.mockReset();
+    mockCreateProject.mockReset();
+    mockUpdateProject.mockReset();
+    mockDeleteProject.mockReset();
+  });
+
+  it("fetches projects", async () => {
+    mockFetchProjects.mockResolvedValue([project(1)]);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useProjects(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([project(1)]);
+  });
+
+  it("invalidates projects after creating one", async () => {
+    mockCreateProject.mockResolvedValue(project(2));
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateProject(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ name: "New" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["projects"] });
+  });
+
+  it("passes id and data through to updateProject", async () => {
+    mockUpdateProject.mockResolvedValue(project(1));
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useUpdateProject(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 1, data: { name: "Renamed" } });
+    });
+
+    expect(mockUpdateProject).toHaveBeenCalledWith(1, { name: "Renamed" });
+  });
+
+  it("optimistically removes a deleted project and rolls back on failure", async () => {
+    mockDeleteProject.mockRejectedValue(new Error("boom"));
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["projects"], [project(1), project(2)]);
+
+    const { result } = renderHook(() => useDeleteProject(), { wrapper });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(1);
+      } catch {
+        // expected
+      }
+    });
+
+    expect(queryClient.getQueryData(["projects"])).toEqual([project(1), project(2)]);
+  });
+
+  it("keeps an optimistically deleted project removed on success", async () => {
+    mockDeleteProject.mockResolvedValue(undefined);
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["projects"], [project(1), project(2)]);
+
+    const { result } = renderHook(() => useDeleteProject(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync(1);
+    });
+
+    expect(queryClient.getQueryData(["projects"])).toEqual([project(2)]);
+  });
+});

--- a/frontend/src/hooks/useRegister.test.ts
+++ b/frontend/src/hooks/useRegister.test.ts
@@ -1,0 +1,155 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import useRegister from "./useRegister";
+
+const mockLogin = vi.fn();
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, json: async () => body } as unknown as Response;
+}
+
+describe("useRegister", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    mockLogin.mockReset();
+  });
+
+  const invoke = () =>
+    renderHook(() => useRegister());
+
+  it("returns an error with the first non_field_error when the response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ non_field_errors: ["Email already registered"] }, false))
+    );
+
+    const { result } = invoke();
+    let registerResult;
+    await act(async () => {
+      registerResult = await result.current.register(
+        "a@b.com", "pw1", "pw1", {}, true, "token", "UTC"
+      );
+    });
+
+    expect(registerResult).toEqual({
+      success: false,
+      errors: { non_field_errors: ["Email already registered"] },
+      errorMessage: "Email already registered",
+    });
+  });
+
+  it("falls back to a generic error message when non_field_errors is absent", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({}, false)));
+
+    const { result } = invoke();
+    let registerResult;
+    await act(async () => {
+      registerResult = await result.current.register("a@b.com", "pw1", "pw1", {}, true, "token", "UTC");
+    });
+
+    expect(registerResult).toMatchObject({ success: false, errorMessage: "Registration failed." });
+  });
+
+  it("tracks character availability from the response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ characters_available: true, detail: "Verification email sent" }))
+    );
+
+    const { result } = invoke();
+    await act(async () => {
+      await result.current.register("a@b.com", "pw1", "pw1", {}, true, "token", "UTC");
+    });
+
+    expect(result.current.characterAvailable).toBe(true);
+  });
+
+  it("reports confirmation-required when a verification email was sent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ detail: "Verification email sent to you" }))
+    );
+
+    const { result } = invoke();
+    let registerResult;
+    await act(async () => {
+      registerResult = await result.current.register("a@b.com", "pw1", "pw1", {}, true, "token", "UTC");
+    });
+
+    expect(registerResult).toEqual({
+      success: true,
+      confirmationRequired: true,
+      message: "Verification email sent to you",
+    });
+  });
+
+  it("logs in directly when the response includes tokens", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ accessToken: "access-1", refreshToken: "refresh-1" }))
+    );
+    mockLogin.mockResolvedValue(undefined);
+
+    const { result } = invoke();
+    let registerResult;
+    await act(async () => {
+      registerResult = await result.current.register("a@b.com", "pw1", "pw1", {}, true, "token", "UTC");
+    });
+
+    expect(mockLogin).toHaveBeenCalledWith("access-1", "refresh-1", { rememberMe: false });
+    expect(registerResult).toEqual({ success: true });
+  });
+
+  it("falls back to a generic confirmation message for unexpected success payloads", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ characters_available: false })));
+
+    const { result } = invoke();
+    let registerResult;
+    await act(async () => {
+      registerResult = await result.current.register("a@b.com", "pw1", "pw1", {}, true, "token", "UTC");
+    });
+
+    expect(registerResult).toEqual({
+      success: true,
+      confirmationRequired: true,
+      message: "Please check your email to confirm your account.",
+      availableCharacters: false,
+    });
+  });
+
+  it("sends invite_token instead of invite_code when a token is present", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ detail: "Verification email sent" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = invoke();
+    await act(async () => {
+      await result.current.register("a@b.com", "pw1", "pw1", { token: "invite-tok", code: "ignored" }, true, "token", "UTC");
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.invite_token).toBe("invite-tok");
+    expect(body.invite_code).toBeUndefined();
+  });
+
+  it("returns a generic error when the request throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const { result } = invoke();
+    let registerResult;
+    await act(async () => {
+      registerResult = await result.current.register("a@b.com", "pw1", "pw1", {}, true, "token", "UTC");
+    });
+
+    expect(registerResult).toEqual({
+      success: false,
+      errors: null,
+      errorMessage: "Something went wrong, please try again.",
+    });
+  });
+});

--- a/frontend/src/hooks/useSimpleCrudPanel.test.ts
+++ b/frontend/src/hooks/useSimpleCrudPanel.test.ts
@@ -1,0 +1,98 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useSimpleCrudPanel } from "./useSimpleCrudPanel";
+
+interface Item {
+  id: number;
+  name: string;
+}
+
+function setup(items: Item[] = [{ id: 1, name: "First" }]) {
+  const createMutate = vi.fn();
+  const updateMutate = vi.fn();
+  const deleteMutate = vi.fn();
+
+  const { result } = renderHook(() =>
+    useSimpleCrudPanel<Item>({
+      useList: () => ({ data: items, isLoading: false }),
+      useCreate: () => ({ mutate: createMutate }),
+      useUpdate: () => ({ mutate: updateMutate }),
+      useDelete: () => ({ mutate: deleteMutate }),
+    })
+  );
+
+  return { result, createMutate, updateMutate, deleteMutate };
+}
+
+describe("useSimpleCrudPanel", () => {
+  it("exposes the list items via asArray", () => {
+    const { result } = setup();
+    expect(result.current.items).toEqual([{ id: 1, name: "First" }]);
+  });
+
+  it("falls back to an empty array when the list data is undefined", () => {
+    const { result } = renderHook(() =>
+      useSimpleCrudPanel<Item>({
+        useList: () => ({ data: undefined, isLoading: true }),
+        useCreate: () => ({ mutate: vi.fn() }),
+        useUpdate: () => ({ mutate: vi.fn() }),
+        useDelete: () => ({ mutate: vi.fn() }),
+      })
+    );
+    expect(result.current.items).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("creates a trimmed item and resets the name field", () => {
+    const { result, createMutate } = setup();
+
+    act(() => {
+      result.current.setNewName("  New item  ");
+    });
+
+    const preventDefault = vi.fn();
+    act(() => {
+      result.current.handleCreate({ preventDefault } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(createMutate).toHaveBeenCalledWith({ name: "New item" });
+    expect(result.current.newName).toBe("");
+  });
+
+  it("does not create when the trimmed name is empty", () => {
+    const { result, createMutate } = setup();
+
+    act(() => {
+      result.current.setNewName("   ");
+    });
+
+    act(() => {
+      result.current.handleCreate({ preventDefault: vi.fn() } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it("edits an item, passing along optional callbacks", () => {
+    const { result, updateMutate } = setup();
+    const callbacks = { onSuccess: vi.fn() };
+
+    act(() => {
+      result.current.handleEdit({ id: 1, name: "First" }, "Renamed", callbacks);
+    });
+
+    expect(updateMutate).toHaveBeenCalledWith({ id: 1, data: { name: "Renamed" } }, callbacks);
+  });
+
+  it("deletes an item by id", () => {
+    const { result, deleteMutate } = setup();
+
+    act(() => {
+      result.current.handleDelete({ id: 1, name: "First" });
+    });
+
+    expect(deleteMutate).toHaveBeenCalledWith(1);
+  });
+});

--- a/frontend/src/hooks/useSkills.test.tsx
+++ b/frontend/src/hooks/useSkills.test.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCreateSkill, useDeleteSkill, useSkills, useUpdateSkill } from "./useSkills";
+import type { PlayerSkill } from "../types";
+
+const mockFetchSkills = vi.fn();
+const mockCreateSkill = vi.fn();
+const mockUpdateSkill = vi.fn();
+const mockDeleteSkill = vi.fn();
+
+vi.mock("../api/skills", () => ({
+  fetchSkills: (...args: unknown[]) => mockFetchSkills(...args),
+  createSkill: (...args: unknown[]) => mockCreateSkill(...args),
+  updateSkill: (...args: unknown[]) => mockUpdateSkill(...args),
+  deleteSkill: (...args: unknown[]) => mockDeleteSkill(...args),
+}));
+
+const skill = (id: number): PlayerSkill => ({ id, name: `Skill ${id}` } as PlayerSkill);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+describe("useSkills", () => {
+  beforeEach(() => {
+    mockFetchSkills.mockReset();
+    mockCreateSkill.mockReset();
+    mockUpdateSkill.mockReset();
+    mockDeleteSkill.mockReset();
+  });
+
+  it("fetches skills", async () => {
+    mockFetchSkills.mockResolvedValue([skill(1)]);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useSkills(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([skill(1)]);
+  });
+
+  it("invalidates skills after creating one", async () => {
+    mockCreateSkill.mockResolvedValue(skill(2));
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateSkill(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ name: "New" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["skills"] });
+  });
+
+  it("passes id and data through to updateSkill", async () => {
+    mockUpdateSkill.mockResolvedValue(skill(1));
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useUpdateSkill(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 1, data: { name: "Renamed" } });
+    });
+
+    expect(mockUpdateSkill).toHaveBeenCalledWith(1, { name: "Renamed" });
+  });
+
+  it("optimistically removes a deleted skill and rolls back on failure", async () => {
+    mockDeleteSkill.mockRejectedValue(new Error("boom"));
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["skills"], [skill(1), skill(2)]);
+
+    const { result } = renderHook(() => useDeleteSkill(), { wrapper });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(1);
+      } catch {
+        // expected
+      }
+    });
+
+    expect(queryClient.getQueryData(["skills"])).toEqual([skill(1), skill(2)]);
+  });
+
+  it("keeps an optimistically deleted skill removed on success", async () => {
+    mockDeleteSkill.mockResolvedValue(undefined);
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["skills"], [skill(1), skill(2)]);
+
+    const { result } = renderHook(() => useDeleteSkill(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync(1);
+    });
+
+    expect(queryClient.getQueryData(["skills"])).toEqual([skill(2)]);
+  });
+});

--- a/frontend/src/hooks/useTasks.test.tsx
+++ b/frontend/src/hooks/useTasks.test.tsx
@@ -1,0 +1,115 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCreateTask, useDeleteTask, useTasks, useUpdateTask } from "./useTasks";
+import type { Task } from "../types";
+
+const mockFetchTasks = vi.fn();
+const mockCreateTask = vi.fn();
+const mockUpdateTask = vi.fn();
+const mockDeleteTask = vi.fn();
+
+vi.mock("../api/tasks", () => ({
+  fetchTasks: (...args: unknown[]) => mockFetchTasks(...args),
+  createTask: (...args: unknown[]) => mockCreateTask(...args),
+  updateTask: (...args: unknown[]) => mockUpdateTask(...args),
+  deleteTask: (...args: unknown[]) => mockDeleteTask(...args),
+}));
+
+const task = (id: number): Task => ({ id, name: `Task ${id}` } as Task);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+describe("useTasks", () => {
+  beforeEach(() => {
+    mockFetchTasks.mockReset();
+    mockCreateTask.mockReset();
+    mockUpdateTask.mockReset();
+    mockDeleteTask.mockReset();
+  });
+
+  it("fetches tasks by default", async () => {
+    mockFetchTasks.mockResolvedValue([task(1)]);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useTasks(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([task(1)]);
+  });
+
+  it("does not fetch when disabled via options", () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useTasks({ enabled: false }), { wrapper });
+    expect(mockFetchTasks).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the tasks query after creating a task", async () => {
+    mockCreateTask.mockResolvedValue(task(2));
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateTask(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "New task" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["tasks"] });
+  });
+
+  it("passes the id and data through to updateTask and invalidates on success", async () => {
+    mockUpdateTask.mockResolvedValue({ task: task(1) });
+    const { queryClient, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateTask(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: 1, data: { name: "Renamed" } });
+    });
+
+    expect(mockUpdateTask).toHaveBeenCalledWith(1, { name: "Renamed" });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["tasks"] });
+  });
+
+  it("optimistically removes a deleted task and confirms it stays gone", async () => {
+    mockDeleteTask.mockResolvedValue(undefined);
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["tasks"], [task(1), task(2)]);
+
+    const { result } = renderHook(() => useDeleteTask(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(1);
+    });
+
+    expect(queryClient.getQueryData(["tasks"])).toEqual([task(2)]);
+  });
+
+  it("rolls back the optimistic delete when the mutation fails", async () => {
+    mockDeleteTask.mockRejectedValue(new Error("boom"));
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(["tasks"], [task(1), task(2)]);
+
+    const { result } = renderHook(() => useDeleteTask(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(1);
+      } catch {
+        // expected
+      }
+    });
+
+    expect(queryClient.getQueryData(["tasks"])).toEqual([task(1), task(2)]);
+  });
+});

--- a/frontend/src/hooks/useTutorialSteps.test.tsx
+++ b/frontend/src/hooks/useTutorialSteps.test.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import useTutorialSteps from "./useTutorialSteps";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("../utils/api", () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return wrapper;
+}
+
+describe("useTutorialSteps", () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+  });
+
+  it("returns a plain array response as-is", async () => {
+    mockApiFetch.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+    const wrapper = makeWrapper();
+
+    const { result } = renderHook(() => useTutorialSteps(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.steps).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it("unwraps a paginated response's results", async () => {
+    mockApiFetch.mockResolvedValue({ results: [{ id: 3 }] });
+    const wrapper = makeWrapper();
+
+    const { result } = renderHook(() => useTutorialSteps(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.steps).toEqual([{ id: 3 }]);
+  });
+
+  it("defaults to an empty array when the paginated response has no results", async () => {
+    mockApiFetch.mockResolvedValue({});
+    const wrapper = makeWrapper();
+
+    const { result } = renderHook(() => useTutorialSteps(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.steps).toEqual([]);
+  });
+});

--- a/frontend/src/hooks/useWaitlistJoin.test.ts
+++ b/frontend/src/hooks/useWaitlistJoin.test.ts
@@ -1,0 +1,54 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import useWaitlistJoin from "./useWaitlistJoin";
+
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, json: async () => body } as unknown as Response;
+}
+
+describe("useWaitlistJoin", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a default success message when the server omits one", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({})));
+
+    const { result } = renderHook(() => useWaitlistJoin());
+    let out;
+    await act(async () => {
+      out = await result.current.joinWaitlist("a@b.com");
+    });
+
+    expect(out).toEqual({ success: true, message: "You're on the waitlist." });
+  });
+
+  it("returns an extracted error message when the response is not ok", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ detail: "Already joined" }, false)));
+
+    const { result } = renderHook(() => useWaitlistJoin());
+    let out;
+    await act(async () => {
+      out = await result.current.joinWaitlist("a@b.com");
+    });
+
+    expect(out).toEqual({ success: false, errorMessage: "Already joined" });
+  });
+
+  it("returns a generic error when the request throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const { result } = renderHook(() => useWaitlistJoin());
+    let out;
+    await act(async () => {
+      out = await result.current.joinWaitlist("a@b.com");
+    });
+
+    expect(out).toEqual({
+      success: false,
+      errorMessage: "Unable to join the waitlist right now. Please try again later.",
+    });
+  });
+});

--- a/frontend/src/hooks/useWaitlistSignup.test.ts
+++ b/frontend/src/hooks/useWaitlistSignup.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import useWaitlistSignup from "./useWaitlistSignup";
+
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, json: async () => body } as unknown as Response;
+}
+
+describe("useWaitlistSignup", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a default success message and null state when the server omits both", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({})));
+
+    const { result } = renderHook(() => useWaitlistSignup());
+    let out;
+    await act(async () => {
+      out = await result.current.requestWaitlistSignup("a@b.com");
+    });
+
+    expect(out).toEqual({ success: true, message: "You're on the list! We'll be in touch soon.", state: null });
+  });
+
+  it("passes through the server-provided state string", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ state: "pending_confirmation" })));
+
+    const { result } = renderHook(() => useWaitlistSignup());
+    let out;
+    await act(async () => {
+      out = await result.current.requestWaitlistSignup("a@b.com");
+    });
+
+    expect(out).toMatchObject({ success: true, state: "pending_confirmation" });
+  });
+
+  it("returns an extracted error message when the response is not ok", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ email: ["Invalid email"] }, false)));
+
+    const { result } = renderHook(() => useWaitlistSignup());
+    let out;
+    await act(async () => {
+      out = await result.current.requestWaitlistSignup("bad");
+    });
+
+    expect(out).toEqual({ success: false, errorMessage: "Invalid email" });
+  });
+
+  it("returns a generic error when the request throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const { result } = renderHook(() => useWaitlistSignup());
+    let out;
+    await act(async () => {
+      out = await result.current.requestWaitlistSignup("a@b.com");
+    });
+
+    expect(out).toEqual({
+      success: false,
+      errorMessage: "Unable to join the waitlist right now. Please try again later.",
+    });
+  });
+});

--- a/frontend/src/hooks/useWebSocketEvent.test.ts
+++ b/frontend/src/hooks/useWebSocketEvent.test.ts
@@ -1,0 +1,51 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useWebSocketEvent } from "./useWebSocketEvent";
+
+const mockAddEventHandler = vi.fn();
+
+vi.mock("./useWebSocket", () => ({
+  useWebSocket: () => ({ addEventHandler: mockAddEventHandler }),
+}));
+
+describe("useWebSocketEvent", () => {
+  beforeEach(() => {
+    mockAddEventHandler.mockReset();
+  });
+
+  it("registers the callback and cleans up the returned remove function on unmount", () => {
+    const remove = vi.fn();
+    mockAddEventHandler.mockReturnValue(remove);
+    const callback = vi.fn();
+
+    const { unmount } = renderHook(() => useWebSocketEvent(callback));
+
+    expect(mockAddEventHandler).toHaveBeenCalledWith(callback);
+    expect(remove).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(remove).toHaveBeenCalled();
+  });
+
+  it("does not register when the callback is null", () => {
+    renderHook(() => useWebSocketEvent(null));
+    expect(mockAddEventHandler).not.toHaveBeenCalled();
+  });
+
+  it("re-registers when the callback identity changes", () => {
+    const removeA = vi.fn();
+    const removeB = vi.fn();
+    mockAddEventHandler.mockReturnValueOnce(removeA).mockReturnValueOnce(removeB);
+
+    const { rerender } = renderHook(({ cb }) => useWebSocketEvent(cb), {
+      initialProps: { cb: vi.fn() },
+    });
+
+    rerender({ cb: vi.fn() });
+
+    expect(removeA).toHaveBeenCalled();
+    expect(mockAddEventHandler).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/pages/Account/Account.test.tsx
+++ b/frontend/src/pages/Account/Account.test.tsx
@@ -381,4 +381,148 @@ describe("Account", () => {
 
     expect(screen.queryByText(/Free trial/)).not.toBeInTheDocument();
   });
+
+  it("saves a valid name and refetches player data on success", async () => {
+    const user = userEvent.setup();
+    const fetchPlayerAndCharacter = vi.fn().mockResolvedValue(undefined);
+    mockUseGame.mockReturnValue({
+      player: mockPlayer(),
+      loading: false,
+      fetchPlayerAndCharacter,
+    });
+    mockUpdatePlayer.mockResolvedValue({ name: "New Name" });
+
+    renderAccount();
+
+    await user.click(screen.getByRole("button", { name: /edit name/i }));
+    const input = screen.getByRole("textbox");
+    await user.clear(input);
+    await user.type(input, "New Name");
+    await user.click(screen.getByRole("button", { name: /save name/i }));
+
+    expect(mockUpdatePlayer).toHaveBeenCalledWith({ name: "New Name" }, expect.anything());
+    await vi.waitFor(() => expect(screen.queryByRole("textbox")).not.toBeInTheDocument());
+    expect(fetchPlayerAndCharacter).toHaveBeenCalled();
+  });
+
+  it("shows an error and stays in edit mode when saving the name fails", async () => {
+    const user = userEvent.setup();
+    mockUseGame.mockReturnValue({
+      player: mockPlayer(),
+      loading: false,
+      fetchPlayerAndCharacter: vi.fn(),
+    });
+    mockUpdatePlayer.mockRejectedValue(new Error("Name already taken"));
+
+    renderAccount();
+
+    await user.click(screen.getByRole("button", { name: /edit name/i }));
+    const input = screen.getByRole("textbox");
+    await user.clear(input);
+    await user.type(input, "New Name");
+    await user.click(screen.getByRole("button", { name: /save name/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Name already taken");
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("cancels editing and discards the draft name", async () => {
+    const user = userEvent.setup();
+    mockUseGame.mockReturnValue({
+      player: mockPlayer(),
+      loading: false,
+      fetchPlayerAndCharacter: vi.fn(),
+    });
+
+    renderAccount();
+
+    await user.click(screen.getByRole("button", { name: /edit name/i }));
+    await user.clear(screen.getByRole("textbox"));
+    await user.type(screen.getByRole("textbox"), "Discarded");
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(mockUpdatePlayer).not.toHaveBeenCalled();
+    expect(screen.getByText("player_01234")).toBeInTheDocument();
+  });
+
+  it("downloads user data when the download button is clicked", async () => {
+    const user = userEvent.setup();
+    mockUseGame.mockReturnValue({
+      player: mockPlayer(),
+      loading: false,
+      fetchPlayerAndCharacter: vi.fn(),
+    });
+    mockDownloadUserData.mockResolvedValue({ url: "http://example.com/data.zip" });
+
+    renderAccount();
+
+    await user.click(screen.getByRole("button", { name: /download my data/i }));
+
+    expect(mockDownloadUserData).toHaveBeenCalled();
+    expect(await screen.findByRole("button", { name: /download my data/i })).toBeInTheDocument();
+  });
+
+  it("requires typing DELETE before the delete-account button is enabled", async () => {
+    const user = userEvent.setup();
+    mockUseGame.mockReturnValue({
+      player: mockPlayer(),
+      loading: false,
+      fetchPlayerAndCharacter: vi.fn(),
+    });
+
+    renderAccount();
+
+    await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    const confirmButton = screen.getByRole("button", { name: /confirm delete/i });
+    expect(confirmButton).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText("Type DELETE to confirm"), "wrong");
+    expect(confirmButton).toBeDisabled();
+
+    await user.clear(screen.getByPlaceholderText("Type DELETE to confirm"));
+    await user.type(screen.getByPlaceholderText("Type DELETE to confirm"), "DELETE");
+    expect(confirmButton).not.toBeDisabled();
+  });
+
+  it("deletes the account, clears storage, and navigates home on confirm", async () => {
+    const user = userEvent.setup();
+    mockUseGame.mockReturnValue({
+      player: mockPlayer(),
+      loading: false,
+      fetchPlayerAndCharacter: vi.fn(),
+    });
+    mockDeleteAccount.mockResolvedValue(undefined);
+    localStorage.setItem("leftover", "1");
+
+    renderAccount();
+
+    await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.type(screen.getByPlaceholderText("Type DELETE to confirm"), "DELETE");
+    await user.click(screen.getByRole("button", { name: /confirm delete/i }));
+
+    await vi.waitFor(() => expect(mockDeleteAccount).toHaveBeenCalled());
+    await vi.waitFor(() => expect(localStorage.getItem("leftover")).toBeNull());
+  });
+
+  it("cancels the delete-account confirmation and resets the typed text", async () => {
+    const user = userEvent.setup();
+    mockUseGame.mockReturnValue({
+      player: mockPlayer(),
+      loading: false,
+      fetchPlayerAndCharacter: vi.fn(),
+    });
+
+    renderAccount();
+
+    await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.type(screen.getByPlaceholderText("Type DELETE to confirm"), "DEL");
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(screen.queryByPlaceholderText("Type DELETE to confirm")).not.toBeInTheDocument();
+    expect(mockDeleteAccount).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    expect(screen.getByPlaceholderText("Type DELETE to confirm")).toHaveValue("");
+  });
 });

--- a/frontend/src/pages/LibraryPage/LibraryPage.test.tsx
+++ b/frontend/src/pages/LibraryPage/LibraryPage.test.tsx
@@ -28,7 +28,21 @@ vi.mock("../../hooks/useFeatureFlag", () => ({
 }));
 
 vi.mock("../../components/TasksPanel/TasksPanel", () => ({
-  default: () => <div data-testid="tasks-panel">Tasks panel</div>,
+  default: ({
+    openTaskId,
+    onOpenTaskHandled,
+    onOpenNote,
+  }: {
+    openTaskId: number | null;
+    onOpenTaskHandled: () => void;
+    onOpenNote: (noteId: number) => void;
+  }) => (
+    <div data-testid="tasks-panel">
+      Tasks panel (open task: {openTaskId ?? "none"})
+      <button onClick={onOpenTaskHandled}>Clear open task</button>
+      <button onClick={() => onOpenNote(42)}>Open note 42</button>
+    </div>
+  ),
 }));
 
 vi.mock("../../components/ActivitiesPanel/ActivitiesPanel", () => ({
@@ -37,6 +51,24 @@ vi.mock("../../components/ActivitiesPanel/ActivitiesPanel", () => ({
 
 vi.mock("../../components/SkillsPanel/SkillsPanel", () => ({
   default: () => <div data-testid="skills-panel">Skills panel</div>,
+}));
+
+vi.mock("../../components/NotesPanel/NotesPanel", () => ({
+  default: ({
+    openNoteId,
+    onOpenNoteHandled,
+    onOpenTask,
+  }: {
+    openNoteId: number | null;
+    onOpenNoteHandled: () => void;
+    onOpenTask: (taskId: number) => void;
+  }) => (
+    <div data-testid="notes-panel">
+      Notes panel (open note: {openNoteId ?? "none"})
+      <button onClick={onOpenNoteHandled}>Clear open note</button>
+      <button onClick={() => onOpenTask(7)}>Open task 7</button>
+    </div>
+  ),
 }));
 
 vi.mock("../../components/ComingSoonPanel/ComingSoonPanel", () => ({
@@ -85,6 +117,52 @@ describe("LibraryPage", () => {
       expect(screen.queryByRole("tab", { name: "Projects" })).not.toBeInTheDocument();
       expect(screen.queryByRole("tab", { name: "Categories" })).not.toBeInTheDocument();
     });
+
+    it("switches to the Notes tab when a note is opened from the Tasks panel", async () => {
+      const user = userEvent.setup();
+      render(<LibraryPage />);
+
+      await user.click(screen.getByRole("tab", { name: "Tasks" }));
+      await user.click(screen.getByRole("button", { name: "Open note 42" }));
+
+      expect(screen.getByTestId("notes-panel")).toHaveTextContent("open note: 42");
+      expect(screen.queryByTestId("tasks-panel")).not.toBeInTheDocument();
+    });
+
+    it("switches to the Tasks tab when a task is opened from the Notes panel", async () => {
+      const user = userEvent.setup();
+      render(<LibraryPage />);
+
+      await user.click(screen.getByRole("tab", { name: "Notes" }));
+      await user.click(screen.getByRole("button", { name: "Open task 7" }));
+
+      expect(screen.getByTestId("tasks-panel")).toHaveTextContent("open task: 7");
+      expect(screen.queryByTestId("notes-panel")).not.toBeInTheDocument();
+    });
+
+    it("clears the pending open-task id once TasksPanel reports it handled", async () => {
+      const user = userEvent.setup();
+      render(<LibraryPage />);
+
+      await user.click(screen.getByRole("tab", { name: "Notes" }));
+      await user.click(screen.getByRole("button", { name: "Open task 7" }));
+      expect(screen.getByTestId("tasks-panel")).toHaveTextContent("open task: 7");
+
+      await user.click(screen.getByRole("button", { name: "Clear open task" }));
+      expect(screen.getByTestId("tasks-panel")).toHaveTextContent("open task: none");
+    });
+
+    it("clears the pending open-note id once NotesPanel reports it handled", async () => {
+      const user = userEvent.setup();
+      render(<LibraryPage />);
+
+      await user.click(screen.getByRole("tab", { name: "Tasks" }));
+      await user.click(screen.getByRole("button", { name: "Open note 42" }));
+      expect(screen.getByTestId("notes-panel")).toHaveTextContent("open note: 42");
+
+      await user.click(screen.getByRole("button", { name: "Clear open note" }));
+      expect(screen.getByTestId("notes-panel")).toHaveTextContent("open note: none");
+    });
   });
 
   describe("when a tab's feature flag is disabled", () => {
@@ -110,6 +188,16 @@ describe("LibraryPage", () => {
 
       expect(screen.queryByTestId("skills-panel")).not.toBeInTheDocument();
       expect(screen.getByTestId("coming-soon-panel")).toHaveTextContent("skills coming soon");
+    });
+
+    it("still shows the Notes tab but renders a coming-soon notice", async () => {
+      const user = userEvent.setup();
+      render(<LibraryPage />);
+
+      await user.click(screen.getByRole("tab", { name: "Notes" }));
+
+      expect(screen.queryByTestId("notes-panel")).not.toBeInTheDocument();
+      expect(screen.getByTestId("coming-soon-panel")).toHaveTextContent("notes coming soon");
     });
 
     it("always renders the Activities tab regardless of flags", async () => {

--- a/frontend/src/testUtils/mockAuthContext.test.ts
+++ b/frontend/src/testUtils/mockAuthContext.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { mockAuthContextValue } from "./mockAuthContext";
+
+describe("mockAuthContextValue", () => {
+  it("defaults to a logged-out state with no tokens or user", () => {
+    const value = mockAuthContextValue();
+
+    expect(value.isAuthenticated).toBe(false);
+    expect(value.accessToken).toBeNull();
+    expect(value.refreshToken).toBeNull();
+    expect(value.user).toBeNull();
+  });
+
+  it("fills in mock tokens and a mock user when authenticated is true", () => {
+    const value = mockAuthContextValue({ authenticated: true });
+
+    expect(value.isAuthenticated).toBe(true);
+    expect(value.accessToken).toBe("mock-access-token");
+    expect(value.refreshToken).toBe("mock-refresh-token");
+    expect(value.user).toMatchObject({ email: "demo@example.com" });
+  });
+
+  it("applies overrides on top of the authenticated defaults", () => {
+    const value = mockAuthContextValue({ authenticated: true, user: { is_staff: true } as never });
+
+    expect(value.isAuthenticated).toBe(true);
+    expect(value.user).toEqual({ is_staff: true });
+  });
+
+  it("rejects when the unmocked authFetch stub is called", async () => {
+    const value = mockAuthContextValue();
+
+    await expect(value.authFetch("/x")).rejects.toThrow("authFetch is not mocked in Storybook");
+  });
+});

--- a/frontend/src/utils/analytics.test.ts
+++ b/frontend/src/utils/analytics.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const initialize = vi.fn();
+const send = vi.fn();
+const event = vi.fn();
+
+vi.mock("react-ga4", () => ({
+  default: { initialize, send, event },
+}));
+
+interface AnalyticsEnv {
+  PROD?: boolean;
+  VITE_GA_TRACKING_ID?: string;
+  VITE_GA_TEST_MODE?: string;
+}
+
+async function loadAnalytics(env: AnalyticsEnv) {
+  vi.resetModules();
+  vi.stubEnv("PROD", env.PROD ?? false);
+  vi.stubEnv("VITE_GA_TRACKING_ID", env.VITE_GA_TRACKING_ID ?? "");
+  vi.stubEnv("VITE_GA_TEST_MODE", env.VITE_GA_TEST_MODE ?? "");
+  return import("./analytics");
+}
+
+describe("analytics", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("does nothing outside prod/test mode, even with a tracking id", async () => {
+    const { initGA, logPageView, trackEvent } = await loadAnalytics({
+      PROD: false,
+      VITE_GA_TRACKING_ID: "G-TEST",
+    });
+
+    initGA();
+    logPageView("/tasks");
+    trackEvent("task_completed");
+
+    expect(initialize).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+    expect(event).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when active but no tracking id is configured", async () => {
+    const { initGA, logPageView, trackEvent } = await loadAnalytics({
+      VITE_GA_TEST_MODE: "true",
+    });
+
+    initGA();
+    logPageView("/tasks");
+    trackEvent("task_completed");
+
+    expect(initialize).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+    expect(event).not.toHaveBeenCalled();
+  });
+
+  it("initializes, logs page views, and tracks events when test mode and a tracking id are set", async () => {
+    const { initGA, logPageView, trackEvent } = await loadAnalytics({
+      VITE_GA_TEST_MODE: "true",
+      VITE_GA_TRACKING_ID: "G-TEST",
+    });
+
+    initGA();
+    expect(initialize).toHaveBeenCalledWith("G-TEST", { testMode: true });
+
+    logPageView("/tasks");
+    expect(send).toHaveBeenCalledWith({ hitType: "pageview", page: "/tasks" });
+
+    trackEvent("task_completed", { taskId: 5 });
+    expect(event).toHaveBeenCalledWith("task_completed", { taskId: 5 });
+  });
+
+  it("defaults trackEvent's params to an empty object", async () => {
+    const { trackEvent } = await loadAnalytics({
+      VITE_GA_TEST_MODE: "true",
+      VITE_GA_TRACKING_ID: "G-TEST",
+    });
+
+    trackEvent("task_completed");
+
+    expect(event).toHaveBeenCalledWith("task_completed", {});
+  });
+});

--- a/frontend/src/utils/api.test.ts
+++ b/frontend/src/utils/api.test.ts
@@ -43,6 +43,43 @@ describe("getValidAccessToken", () => {
     expect(getStoredAuthTokens().accessToken).toBe("new-access-token");
   });
 
+  it("logs the user out and throws when no tokens are stored at all", async () => {
+    localStorage.clear();
+    sessionStorage.clear();
+    const unauthorizedHandler = vi.fn();
+    setUnauthorizedHandler(unauthorizedHandler);
+
+    await expect(getValidAccessToken()).rejects.toThrow("Missing tokens");
+
+    expect(unauthorizedHandler).toHaveBeenCalled();
+  });
+
+  it("returns the stored access token without refreshing when it is not expiring soon", async () => {
+    storeAuthTokens("fresh-token", "refresh-token", true);
+    (jwtDecode as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      exp: Date.now() / 1000 + 3600, // an hour from now
+    });
+
+    const token = await getValidAccessToken();
+
+    expect(token).toBe("fresh-token");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("treats a token that fails to decode as expiring soon and refreshes it", async () => {
+    (jwtDecode as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("malformed token");
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: "refreshed-token" }),
+    });
+
+    const token = await getValidAccessToken();
+
+    expect(token).toBe("refreshed-token");
+  });
+
   it("logs the user out when the refresh response is missing access_token", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
@@ -80,6 +117,22 @@ describe("apiFetch", () => {
 
     expect(result).toEqual({ ok: true });
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to getValidAccessToken when no explicit access token is given", async () => {
+    storeAuthTokens("stored-access", "stored-refresh", true);
+    (jwtDecode as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      exp: Date.now() / 1000 + 3600,
+    });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse);
+
+    await apiFetch("/me/", {});
+
+    const [, requestInit] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(requestInit.headers.Authorization).toBe("Bearer stored-access");
+
+    localStorage.clear();
+    sessionStorage.clear();
   });
 
   it("recovers after one transient network error", async () => {
@@ -182,6 +235,60 @@ describe("apiFetch", () => {
     } satisfies Partial<ApiFetchError>);
 
     expect(maintenanceHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws with the response body text on a non-ok, non-401/503 response", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "Internal Server Error",
+    });
+
+    await expect(apiFetch("/me/", {}, "test-token")).rejects.toThrow("Internal Server Error");
+  });
+
+  it("falls back to a generic message when the error response has no body text", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "",
+    });
+
+    await expect(apiFetch("/me/", {}, "test-token")).rejects.toThrow("API error");
+  });
+
+  it("returns a Blob when responseType is blob", async () => {
+    const blob = new Blob(["data"]);
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      blob: async () => blob,
+    });
+
+    const result = await apiFetch("/export/", { responseType: "blob" }, "test-token");
+
+    expect(result).toBe(blob);
+  });
+
+  it("returns text when responseType is text", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => "raw text",
+    });
+
+    const result = await apiFetch("/export/", { responseType: "text" }, "test-token");
+
+    expect(result).toBe("raw text");
+  });
+
+  it("returns the raw Response when responseType is raw", async () => {
+    const rawResponse = { ok: true, status: 200 };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(rawResponse);
+
+    const result = await apiFetch("/export/", { responseType: "raw" }, "test-token");
+
+    expect(result).toBe(rawResponse);
   });
 
   describe("skipAuth", () => {

--- a/frontend/src/utils/apiErrors.test.ts
+++ b/frontend/src/utils/apiErrors.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { extractApiMessage, readJsonSafe } from "./apiErrors";
+
+describe("readJsonSafe", () => {
+  it("returns the parsed JSON body", async () => {
+    const response = { json: async () => ({ detail: "nope" }) } as Response;
+    await expect(readJsonSafe(response)).resolves.toEqual({ detail: "nope" });
+  });
+
+  it("returns null when the body is not valid JSON", async () => {
+    const response = { json: async () => { throw new Error("invalid json"); } } as unknown as Response;
+    await expect(readJsonSafe(response)).resolves.toBeNull();
+  });
+});
+
+describe("extractApiMessage", () => {
+  it("returns the fallback when data is null", () => {
+    expect(extractApiMessage(null, "fallback")).toBe("fallback");
+  });
+
+  it("returns the fallback when data is not an object", () => {
+    expect(extractApiMessage("oops" as never, "fallback")).toBe("fallback");
+  });
+
+  it("prefers a string detail field", () => {
+    expect(extractApiMessage({ detail: "specific error" }, "fallback")).toBe("specific error");
+  });
+
+  it("ignores an empty detail string", () => {
+    expect(extractApiMessage({ name: ["Name is required"], detail: "" }, "fallback")).toBe(
+      "Name is required"
+    );
+  });
+
+  it("falls back to the first value of the first field-error array", () => {
+    expect(extractApiMessage({ name: ["Name is required"] }, "fallback")).toBe("Name is required");
+  });
+
+  it("stringifies a non-string first entry", () => {
+    expect(extractApiMessage({ code: [404] }, "fallback")).toBe("404");
+  });
+
+  it("returns the fallback when the first entry is not a non-empty array", () => {
+    expect(extractApiMessage({ name: [] }, "fallback")).toBe("fallback");
+  });
+
+  it("returns the fallback when there are no fields at all", () => {
+    expect(extractApiMessage({}, "fallback")).toBe("fallback");
+  });
+});

--- a/frontend/src/utils/arrayUtils.test.ts
+++ b/frontend/src/utils/arrayUtils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { asArray } from "./arrayUtils";
+
+describe("asArray", () => {
+  it("returns the array unchanged when given an array", () => {
+    expect(asArray([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("returns an empty array for null", () => {
+    expect(asArray(null)).toEqual([]);
+  });
+
+  it("returns an empty array for undefined", () => {
+    expect(asArray(undefined)).toEqual([]);
+  });
+});

--- a/frontend/src/utils/authStorage.test.ts
+++ b/frontend/src/utils/authStorage.test.ts
@@ -82,6 +82,32 @@ describe('authStorage', () => {
     expect(localStorage.getItem(AUTH_SESSION_KEY)).toBeNull();
   });
 
+  it('treats corrupted JSON in the active storage as no session', () => {
+    localStorage.setItem(AUTH_SESSION_KEY, 'not-json{');
+
+    expect(getStoredAuthTokens()).toEqual({ accessToken: null, refreshToken: null });
+  });
+
+  it('treats a descriptor missing a token as no session', () => {
+    localStorage.setItem(AUTH_SESSION_KEY, JSON.stringify({ accessToken: 'only-access' }));
+
+    expect(getStoredAuthTokens()).toEqual({ accessToken: null, refreshToken: null });
+  });
+
+  it('updates a remembered (localStorage) session with no sessionStorage descriptor', () => {
+    storeAuthTokens('old-access', 'refresh-token', true);
+
+    updateStoredAccessToken('new-access');
+
+    expect(readDescriptor(localStorage)?.accessToken).toBe('new-access');
+  });
+
+  it('is a no-op when neither storage has a descriptor to update', () => {
+    expect(() => updateStoredAccessToken('new-access')).not.toThrow();
+    expect(readDescriptor(localStorage)).toBeNull();
+    expect(readDescriptor(sessionStorage)).toBeNull();
+  });
+
   it('updates the access token in sessionStorage rather than a stale localStorage bundle', () => {
     storeAuthTokens('other-tab-access', 'other-tab-refresh', true);
     storeAuthTokens('this-tab-access', 'this-tab-refresh', false);

--- a/frontend/src/utils/completable.test.ts
+++ b/frontend/src/utils/completable.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { isCompletable } from "./completable";
+
+describe("isCompletable", () => {
+  it("is true when completed_at is set", () => {
+    expect(isCompletable({ completed_at: "2026-01-01T00:00:00.000Z" })).toBe(true);
+  });
+
+  it("is true when is_complete is true and completed_at is absent", () => {
+    expect(isCompletable({ is_complete: true })).toBe(true);
+  });
+
+  it("prefers completed_at over is_complete when both are present", () => {
+    expect(isCompletable({ completed_at: null, is_complete: true })).toBe(true);
+  });
+
+  it("is false when neither field indicates completion", () => {
+    expect(isCompletable({ completed_at: null, is_complete: false })).toBe(false);
+  });
+
+  it("is false for an empty object", () => {
+    expect(isCompletable({})).toBe(false);
+  });
+});

--- a/frontend/src/utils/formatUtils.test.ts
+++ b/frontend/src/utils/formatUtils.test.ts
@@ -2,11 +2,109 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   formatDueAt,
-  toDateInputValue,
-  toTimeInputValue,
+  formatDuration,
+  formatDurationShort,
+  formatPublishedAt,
+  formatRewardDuration,
   fromDateAndTimeInputValues,
   isOverdue,
+  pluralize,
+  toDateInputValue,
+  toTimeInputValue,
 } from "./formatUtils";
+
+describe("formatDuration", () => {
+  it("formats seconds under a minute as mm:ss", () => {
+    expect(formatDuration(5)).toBe("0:05");
+  });
+
+  it("formats minutes and seconds without a leading zero on minutes", () => {
+    expect(formatDuration(125)).toBe("2:05");
+  });
+
+  it("formats hours as h:mm:ss with padded minutes", () => {
+    expect(formatDuration(3665)).toBe("1:01:05");
+  });
+});
+
+describe("formatDurationShort", () => {
+  it("formats sub-minute durations as seconds", () => {
+    expect(formatDurationShort(45)).toBe("45s");
+  });
+
+  it("formats whole minutes without a seconds remainder", () => {
+    expect(formatDurationShort(120)).toBe("2m");
+  });
+
+  it("formats minutes with a seconds remainder", () => {
+    expect(formatDurationShort(125)).toBe("2m 5s");
+  });
+
+  it("formats whole hours without a minutes remainder", () => {
+    expect(formatDurationShort(7200)).toBe("2h");
+  });
+
+  it("formats hours with a minutes remainder", () => {
+    expect(formatDurationShort(7260)).toBe("2h 1m");
+  });
+});
+
+describe("pluralize", () => {
+  it("uses the singular form for a count of 1", () => {
+    expect(pluralize(1, "day")).toBe("day");
+  });
+
+  it("uses the default plural form (singular + s) for other counts", () => {
+    expect(pluralize(0, "day")).toBe("days");
+    expect(pluralize(3, "day")).toBe("days");
+  });
+
+  it("uses an explicit irregular plural when given", () => {
+    expect(pluralize(3, "child", "children")).toBe("children");
+  });
+});
+
+describe("formatRewardDuration", () => {
+  it("clamps negative durations to zero seconds", () => {
+    expect(formatRewardDuration(-5)).toBe("0 seconds");
+  });
+
+  it("formats a sub-minute duration in seconds, pluralizing correctly", () => {
+    expect(formatRewardDuration(1)).toBe("1 second");
+    expect(formatRewardDuration(45)).toBe("45 seconds");
+  });
+
+  it("formats minutes with a seconds remainder", () => {
+    expect(formatRewardDuration(90)).toBe("1 minute 30 seconds");
+  });
+
+  it("formats whole minutes without a seconds remainder", () => {
+    expect(formatRewardDuration(120)).toBe("2 minutes");
+  });
+
+  it("formats hours with a minutes remainder, dropping any seconds", () => {
+    expect(formatRewardDuration(3665)).toBe("1 hour 1 minute");
+  });
+
+  it("formats whole hours without a minutes remainder", () => {
+    expect(formatRewardDuration(7200)).toBe("2 hours");
+  });
+});
+
+describe("formatPublishedAt", () => {
+  it("returns null when publishedAt is null", () => {
+    expect(formatPublishedAt(null)).toBeNull();
+  });
+
+  it("returns null for an invalid date string", () => {
+    expect(formatPublishedAt("not-a-date")).toBeNull();
+  });
+
+  it("formats a valid ISO string as a date and time", () => {
+    const result = formatPublishedAt("2026-05-01T08:30:00.000Z");
+    expect(result).toMatch(/\d{1,2}.*2026.*\d{1,2}:\d{2}/);
+  });
+});
 
 describe("formatDueAt", () => {
   // Anchor "today" to a fixed, mid-week local date so day-diff buckets are deterministic.
@@ -83,6 +181,28 @@ describe("formatDueAt", () => {
   it("falls back to an absolute date beyond the month cap (future)", () => {
     // 200 days out from Wed 15 Jul 2026 is Sun 31 Jan 2027.
     expect(formatDueAt(atLocalMidnight(200))).toBe("Sun 31st Jan");
+  });
+
+  it("uses the 'th' ordinal suffix for the 11th-13th of the month", () => {
+    // Well beyond the 180-day month cutoff from Wed 15 Jul 2026, so this falls
+    // back to an absolute date.
+    const mar12 = new Date(2027, 2, 12, 9, 0, 0);
+    expect(formatDueAt(mar12.toISOString())).toBe("Fri 12th Mar");
+  });
+
+  it("uses the 'nd' ordinal suffix for the 2nd of the month", () => {
+    const mar2 = new Date(2027, 2, 2, 9, 0, 0);
+    expect(formatDueAt(mar2.toISOString())).toBe("Tue 2nd Mar");
+  });
+
+  it("uses the 'rd' ordinal suffix for the 3rd of the month", () => {
+    const mar3 = new Date(2027, 2, 3, 9, 0, 0);
+    expect(formatDueAt(mar3.toISOString())).toBe("Wed 3rd Mar");
+  });
+
+  it("uses the default 'th' ordinal suffix outside 1st/2nd/3rd/11th-13th", () => {
+    const mar15 = new Date(2027, 2, 15, 9, 0, 0);
+    expect(formatDueAt(mar15.toISOString())).toBe("Mon 15th Mar");
   });
 });
 

--- a/frontend/src/utils/playerNameValidation.test.ts
+++ b/frontend/src/utils/playerNameValidation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   PLAYER_NAME_MAX_LENGTH,
   PLAYER_NAME_MIN_LENGTH,
+  getPlayerNameErrorMessage,
   getPlayerNameValidation,
   normalizePlayerName,
 } from "./playerNameValidation";
@@ -34,5 +35,35 @@ describe("playerNameValidation", () => {
     expect(
       getPlayerNameValidation("a".repeat(PLAYER_NAME_MIN_LENGTH)).isValid
     ).toBe(true);
+  });
+});
+
+describe("getPlayerNameErrorMessage", () => {
+  it("returns a generic message when there is no error", () => {
+    expect(getPlayerNameErrorMessage(null)).toBe("Failed to update name.");
+    expect(getPlayerNameErrorMessage(undefined)).toBe("Failed to update name.");
+  });
+
+  it("returns a generic message when the error has no message", () => {
+    expect(getPlayerNameErrorMessage({})).toBe("Failed to update name.");
+  });
+
+  it("extracts the first field error from a DRF-style JSON message", () => {
+    const error = { message: JSON.stringify({ name: ["This name is taken."] }) };
+    expect(getPlayerNameErrorMessage(error)).toBe("This name is taken.");
+  });
+
+  it("falls back to a JSON detail field when there is no name error", () => {
+    const error = { message: JSON.stringify({ detail: "Server error." }) };
+    expect(getPlayerNameErrorMessage(error)).toBe("Server error.");
+  });
+
+  it("returns the raw message when it is not JSON", () => {
+    expect(getPlayerNameErrorMessage({ message: "Network error" })).toBe("Network error");
+  });
+
+  it("returns the raw message when the parsed JSON has neither name nor detail", () => {
+    const error = { message: JSON.stringify({ other: "field" }) };
+    expect(getPlayerNameErrorMessage(error)).toBe(error.message);
   });
 });

--- a/frontend/src/utils/sounds.test.ts
+++ b/frontend/src/utils/sounds.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+class FakeAudioParam {
+  value = 0;
+  setValueAtTime = vi.fn();
+  exponentialRampToValueAtTime = vi.fn();
+}
+
+class FakeOscillatorNode {
+  type = "";
+  frequency = new FakeAudioParam();
+  connect = vi.fn();
+  start = vi.fn();
+  stop = vi.fn();
+}
+
+class FakeGainNode {
+  gain = new FakeAudioParam();
+  connect = vi.fn();
+}
+
+function createFakeAudioContext(state: "running" | "suspended" = "running") {
+  const resume = vi.fn().mockResolvedValue(undefined);
+  return {
+    state,
+    currentTime: 0,
+    createOscillator: vi.fn(() => new FakeOscillatorNode()),
+    createGain: vi.fn(() => new FakeGainNode()),
+    destination: {},
+    resume,
+  };
+}
+
+// sounds.ts keeps a module-level AudioContext singleton, so each test needs a
+// fresh module instance to control which fake context getContext() sees.
+async function loadSounds() {
+  vi.resetModules();
+  return import("./sounds");
+}
+
+describe("sounds", () => {
+  const originalAudioContext = window.AudioContext;
+
+  afterEach(() => {
+    window.AudioContext = originalAudioContext;
+    vi.useRealTimers();
+  });
+
+  it("does nothing when AudioContext is unsupported", async () => {
+    // @ts-expect-error simulating an environment without AudioContext
+    delete window.AudioContext;
+    const { playActivityStartedSound, primeAudio } = await loadSounds();
+
+    expect(() => playActivityStartedSound()).not.toThrow();
+    expect(() => primeAudio()).not.toThrow();
+  });
+
+  it("schedules oscillator notes for the activity-started chime", async () => {
+    const fakeCtx = createFakeAudioContext("running");
+    window.AudioContext = vi.fn(function () { return fakeCtx; }) as unknown as typeof AudioContext;
+    const { playActivityStartedSound } = await loadSounds();
+
+    playActivityStartedSound();
+
+    expect(fakeCtx.createOscillator).toHaveBeenCalledTimes(3);
+    expect(fakeCtx.createGain).toHaveBeenCalledTimes(3);
+  });
+
+  it("schedules oscillator notes for the limit-reached chime", async () => {
+    const fakeCtx = createFakeAudioContext("running");
+    window.AudioContext = vi.fn(function () { return fakeCtx; }) as unknown as typeof AudioContext;
+    const { playLimitReachedSound } = await loadSounds();
+
+    playLimitReachedSound();
+
+    expect(fakeCtx.createOscillator).toHaveBeenCalledTimes(4);
+  });
+
+  it("resumes a suspended context before scheduling notes", async () => {
+    const fakeCtx = createFakeAudioContext("suspended");
+    window.AudioContext = vi.fn(function () { return fakeCtx; }) as unknown as typeof AudioContext;
+    const { playActivityStartedSound } = await loadSounds();
+
+    playActivityStartedSound();
+    expect(fakeCtx.resume).toHaveBeenCalledTimes(1);
+    expect(fakeCtx.createOscillator).not.toHaveBeenCalled();
+
+    await fakeCtx.resume.mock.results[0].value;
+    expect(fakeCtx.createOscillator).toHaveBeenCalledTimes(3);
+  });
+
+  it("primes and resumes a suspended context synchronously", async () => {
+    const fakeCtx = createFakeAudioContext("suspended");
+    window.AudioContext = vi.fn(function () { return fakeCtx; }) as unknown as typeof AudioContext;
+    const { primeAudio } = await loadSounds();
+
+    primeAudio();
+
+    expect(fakeCtx.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not resume an already-running context when primed", async () => {
+    const fakeCtx = createFakeAudioContext("running");
+    window.AudioContext = vi.fn(function () { return fakeCtx; }) as unknown as typeof AudioContext;
+    const { primeAudio } = await loadSounds();
+
+    primeAudio();
+
+    expect(fakeCtx.resume).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors thrown while creating or scheduling a chime", async () => {
+    window.AudioContext = vi.fn(() => {
+      throw new Error("blocked by browser");
+    }) as unknown as typeof AudioContext;
+    const { playActivityStartedSound, primeAudio } = await loadSounds();
+
+    expect(() => playActivityStartedSound()).not.toThrow();
+    expect(() => primeAudio()).not.toThrow();
+  });
+
+  it("reuses the same AudioContext instance across calls", async () => {
+    const fakeCtx = createFakeAudioContext("running");
+    const factory = vi.fn(function () { return fakeCtx; });
+    window.AudioContext = factory as unknown as typeof AudioContext;
+    const { playActivityStartedSound, playLimitReachedSound } = await loadSounds();
+
+    playActivityStartedSound();
+    playLimitReachedSound();
+
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/utils/userPreferences.test.ts
+++ b/frontend/src/utils/userPreferences.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { TASKS_HIDE_COMPLETED_KEY, clearUserPreferences } from "./userPreferences";
+
+describe("clearUserPreferences", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("removes the hide-completed-tasks preference", () => {
+    localStorage.setItem(TASKS_HIDE_COMPLETED_KEY, "true");
+
+    clearUserPreferences();
+
+    expect(localStorage.getItem(TASKS_HIDE_COMPLETED_KEY)).toBeNull();
+  });
+
+  it("is a no-op when no preference was stored", () => {
+    expect(() => clearUserPreferences()).not.toThrow();
+    expect(localStorage.getItem(TASKS_HIDE_COMPLETED_KEY)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `frontend/src/api` (100% stmt/line/fn, 96% branch)
- Add unit tests for `frontend/src/context` (GameContext, WebSocketContext, extended AuthContext, Maintenance/OnlineCount/ToastContext)
- Add unit tests for `frontend/src/utils` and `testUtils/mockAuthContext`
- Add unit tests for ~34 hooks in `frontend/src/hooks`
- Add unit tests for `BackToTopButton`, `MapDetailCard`, `LibraryPage`, `Account`, and `Tooltip` components

## Test plan
- [x] `npx vitest run` passes across all touched directories
- [x] `npx eslint --max-warnings=0` clean on all touched files
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAdWrMLaL5PP7QyF5NnFb7