### PR TITLE
Finish the remaining #569 sub-issues (#571, #574, #577)

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,11 @@
+# Loaded by Vite for `--mode development` (npm run dev, npm run build:development,
+# storybook dev). Committed on purpose: it is the explicit local-dev value that
+# replaced config.ts's old `window.location.hostname === 'localhost'` sniffing
+# (#571). Override it in .env.development.local, which stays gitignored.
+#
+# This points straight at the backend container's exposed port rather than at
+# Vite's /api dev proxy (vite.config.ts `server.proxy`) - same effective URL as
+# before this was made explicit. See #538 for the argument that local dev should
+# instead go through the proxy; that is a behaviour change, deliberately not
+# bundled into this one.
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/.env.test
+++ b/frontend/.env.test
@@ -1,0 +1,5 @@
+# Loaded by Vite when vitest runs (mode 'test'). Tests never reach a real
+# backend - MSW/fetch mocks intercept - but config.ts now requires an explicit
+# VITE_API_BASE_URL, so give the suite a stable, obviously-local value to build
+# expected URLs from.
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,7 +11,11 @@ node_modules
 dist
 dist-ssr
 *.local
+# Committed: the explicit per-mode API base URL defaults config.ts now
+# requires (#571). Real secrets/overrides go in .env*.local.
 .env.*
+!.env.development
+!.env.test
 
 # Editor directories and files
 .vscode/*

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -9,6 +9,18 @@ const config: StorybookConfig = {
   ],
   framework: '@storybook/react-vite',
   viteFinal: async (config, options) => {
+    // src/config.ts requires an explicit VITE_API_BASE_URL and throws without
+    // one (#571). Stories never call the backend, but some of them do pull in
+    // modules that import it transitively (Footer renders an /admin link), and
+    // the static build runs in production mode, so no .env.<mode> file supplies
+    // a value. Give it an obviously-local placeholder rather than letting the
+    // gallery white-screen on a config error it has no stake in.
+    config.define = {
+      ...config.define,
+      'import.meta.env.VITE_API_BASE_URL': JSON.stringify(
+        process.env.VITE_API_BASE_URL || 'http://localhost:8000',
+      ),
+    };
     // Only the static build (deployed to GitHub Pages under the repo name)
     // needs this subpath base. Dev server and @storybook/addon-vitest's
     // browser test runner both reuse this same viteFinal, and serving them

--- a/frontend/src/components/ActivityInput/ActivityInput.tsx
+++ b/frontend/src/components/ActivityInput/ActivityInput.tsx
@@ -13,6 +13,7 @@ export default function ActivityInput() {
   const {
     name,
     setName,
+    setActivityInputRef,
     isActive,
     inputValue,
     elapsed,
@@ -43,6 +44,7 @@ export default function ActivityInput() {
             <div className={classNames(styles.grow, styles.control)}>
               <EntitySearchInput
                 type="activity"
+                inputRef={setActivityInputRef}
                 value={inputValue}
                 onChange={setName}
                 onSelect={async (activity) => {

--- a/frontend/src/components/ActivityInput/useActivityInput.test.ts
+++ b/frontend/src/components/ActivityInput/useActivityInput.test.ts
@@ -344,6 +344,72 @@ describe('useActivityInput unified handlers', () => {
     });
   });
 
+  describe('blurring the activity input on start (#574)', () => {
+    it('blurs the registered input when the timer becomes active', () => {
+      const blur = vi.fn();
+
+      const { result, rerender } = renderHook(() => useActivityInput());
+
+      act(() => {
+        result.current.setActivityInputRef({ blur });
+      });
+
+      expect(blur).not.toHaveBeenCalled();
+
+      mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+      rerender();
+
+      expect(blur).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not blur while no timer is running', () => {
+      const blur = vi.fn();
+
+      const { result } = renderHook(() => useActivityInput());
+
+      act(() => {
+        result.current.setActivityInputRef({ blur });
+      });
+
+      expect(blur).not.toHaveBeenCalled();
+    });
+
+    it('leaves other focused elements alone - only the activity input is blurred', () => {
+      // The old implementation blurred document.activeElement, i.e. whatever
+      // happened to be focused anywhere on the page.
+      const other = document.createElement('input');
+      document.body.appendChild(other);
+      other.focus();
+      const otherBlur = vi.spyOn(other, 'blur');
+
+      const { result, rerender } = renderHook(() => useActivityInput());
+
+      act(() => {
+        result.current.setActivityInputRef({ blur: vi.fn() });
+      });
+
+      mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+      rerender();
+
+      expect(otherBlur).not.toHaveBeenCalled();
+      other.remove();
+    });
+
+    it('is a no-op when the input has already unmounted', () => {
+      // The unified timer swaps the search input for the label display on
+      // start, so the ref can be null by the time the effect runs.
+      const { result, rerender } = renderHook(() => useActivityInput());
+
+      act(() => {
+        result.current.setActivityInputRef(null);
+      });
+
+      mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
+
+      expect(() => rerender()).not.toThrow();
+    });
+  });
+
   it('invalidates the daily-goals query after completing an activity, so the map badge updates immediately (#673, #751)', async () => {
     mockGame({ status: 'active', currentActivity: { name: 'Deep work' } });
     stop.mockResolvedValue({ xp_gained: 10 });

--- a/frontend/src/components/ActivityInput/useActivityInput.ts
+++ b/frontend/src/components/ActivityInput/useActivityInput.ts
@@ -10,6 +10,16 @@ import type { PlayerActivity } from "../../types";
 import { playLimitReachedSound, primeAudio } from "../../utils/sounds";
 import { formatDuration } from "../../utils/formatUtils";
 
+/**
+ * Minimal handle the hook needs from the activity name input: enough to blur
+ * it, nothing more. Structural rather than `HTMLInputElement` so this module
+ * stays free of DOM types — a React Native `TextInput` satisfies it too
+ * (#569/#574).
+ */
+export interface BlurrableInput {
+  blur: () => void;
+}
+
 /** Populated on stop when `results_mode` is on, instead of opening the SupportFlow modal. */
 export interface ResultsData {
   activityId: number | null;
@@ -287,6 +297,13 @@ export function useActivityInput() {
   const inputValue = hasSession ? (isEditingLabel ? name : name || currentActivity?.name || "") : name;
   const isUnlabelled = hasSession && !(currentActivity?.name ?? currentActivity?.text ?? "").trim();
 
+  // Ref callback rather than a bare ref object so the type stays structural
+  // (BlurrableInput) while still being assignable to a DOM `ref` prop.
+  const activityInputRef = useRef<BlurrableInput | null>(null);
+  const setActivityInputRef = useCallback((node: BlurrableInput | null) => {
+    activityInputRef.current = node;
+  }, []);
+
   useWelcomeMessageEffect({
     loginState,
     loginStreak,
@@ -295,9 +312,15 @@ export function useActivityInput() {
     openWelcomeMessage,
   });
 
+  // Dismiss the mobile keyboard once the timer starts running. This used to
+  // blur `document.activeElement` — whatever happened to be focused anywhere
+  // on the page, which is both a global DOM reach-around and imprecise. The
+  // component hands us a ref to the activity input itself, so blur exactly
+  // that; if it has already unmounted (the unified timer swaps it for the
+  // label display on start), unmounting blurred it anyway.
   useEffect(() => {
     if (isActive) {
-      (document.activeElement as HTMLElement | null)?.blur();
+      activityInputRef.current?.blur();
     }
   }, [isActive]);
 
@@ -603,6 +626,7 @@ export function useActivityInput() {
   return {
     name,
     setName,
+    setActivityInputRef,
     isActive,
     isPaused,
     isWaiting,

--- a/frontend/src/components/EntitySearchInput/EntitySearchInput.test.tsx
+++ b/frontend/src/components/EntitySearchInput/EntitySearchInput.test.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { Ref } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -28,6 +29,7 @@ function Harness({
   alwaysOpen,
   maxVisibleRows,
   emptyMessage,
+  inputRef,
 }: {
   type?: "task" | "activity";
   onCreate?: (name: string) => void;
@@ -35,6 +37,7 @@ function Harness({
   alwaysOpen?: boolean;
   maxVisibleRows?: number;
   emptyMessage?: string;
+  inputRef?: Ref<HTMLInputElement>;
 }) {
   const [value, setValue] = useState("");
   return (
@@ -48,6 +51,7 @@ function Harness({
       alwaysOpen={alwaysOpen}
       maxVisibleRows={maxVisibleRows}
       emptyMessage={emptyMessage}
+      inputRef={inputRef}
     />
   );
 }
@@ -56,6 +60,14 @@ describe("EntitySearchInput", () => {
   beforeEach(() => {
     addEntityToCache.mockReset();
     mockEntities = [];
+  });
+
+  it("forwards inputRef to the text input, so callers can blur it directly (#574)", () => {
+    let node: HTMLInputElement | null = null;
+
+    render(<Harness inputRef={(el) => { node = el; }} />);
+
+    expect(node).toBe(screen.getByRole("combobox"));
   });
 
   it("dedupes a task and an identically-named activity into one suggestion", async () => {

--- a/frontend/src/components/EntitySearchInput/EntitySearchInput.tsx
+++ b/frontend/src/components/EntitySearchInput/EntitySearchInput.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import type { CSSProperties, KeyboardEvent } from "react";
+import type { CSSProperties, KeyboardEvent, Ref } from "react";
 import classNames from "classnames";
 
 import { useEntitySearchInput, type SearchEntity } from "./useEntitySearchInput";
@@ -30,6 +30,12 @@ interface EntitySearchInputProps {
   maxVisibleRows?: number;
   /** Shown instead of the list when alwaysOpen is set and there are no rows. */
   emptyMessage?: string;
+  /**
+   * Forwarded to the text input, so a caller can act on the element directly
+   * (e.g. blurring it to dismiss the mobile keyboard) instead of reaching for
+   * `document.activeElement`. See useActivityInput (#574).
+   */
+  inputRef?: Ref<HTMLInputElement>;
 }
 
 export default function EntitySearchInput({
@@ -48,6 +54,7 @@ export default function EntitySearchInput({
   alwaysOpen = false,
   maxVisibleRows,
   emptyMessage,
+  inputRef,
 }: EntitySearchInputProps) {
   const {
     canSearch,
@@ -158,6 +165,7 @@ export default function EntitySearchInput({
   return (
     <div ref={rootRef} className={classNames(styles.root, className)}>
       <input
+        ref={inputRef}
         type="text"
         role="combobox"
         value={value}

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
@@ -38,7 +38,6 @@ export default function UnifiedTimerHome() {
     setActivityInputRef,
     isActive,
     isPaused,
-    isWaiting,
     hasSession,
     canResume,
     isUnlabelled,

--- a/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
+++ b/frontend/src/components/UnifiedTimerHome/UnifiedTimerHome.tsx
@@ -35,6 +35,7 @@ export default function UnifiedTimerHome() {
   const {
     name,
     setName,
+    setActivityInputRef,
     isActive,
     isPaused,
     isWaiting,
@@ -272,6 +273,7 @@ export default function UnifiedTimerHome() {
                 <motion.div key="search" {...fadeProps} className={styles.searchControl}>
                   <EntitySearchInput
                     type="activity"
+                    inputRef={setActivityInputRef}
                     value={inputValue}
                     onChange={setName}
                     onSelect={handleUnifiedSelect}

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -1,22 +1,48 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { resolveApiBaseUrl } from './config';
+import { API_BASE_URL, resolveApiBaseUrl } from './config';
+
+// resolveApiBaseUrl reads import.meta.env by default, but takes an override so
+// the unconfigured/misconfigured cases are testable: vi.stubEnv can set a value
+// but not remove one, and .env.test supplies a real value to the whole suite.
+const env = (value?: string) => ({ VITE_API_BASE_URL: value }) as unknown as ImportMetaEnv;
 
 describe('resolveApiBaseUrl', () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    window.history.pushState({}, '', 'http://localhost:3000/');
-  });
-
-  it('falls back to localhost when the env value is blank', () => {
-    vi.stubEnv('VITE_API_BASE_URL', '   ');
-
-    expect(resolveApiBaseUrl()).toBe('http://localhost:8000');
+  it('uses the configured value', () => {
+    expect(resolveApiBaseUrl(env('https://web-staging-wjii.onrender.com'))).toBe(
+      'https://web-staging-wjii.onrender.com',
+    );
   });
 
   it('trims a configured API base URL before use', () => {
-    vi.stubEnv('VITE_API_BASE_URL', ' https://web-staging-wjii.onrender.com/ ');
+    expect(resolveApiBaseUrl(env(' https://web-staging-wjii.onrender.com/ '))).toBe(
+      'https://web-staging-wjii.onrender.com',
+    );
+  });
 
-    expect(resolveApiBaseUrl()).toBe('https://web-staging-wjii.onrender.com');
+  it('strips a trailing /api/v1 suffix, with or without a trailing slash', () => {
+    expect(resolveApiBaseUrl(env('https://example.com/api/v1'))).toBe('https://example.com');
+    expect(resolveApiBaseUrl(env('https://example.com/api/v1/'))).toBe('https://example.com');
+  });
+
+  it('throws when the env value is missing', () => {
+    expect(() => resolveApiBaseUrl(env())).toThrow(/VITE_API_BASE_URL is not set/);
+  });
+
+  it('throws when the env value is blank', () => {
+    expect(() => resolveApiBaseUrl(env('   '))).toThrow(/VITE_API_BASE_URL is not set/);
+  });
+
+  it('does not consult window.location', () => {
+    // The point of #571: no origin sniffing. Guard against it regressing by
+    // resolving under a hostname that would previously have changed the answer.
+    window.history.pushState({}, '', 'http://localhost:3000/');
+    expect(resolveApiBaseUrl(env('https://api.example.com'))).toBe('https://api.example.com');
+  });
+});
+
+describe('API_BASE_URL', () => {
+  it('resolves from .env.test for the suite', () => {
+    expect(API_BASE_URL).toBe('http://localhost:8000');
   });
 });

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,17 +1,55 @@
 // src/config.ts
-export function resolveApiBaseUrl(): string {
-  const rawEnvApiBaseUrl = import.meta.env.VITE_API_BASE_URL as string | undefined;
-  const envApiBaseUrl = typeof rawEnvApiBaseUrl === 'string'
-    ? rawEnvApiBaseUrl.trim()
-    : undefined;
 
-  const base =
-    (envApiBaseUrl && envApiBaseUrl.length > 0 ? envApiBaseUrl : undefined) ??
-    (window.location.hostname === 'localhost'
-      ? 'http://localhost:8000'
-      : window.location.origin);
+/**
+ * Base URL for the Django backend, as an absolute origin (no trailing slash,
+ * no `/api/v1` suffix - callers append their own paths).
+ *
+ * This is configured explicitly per environment via `VITE_API_BASE_URL`, never
+ * inferred from the page that happens to be serving the app:
+ *
+ * - local dev / `--mode development` builds: `.env.development`
+ * - vitest (`--mode test`): `.env.test`
+ * - Storybook's static build: a placeholder injected in `.storybook/main.ts`
+ * - staging / production: the Render env var on the `frontend` service
+ *   (`render.yaml` / `render-staging.yaml`, `sync: false`)
+ *
+ * Inferring it used to mean falling back to `window.location.origin`, which is
+ * (a) unavailable on React Native, where there is no page origin to sniff
+ * (#569/#571), and (b) wrong in every deployed environment anyway: the
+ * frontend is a Render static site on its own hostname, so its origin is not
+ * the backend's. That fallback only ever looked harmless because
+ * `VITE_API_BASE_URL` is in fact always set in staging and production - if it
+ * were dropped, it would have silently pointed the whole app at the static
+ * site instead of failing. Hence the throw below rather than a guess.
+ */
+const API_BASE_URL_ENV_VAR = 'VITE_API_BASE_URL';
 
-  return base.replace(/\/api\/v1\/?$/i, '').replace(/\/$/, '');
+/**
+ * Strip a `/api/v1` suffix and any trailing slash, so a value configured as
+ * either an origin or a full API root resolves to the same base. Callers
+ * concatenate `/api/v1/...` themselves.
+ */
+function normaliseApiBaseUrl(value: string): string {
+  return value.replace(/\/api\/v1\/?$/i, '').replace(/\/$/, '');
+}
+
+export function resolveApiBaseUrl(
+  env: ImportMetaEnv = import.meta.env,
+): string {
+  const rawEnvApiBaseUrl = env[API_BASE_URL_ENV_VAR] as string | undefined;
+  const configured =
+    typeof rawEnvApiBaseUrl === 'string' ? rawEnvApiBaseUrl.trim() : '';
+
+  if (configured.length === 0) {
+    throw new Error(
+      `${API_BASE_URL_ENV_VAR} is not set. The API base URL must be configured ` +
+        'explicitly for every environment - it is no longer inferred from ' +
+        'window.location. Set it in the environment (Render env var for ' +
+        'staging/production) or in the matching frontend/.env.<mode> file.',
+    );
+  }
+
+  return normaliseApiBaseUrl(configured);
 }
 
 export const API_BASE_URL = resolveApiBaseUrl();

--- a/frontend/src/hooks/useActivityTimer.paused.test.tsx
+++ b/frontend/src/hooks/useActivityTimer.paused.test.tsx
@@ -6,11 +6,11 @@ import type { ActivityTimerApiData } from '../types';
 
 const mockApiFetch = vi.fn();
 
-vi.mock('../utils/api.js', () => ({
+vi.mock('../utils/api', () => ({
   apiFetch: (...args: unknown[]) => mockApiFetch(...args),
 }));
 
-vi.mock('../utils/sounds.js', () => ({
+vi.mock('../utils/sounds', () => ({
   playActivityStartedSound: vi.fn(),
   primeAudio: vi.fn(),
 }));

--- a/frontend/src/hooks/useActivityTimer.test.tsx
+++ b/frontend/src/hooks/useActivityTimer.test.tsx
@@ -7,11 +7,11 @@ import type { ActivityTimerApiData } from '../types';
 const mockApiFetch = vi.fn();
 const mockPlayActivityStartedSound = vi.fn();
 
-vi.mock("../utils/api.js", () => ({
+vi.mock("../utils/api", () => ({
   apiFetch: (...args: unknown[]) => mockApiFetch(...args),
 }));
 
-vi.mock("../utils/sounds.js", () => ({
+vi.mock("../utils/sounds", () => ({
   playActivityStartedSound: (...args: unknown[]) => mockPlayActivityStartedSound(...args),
   primeAudio: vi.fn(),
 }));
@@ -214,6 +214,9 @@ describe('useActivityTimer', () => {
           // because an unlabelled quick-start declares no duration.
           limitSeconds: null,
           limitReason: null,
+          // set_activity assigns the activity and starts the clock in one
+          // round-trip (see useActivityTimer's comment on the call site).
+          start: true,
         }),
       })
     );

--- a/frontend/src/hooks/useActivityTimer.ts
+++ b/frontend/src/hooks/useActivityTimer.ts
@@ -1,7 +1,7 @@
 // hooks/useActivityTimer.ts
 import { useState, useRef, useEffect, useCallback } from "react";
-import { apiFetch } from "../utils/api.js";
-import { playActivityStartedSound, primeAudio } from "../utils/sounds.js";
+import { apiFetch } from "../utils/api";
+import { playActivityStartedSound, primeAudio } from "../utils/sounds";
 import type {
   TimerStatus,
   CurrentActivity,
@@ -11,7 +11,6 @@ import type {
   AutoStopCompletion,
   ActivityTimerReturn,
 } from "../types";
-//import { useGame } from "../context/GameContext.jsx";
 
 
 export default function useActivityTimer(): ActivityTimerReturn {


### PR DESCRIPTION
Closes the last three open sub-issues of #569 (Decouple frontend logic from the DOM). #570, #572, #573, #575 and #576 were already done; this takes the epic to 8/8.

Three independent commits, each behaviour-preserving.

## #571 — Derive `API_BASE_URL` from explicit config rather than `window.location`

`config.ts` inferred the API base URL from whatever page was serving the app: a `window.location.hostname === 'localhost'` branch for local dev, `window.location.origin` otherwise. Neither survives React Native, which has no page origin to sniff.

Worth noting the origin fallback was quietly wrong in deployed environments anyway — the frontend is a Render static site on its own hostname, so its origin is not the backend's. It only ever looked harmless because `VITE_API_BASE_URL` is in fact always set in staging and production; had it been dropped, the app would have silently pointed at the static site instead of failing. That's the argument for the throw rather than another guess.

`resolveApiBaseUrl` now reads `VITE_API_BASE_URL` and nothing else, throwing with a pointed message when it's missing or blank. The `/api/v1` and trailing-slash normalisation is unchanged, and **every environment resolves to the same effective base URL as before**:

| Environment | Source |
|---|---|
| local dev / `build:development` / Playwright's `npm run dev` | new committed `.env.development` |
| vitest (mode `test`) | new committed `.env.test` |
| Storybook static build (production mode, so no `.env` file applies) | placeholder injected via `define` in `.storybook/main.ts` |
| staging / production | the existing Render env var, unchanged |

Storybook needs its own path because stories transitively import `config.ts` (Footer's `/admin` link) without ever calling a backend, and `build-storybook` runs in CI for the docs deploy. `frontend/.gitignore`'s blanket `.env.*` is narrowed to let the two committed per-mode defaults through; `.env*.local` overrides stay ignored.

`resolveApiBaseUrl` takes the env object as an optional parameter so the missing-value case is testable — `vi.stubEnv` can set a value but not remove one, and `.env.test` now supplies one to the whole suite.

Local dev still points straight at `http://localhost:8000` rather than Vite's `/api` proxy, matching today's behaviour. #538 argues for the proxy instead; that's a behaviour change, deliberately left out of this one.

## #574 — Ref-based blur in `useActivityInput`

The hook dismissed the mobile keyboard on timer start via `(document.activeElement as HTMLElement | null)?.blur()` — its only DOM reference, and imprecise besides: it blurred whatever happened to be focused anywhere on the page.

It now exposes `setActivityInputRef`, a ref callback its two consumers (`ActivityInput` and `UnifiedTimerHome`) hand to `EntitySearchInput`'s new `inputRef` prop, and the start effect blurs that element specifically.

The ref is typed against a structural `BlurrableInput` (`{ blur(): void }`) rather than `HTMLInputElement`, so the hook carries no DOM types at all — React Native's `TextInput` satisfies the same shape. Exposing it as a ref *callback* rather than a ref object is what keeps it assignable to a DOM `ref` prop, since callback parameters are checked contravariantly.

The unified timer swaps the search input for the label display when a timer starts, so the ref can be null by the time the effect runs; that's a no-op, and unmounting a focused input blurs it natively anyway.

## #577 — Normalise `.js` extension imports

`useActivityTimer` imported `../utils/api.js` and `../utils/sounds.js`, both `.ts` modules, plus a dead commented-out `GameContext.jsx` line. Extensions dropped, dead line deleted, and the matching `vi.mock` specifiers in the two `useActivityTimer` test files updated so source and mocks stay in step.

A sweep of `src/`, `tests/`, `playwright/` and `.storybook/` found no other stragglers. `tests/a11y/future-proofing.spec.ts` keeps its `.js` extension: `src/routes/routePaths.js` really is a JavaScript file, so that extension is accurate rather than misleading.

### Two pre-existing failures on `development`, fixed here

Both blocked #577's "lint and tests pass" criterion, and both are in files this change already touches:

- `useActivityTimer.test.tsx` asserted a `set_activity` body without `start: true`, which the hook has deliberately sent since it collapsed `set_activity` and `start` into one round-trip (see the comment at its call site). Stale assertion, not a regression — the expectation is updated, not the code.
- `UnifiedTimerHome` destructured `isWaiting` without using it, failing `no-unused-vars`. Removed.

## Verification

Per CLAUDE.md I ran scoped tests rather than the full suites:

- `vitest --project unit` on `config`, `registrationStatus`, `ActivityInput`, `EntitySearchInput`, `UnifiedTimerHome`, `useActivityTimer` — **all pass** (87 tests)
- `npm run lint` — **clean** (was 1 error on `development`)
- `tsc --noEmit` — **clean**
- `vite build --mode development` — emitted config chunk contains `http://localhost:8000` and no `window` reference
- `vite build --mode production` with the var set — resolves to it; with it unset — the throw survives into the bundle, i.e. fails loudly at boot
- `storybook build` — succeeds, placeholder injected as intended

Worth a local `npm run test` / `npx playwright test` before un-drafting.

### New tests

- `config.test.ts`: configured value, trimming, `/api/v1` stripping with and without a trailing slash, throws on missing, throws on blank, and a guard that resolution doesn't consult `window.location`
- `useActivityInput.test.ts`: blurs the registered input on activation, doesn't blur while idle, leaves other focused elements alone, no-ops on an unmounted input
- `EntitySearchInput.test.tsx`: forwards `inputRef` to its text input

## Deploy note

No action needed — `VITE_API_BASE_URL` is already set on both Render frontend services. But it is now **required**: if it were ever unset, the app fails at boot with an explicit error instead of silently pointing at the static site's own origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176UPNV3GdbSqdUHZn9guw6

---
_Generated by [Claude Code](https://claude.ai/code/session_0176UPNV3GdbSqdUHZn9guw6)_