### PR TITLE
Deploy: staging → main (announcement title rendering fix)

### DIFF
--- a/frontend/src/layout/Navbar/Announcements.module.scss
+++ b/frontend/src/layout/Navbar/Announcements.module.scss
@@ -122,6 +122,14 @@
   // style) so the title stays compact along with the rest of this list.
   font-family: inherit;
   font-size: 0.85rem;
+  // Tamagui's base `.is_View` rule sets `letter-spacing: var(--f-letterSpacing-true)`
+  // on every Tamagui host element, including this trigger (built on
+  // Collapsible.Trigger/Button). That variable is tuned for Tamagui's own
+  // default font-size token, not this component's much smaller overridden
+  // font-size above, and resolves to several negative pixels here - enough
+  // to render the title's characters overlapping. Reset it explicitly since
+  // this element never opts into Tamagui's font-size scale in the first place.
+  letter-spacing: normal;
 
   // No custom focus style here - falls back to the site-wide
   // :focus-visible outline (see styles/base/_a11y.scss) instead of this


### PR DESCRIPTION
## Release summary

### Fixes
- Fixed announcement titles rendering with overlapping, garbled characters in the announcements panel.

---

## Contributors
<!-- none besides self -->

## Technical notes
- Root cause: Tamagui's base `.is_View` rule sets `letter-spacing` from a CSS var tuned for Tamagui's own default font-size token. The announcement accordion trigger overrides font-size down to 0.85rem but never reset letter-spacing, so it inherited a large negative value meant for much bigger text.
- Fix: explicit `letter-spacing: normal;` on `.accordionTrigger` in `frontend/src/layout/Navbar/Announcements.module.scss` (commit eac6d5d3).
- Committed directly to `staging` (not via a development → staging PR) since this was a targeted hotfix; `development` was fast-forwarded to match so it isn't lost on the next merge.
- No migrations or env var changes.
