### PR TITLE
feat(users): add a timezone preference to the Account page

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -637,3 +637,66 @@ class DayStartTimeSettingTests(APITestCase):
         self.assertEqual(response.status_code, 400)
         self.user.refresh_from_db()
         self.assertEqual(self.user.day_start_time, time(2, 0))
+
+    def test_timezone_can_be_updated(self):
+        response = self.client.patch(
+            reverse("me-user-settings"),
+            {"timezone": "Europe/London"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertEqual(str(self.user.timezone), "Europe/London")
+
+    def test_an_invalid_timezone_is_rejected(self):
+        response = self.client.patch(
+            reverse("me-user-settings"),
+            {"timezone": "Not/A_Timezone"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.user.refresh_from_db()
+        self.assertEqual(str(self.user.timezone), "UTC")
+
+
+class TimezoneChoicesTests(APITestCase):
+    """
+    Backs the Account Preferences tab's timezone picker with every value
+    `user_settings`'s `timezone` field will actually accept.
+    """
+
+    def setUp(self):
+        from users.tests import user_factory
+
+        self.user = user_factory(with_player=True)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def test_requires_auth(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.get(reverse("me-timezone-choices"))
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_value_label_pairs_including_known_zones(self):
+        response = self.client.get(reverse("me-timezone-choices"))
+
+        self.assertEqual(response.status_code, 200)
+        timezones = response.data["timezones"]
+        values = {entry["value"] for entry in timezones}
+        self.assertIn("Europe/London", values)
+        self.assertIn("UTC", values)
+
+        by_value = {entry["value"]: entry["label"] for entry in timezones}
+        self.assertEqual(by_value["Europe/London"], "Europe/London")
+
+    def test_every_returned_value_is_accepted_by_user_settings(self):
+        response = self.client.get(reverse("me-timezone-choices"))
+        sample = response.data["timezones"][0]["value"]
+
+        update = self.client.patch(
+            reverse("me-user-settings"), {"timezone": sample}, format="json"
+        )
+
+        self.assertEqual(update.status_code, 200)

--- a/api/views.py
+++ b/api/views.py
@@ -374,6 +374,40 @@ class MeViewSet(viewsets.ViewSet):
 
         return Response(UserSerializer(request.user).data)
 
+    @extend_schema(
+        responses=inline_serializer(
+            name="TimezoneChoicesResponse",
+            fields={
+                "timezones": inline_serializer(
+                    name="TimezoneChoiceItem",
+                    fields={
+                        "value": drf_serializers.CharField(),
+                        "label": drf_serializers.CharField(),
+                    },
+                    many=True,
+                ),
+            },
+        )
+    )
+    @action(detail=False, methods=["get"])
+    def timezone_choices(self, request):
+        """
+        Every IANA timezone name `user_settings`'s `timezone` field will
+        accept, paired with a display label - backs the timezone picker on
+        the Account Preferences tab. Sourced from the same `zoneinfo` data
+        `validate_timezone_name` validates against, via
+        timezone_field.choices.standard() for consistent, sorted labels.
+        """
+        from zoneinfo import available_timezones
+
+        from timezone_field.choices import standard
+
+        timezones = [
+            {"value": value, "label": label}
+            for value, label in standard(available_timezones())
+        ]
+        return Response({"timezones": timezones})
+
     @extend_schema(responses=PlayerSerializer)
     @action(detail=False, methods=["get", "patch"])
     def player(self, request):

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -1,0 +1,17 @@
+// src/api/user.ts
+import type { TimezoneChoicesResponse } from "../types/api";
+import type { User } from "../types/domain";
+import { apiFetch } from "../utils/api";
+
+export const fetchTimezoneChoices = async (): Promise<TimezoneChoicesResponse> => {
+  return apiFetch<TimezoneChoicesResponse>("/me/timezone_choices/");
+};
+
+export const updateUserSettings = async (
+  patch: Partial<Pick<User, "timezone">> & { day_start_time?: string }
+): Promise<User> => {
+  return apiFetch<User>("/me/user_settings/", {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+};

--- a/frontend/src/components/TimezoneSelect/TimezoneSelect.module.scss
+++ b/frontend/src/components/TimezoneSelect/TimezoneSelect.module.scss
@@ -1,0 +1,84 @@
+@use '../../styles/utilities/mixins' as m;
+@use '../../styles/base/variables' as v;
+@use '../../styles/semantic/spacing' as sp;
+@use '../../styles/semantic/typography' as t;
+@use '../../styles/semantic/colors' as c;
+
+.root {
+  position: relative;
+  width: 100%;
+  max-width: 22rem;
+  min-width: 0;
+}
+
+.input {
+  width: 100%;
+  min-width: 0;
+  height: sp.$form-control-height;
+  padding: sp.$padding-base;
+  box-sizing: border-box;
+  border-radius: sp.$form-control-radius;
+  @include t.apply-text-style(t.$text-body);
+  @include m.border-interactive(
+    rgba(c.$color-border-primary, 0.4),
+    c.$color-border-primary,
+    c.$color-border-accent
+  );
+
+  &:focus {
+    outline: none;
+    border-color: c.$color-border-primary;
+    background-color: c.$color-bg;
+  }
+
+  @include m.focus-outline(c.$color-border-accent);
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + #{sp.$spacing-xs});
+  left: 0;
+  right: 0;
+  z-index: v.$z-index-tooltip;
+  margin: 0;
+  padding: sp.$spacing-xs 0;
+  max-height: 16rem;
+  overflow-y: auto;
+  list-style: none;
+  border: 1px solid rgba(c.$color-border-primary, 0.2);
+  border-radius: sp.$border-radius;
+  background: rgba(c.$color-bg, 0.98);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+}
+
+.optionItem {
+  margin: 0;
+}
+
+.optionButton {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  padding: sp.$spacing-sm sp.$spacing-md;
+  text-align: left;
+  color: c.$color-text-body;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(c.$color-border-primary, 0.08);
+  }
+}
+
+.optionButtonActive {
+  background: rgba(c.$color-border-primary, 0.14);
+}
+
+.optionButtonSelected {
+  font-weight: 600;
+}
+
+.emptyMessage {
+  padding: sp.$spacing-sm sp.$spacing-md;
+  color: c.$color-text-muted-strong;
+  @include t.apply-text-style(t.$text-body);
+}

--- a/frontend/src/components/TimezoneSelect/TimezoneSelect.test.tsx
+++ b/frontend/src/components/TimezoneSelect/TimezoneSelect.test.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import TimezoneSelect from "./TimezoneSelect";
+import type { TimezoneChoice } from "../../types/api";
+
+const options: TimezoneChoice[] = [
+  { value: "UTC", label: "UTC" },
+  { value: "Europe/London", label: "Europe/London" },
+  { value: "America/New_York", label: "America/New York" },
+];
+
+// TimezoneSelect is controlled by value/onChange, so tests drive the value
+// from local state, same as the app would.
+function Harness({ initialValue = "UTC" }: { initialValue?: string }) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <TimezoneSelect
+      options={options}
+      value={value}
+      onChange={setValue}
+      ariaLabel="Timezone"
+    />
+  );
+}
+
+describe("TimezoneSelect", () => {
+  it("shows the selected timezone's label in the input", () => {
+    render(<Harness />);
+
+    expect(screen.getByRole("combobox", { name: "Timezone" })).toHaveValue("UTC");
+  });
+
+  it("opens a listbox of options on focus", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("combobox", { name: "Timezone" }));
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Europe/London" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "America/New York" })).toBeInTheDocument();
+  });
+
+  it("filters options as the user types", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const combobox = screen.getByRole("combobox", { name: "Timezone" });
+    await user.click(combobox);
+    await user.clear(combobox);
+    await user.type(combobox, "london");
+
+    expect(screen.getByRole("option", { name: "Europe/London" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "UTC" })).not.toBeInTheDocument();
+  });
+
+  it("commits a selection on click and updates the displayed value", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("combobox", { name: "Timezone" }));
+    await user.click(screen.getByRole("option", { name: "Europe/London" }));
+
+    expect(screen.getByRole("combobox", { name: "Timezone" })).toHaveValue(
+      "Europe/London"
+    );
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("keeps a committed selection after clicking away, rather than reverting to the value from mount", async () => {
+    // Regression test: the outside-click listener used to be captured once
+    // on mount and never refreshed, so it always reverted to whatever the
+    // *initial* value was (here "UTC") on every later blur, no matter what
+    // had since been selected.
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("combobox", { name: "Timezone" }));
+    await user.click(screen.getByRole("option", { name: "Europe/London" }));
+    await user.click(document.body);
+
+    expect(screen.getByRole("combobox", { name: "Timezone" })).toHaveValue(
+      "Europe/London"
+    );
+  });
+
+  it("commits the highlighted option on Enter after arrow-key navigation", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const combobox = screen.getByRole("combobox", { name: "Timezone" });
+    await user.click(combobox);
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+
+    expect(combobox).toHaveValue("Europe/London");
+  });
+
+  it("reverts an abandoned query on Escape without calling onChange", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <TimezoneSelect
+        options={options}
+        value="UTC"
+        onChange={handleChange}
+        ariaLabel="Timezone"
+      />
+    );
+
+    const combobox = screen.getByRole("combobox", { name: "Timezone" });
+    await user.click(combobox);
+    await user.clear(combobox);
+    await user.type(combobox, "nowhere");
+    await user.keyboard("{Escape}");
+
+    expect(combobox).toHaveValue("UTC");
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it("does not open the dropdown when disabled", async () => {
+    const user = userEvent.setup();
+    render(
+      <TimezoneSelect
+        options={options}
+        value="UTC"
+        onChange={() => {}}
+        ariaLabel="Timezone"
+        disabled
+      />
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Timezone" }));
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TimezoneSelect/TimezoneSelect.tsx
+++ b/frontend/src/components/TimezoneSelect/TimezoneSelect.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useRef } from "react";
+import type { KeyboardEvent } from "react";
+import classNames from "classnames";
+
+import { useTimezoneSelect } from "./useTimezoneSelect";
+import type { TimezoneChoice } from "../../types/api";
+import styles from "./TimezoneSelect.module.scss";
+
+const optionId = (index: number) => `timezone-select-option-${index}`;
+
+interface TimezoneSelectProps {
+  options: TimezoneChoice[];
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  ariaLabel?: string;
+  id?: string;
+  className?: string;
+}
+
+export default function TimezoneSelect({
+  options,
+  value,
+  onChange,
+  disabled = false,
+  ariaLabel = "Timezone",
+  id,
+  className,
+}: TimezoneSelectProps) {
+  const {
+    query,
+    isOpen,
+    highlightedIndex,
+    filteredOptions,
+    openDropdown,
+    closeDropdown,
+    handleQueryChange,
+    commitSelection,
+    selectHighlighted,
+    moveHighlight,
+  } = useTimezoneSelect({ options, value, onChange, disabled });
+
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        closeDropdown();
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [closeDropdown]);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) return;
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        moveHighlight(1);
+        return;
+      case "ArrowUp":
+        event.preventDefault();
+        moveHighlight(-1);
+        return;
+      case "Escape":
+        if (isOpen) event.preventDefault();
+        closeDropdown();
+        return;
+      case "Enter":
+        if (selectHighlighted()) event.preventDefault();
+        return;
+      default:
+        return;
+    }
+  };
+
+  return (
+    <div ref={rootRef} className={classNames(styles.root, className)}>
+      <input
+        id={id}
+        type="text"
+        role="combobox"
+        value={query}
+        onChange={(event) => handleQueryChange(event.target.value)}
+        onFocus={openDropdown}
+        onKeyDown={handleKeyDown}
+        aria-label={ariaLabel}
+        aria-autocomplete="list"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? "timezone-select-results" : undefined}
+        aria-activedescendant={
+          isOpen && highlightedIndex >= 0 ? optionId(highlightedIndex) : undefined
+        }
+        className={styles.input}
+        disabled={disabled}
+        autoComplete="off"
+      />
+
+      {isOpen && (
+        <ul
+          id="timezone-select-results"
+          className={styles.dropdown}
+          role="listbox"
+          aria-label="Timezone suggestions"
+        >
+          {filteredOptions.length === 0 && (
+            <li role="presentation" className={styles.emptyMessage}>
+              No matching timezones
+            </li>
+          )}
+          {filteredOptions.map((option, index) => (
+            <li
+              key={option.value}
+              id={optionId(index)}
+              role="option"
+              aria-selected={index === highlightedIndex}
+              className={styles.optionItem}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => commitSelection(option)}
+            >
+              <div
+                className={classNames(styles.optionButton, {
+                  [styles.optionButtonActive]: index === highlightedIndex,
+                  [styles.optionButtonSelected]: option.value === value,
+                })}
+              >
+                {option.label}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TimezoneSelect/useTimezoneSelect.ts
+++ b/frontend/src/components/TimezoneSelect/useTimezoneSelect.ts
@@ -1,0 +1,131 @@
+import { useCallback, useMemo, useState } from "react";
+import type { TimezoneChoice } from "../../types/api";
+
+interface UseTimezoneSelectArgs {
+  options: TimezoneChoice[];
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+// Caps the rendered list so typing a broad query (or focusing with an empty
+// query, which matches everything) doesn't mount ~400 <li> nodes at once -
+// narrowing the query trims the list back down, same as any typeahead.
+const MAX_VISIBLE_OPTIONS = 50;
+
+export function useTimezoneSelect({
+  options,
+  value,
+  onChange,
+  disabled,
+}: UseTimezoneSelectArgs) {
+  const selectedLabel = useMemo(
+    () => options.find((option) => option.value === value)?.label ?? value,
+    [options, value]
+  );
+
+  const [query, setQuery] = useState(selectedLabel);
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  // Keep the input's displayed text in sync when the selected value changes
+  // from outside (e.g. another tab's save, or the "use detected" hint).
+  // Adjusted during render rather than in an effect - React's documented
+  // pattern for syncing state to a changed prop without an extra render
+  // pass (react.dev/learn/you-might-not-need-an-effect).
+  const [prevSelectedLabel, setPrevSelectedLabel] = useState(selectedLabel);
+  if (selectedLabel !== prevSelectedLabel) {
+    setPrevSelectedLabel(selectedLabel);
+    setQuery(selectedLabel);
+  }
+
+  const filteredOptions = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    const matches =
+      normalizedQuery === "" || normalizedQuery === selectedLabel.toLowerCase()
+        ? options
+        : options.filter((option) =>
+            option.label.toLowerCase().includes(normalizedQuery)
+          );
+    return matches.slice(0, MAX_VISIBLE_OPTIONS);
+  }, [options, query, selectedLabel]);
+
+  // Stable-identity handlers (useCallback, correct deps) rather than plain
+  // closures: TimezoneSelect subscribes closeDropdown to a document
+  // mousedown listener, and a bare closure recreated every render would
+  // otherwise get captured once by an empty-deps effect - permanently
+  // pinned to whatever `selectedLabel` was at mount (see EntitySearchInput's
+  // useEntitySearchInput for the same pattern with onDismiss).
+  const openDropdown = useCallback(() => {
+    if (disabled) return;
+    setIsOpen(true);
+    setHighlightedIndex(-1);
+  }, [disabled]);
+
+  const closeDropdown = useCallback(() => {
+    setIsOpen(false);
+    setHighlightedIndex(-1);
+    // Revert to the last committed selection - an abandoned query shouldn't
+    // linger in the box looking like it was applied.
+    setQuery(selectedLabel);
+  }, [selectedLabel]);
+
+  const handleQueryChange = useCallback(
+    (nextQuery: string) => {
+      if (disabled) return;
+      setQuery(nextQuery);
+      setIsOpen(true);
+      setHighlightedIndex(-1);
+    },
+    [disabled]
+  );
+
+  const commitSelection = useCallback(
+    (option: TimezoneChoice) => {
+      onChange(option.value);
+      setQuery(option.label);
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+    },
+    [onChange]
+  );
+
+  const selectHighlighted = useCallback((): boolean => {
+    if (!isOpen || highlightedIndex < 0) return false;
+    const option = filteredOptions[highlightedIndex];
+    if (!option) return false;
+    commitSelection(option);
+    return true;
+  }, [isOpen, highlightedIndex, filteredOptions, commitSelection]);
+
+  const moveHighlight = useCallback(
+    (delta: number) => {
+      if (!isOpen) {
+        openDropdown();
+        return;
+      }
+      setHighlightedIndex((current) => {
+        const count = filteredOptions.length;
+        if (count === 0) return -1;
+        const next = current + delta;
+        if (next < 0) return count - 1;
+        if (next >= count) return 0;
+        return next;
+      });
+    },
+    [isOpen, filteredOptions.length, openDropdown]
+  );
+
+  return {
+    query,
+    isOpen,
+    highlightedIndex,
+    filteredOptions,
+    openDropdown,
+    closeDropdown,
+    handleQueryChange,
+    commitSelection,
+    selectHighlighted,
+    moveHighlight,
+  };
+}

--- a/frontend/src/pages/Account/Account.test.tsx
+++ b/frontend/src/pages/Account/Account.test.tsx
@@ -15,6 +15,10 @@ const mockDownloadUserData = vi.fn();
 const mockDeleteAccount = vi.fn();
 const mockFetchPreferences = vi.fn();
 const mockUpdatePreferences = vi.fn();
+const mockFetchTimezoneChoices = vi.fn();
+const mockUpdateUserSettings = vi.fn();
+const mockSetUser = vi.fn();
+const mockUseAuth = vi.fn();
 
 const TEST_BILLING_PORTAL_URL = "https://billing.stripe.com/p/login/test_portal";
 
@@ -31,6 +35,15 @@ vi.mock("../../api/player", () => ({
 vi.mock("../../api/preferences", () => ({
   fetchPreferences: (...args) => mockFetchPreferences(...args),
   updatePreferences: (...args) => mockUpdatePreferences(...args),
+}));
+
+vi.mock("../../api/user", () => ({
+  fetchTimezoneChoices: (...args) => mockFetchTimezoneChoices(...args),
+  updateUserSettings: (...args) => mockUpdateUserSettings(...args),
+}));
+
+vi.mock("../../context/AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
 }));
 
 vi.mock("../../hooks/useAppConfig", () => ({
@@ -199,6 +212,26 @@ describe("Account", () => {
     mockDeleteAccount.mockReset();
     mockFetchPreferences.mockReset().mockResolvedValue({ preferences: [] });
     mockUpdatePreferences.mockReset();
+    mockFetchTimezoneChoices.mockReset().mockResolvedValue({
+      timezones: [
+        { value: "UTC", label: "UTC" },
+        { value: "Europe/London", label: "Europe/London" },
+        { value: "America/New_York", label: "America/New York" },
+      ],
+    });
+    mockUpdateUserSettings.mockReset();
+    mockSetUser.mockReset();
+    mockUseAuth.mockReset().mockReturnValue({
+      user: {
+        email: "test@example.com",
+        is_confirmed: true,
+        is_staff: false,
+        is_superuser: false,
+        date_of_birth: null,
+        timezone: "UTC",
+      },
+      setUser: mockSetUser,
+    });
     mockUseGame.mockReturnValue({
       player: mockPlayer(),
       loading: false,
@@ -626,5 +659,75 @@ describe("Account", () => {
       expect.anything()
     );
     await vi.waitFor(() => expect(checkbox).not.toBeChecked());
+  });
+
+  it("shows the saved timezone on the Preferences tab", async () => {
+    const user = userEvent.setup();
+
+    renderAccount();
+
+    await user.click(screen.getByRole("tab", { name: "Preferences" }));
+
+    expect(await screen.findByRole("heading", { name: "Timezone" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Timezone" })).toHaveValue("UTC");
+  });
+
+  it("updates the timezone when a new option is selected from the list", async () => {
+    const user = userEvent.setup();
+    mockUpdateUserSettings.mockResolvedValue({
+      email: "test@example.com",
+      is_confirmed: true,
+      is_staff: false,
+      is_superuser: false,
+      date_of_birth: null,
+      timezone: "Europe/London",
+    });
+
+    renderAccount();
+
+    await user.click(screen.getByRole("tab", { name: "Preferences" }));
+    const combobox = await screen.findByRole("combobox", { name: "Timezone" });
+    await user.click(combobox);
+    await user.click(await screen.findByRole("option", { name: "Europe/London" }));
+
+    expect(mockUpdateUserSettings).toHaveBeenCalledWith(
+      { timezone: "Europe/London" },
+      expect.anything()
+    );
+    await vi.waitFor(() => expect(mockSetUser).toHaveBeenCalled());
+  });
+
+  it("offers to switch to the browser-detected timezone when it differs from the saved one", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: "Europe/London" }),
+        }) as Intl.DateTimeFormat
+    );
+    mockUpdateUserSettings.mockResolvedValue({
+      email: "test@example.com",
+      is_confirmed: true,
+      is_staff: false,
+      is_superuser: false,
+      date_of_birth: null,
+      timezone: "Europe/London",
+    });
+
+    renderAccount();
+
+    await user.click(screen.getByRole("tab", { name: "Preferences" }));
+    const hintButton = await screen.findByRole("button", {
+      name: /use detected timezone \(europe\/london\)/i,
+    });
+
+    await user.click(hintButton);
+
+    expect(mockUpdateUserSettings).toHaveBeenCalledWith(
+      { timezone: "Europe/London" },
+      expect.anything()
+    );
+
+    vi.restoreAllMocks();
   });
 });

--- a/frontend/src/pages/Account/Account.tsx
+++ b/frontend/src/pages/Account/Account.tsx
@@ -3,11 +3,13 @@ import React, { useState } from "react";
 import Achievements from "../../components/Achievements/Achievements";
 import Button from "../../components/Button/Button";
 import * as Tabs from "../../components/Tabs/Tabs";
+import TimezoneSelect from "../../components/TimezoneSelect/TimezoneSelect";
 import {
   PLAYER_NAME_MAX_LENGTH,
 } from "../../utils/playerNameValidation";
 import { useAccountPage } from "./useAccountPage";
 import { usePreferencesTab } from "./usePreferencesTab";
+import { useTimezonePreference } from "./useTimezonePreference";
 import styles from "./Account.module.scss";
 
 export default function Account(): React.ReactElement {
@@ -50,6 +52,18 @@ export default function Account(): React.ReactElement {
     handleToggle,
     pendingKey,
   } = usePreferencesTab();
+
+  const {
+    timezones,
+    timezonesLoading,
+    timezonesError,
+    currentTimezone,
+    detectedTimezone,
+    showDetectedTimezoneHint,
+    handleTimezoneChange,
+    isUpdating: isUpdatingTimezone,
+    updateError: timezoneUpdateError,
+  } = useTimezonePreference();
 
   const [activeTab, setActiveTab] = useState("account");
 
@@ -284,6 +298,51 @@ export default function Account(): React.ReactElement {
           </Tabs.Content>
 
           <Tabs.Content value="preferences" className={styles.tabContent}>
+            <section className={styles.section}>
+              <h2>Timezone</h2>
+              <p className={styles.description}>
+                Used to work out when your day rolls over.
+              </p>
+              {timezonesLoading && (
+                <p className={styles.description}>Loading timezones...</p>
+              )}
+              {timezonesError && (
+                <p className={styles.fieldError} role="alert">
+                  Couldn't load the timezone list. Please try again later.
+                </p>
+              )}
+              {!timezonesLoading && !timezonesError && (
+                <div className={styles.infoItem}>
+                  <label className={styles.label} htmlFor="account-timezone">
+                    Timezone
+                  </label>
+                  <TimezoneSelect
+                    id="account-timezone"
+                    options={timezones}
+                    value={currentTimezone}
+                    onChange={handleTimezoneChange}
+                    disabled={isUpdatingTimezone}
+                    ariaLabel="Timezone"
+                  />
+                  {showDetectedTimezoneHint && detectedTimezone && (
+                    <Button
+                      variant="secondary"
+                      className={styles.inlineButton}
+                      disabled={isUpdatingTimezone}
+                      onClick={() => handleTimezoneChange(detectedTimezone)}
+                    >
+                      Use detected timezone ({detectedTimezone})
+                    </Button>
+                  )}
+                  {timezoneUpdateError && (
+                    <p className={styles.fieldError} role="alert">
+                      Couldn't update your timezone. Please try again.
+                    </p>
+                  )}
+                </div>
+              )}
+            </section>
+
             <section className={styles.section}>
               <h2>Notifications</h2>
               {preferencesLoading && (

--- a/frontend/src/pages/Account/useTimezonePreference.ts
+++ b/frontend/src/pages/Account/useTimezonePreference.ts
@@ -1,0 +1,64 @@
+import { useMemo } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { useAuth } from "../../context/AuthContext";
+import { fetchTimezoneChoices, updateUserSettings } from "../../api/user";
+
+const TIMEZONE_CHOICES_QUERY_KEY = ["timezoneChoices"];
+
+/** Best-effort browser timezone detection - unsupported/sandboxed
+ * environments can throw or return an empty string, in which case there's
+ * nothing to suggest and the picker just falls back to manual selection. */
+function detectBrowserTimezone(): string | null {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+  } catch {
+    return null;
+  }
+}
+
+export function useTimezonePreference() {
+  const { user, setUser } = useAuth();
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: TIMEZONE_CHOICES_QUERY_KEY,
+    queryFn: fetchTimezoneChoices,
+    // Reference data (IANA zone names) - doesn't change during a session.
+    staleTime: 60 * 60 * 1000,
+  });
+
+  const detectedTimezone = useMemo(() => detectBrowserTimezone(), []);
+
+  const updateMutation = useMutation({
+    mutationFn: updateUserSettings,
+    onSuccess: (updatedUser) => {
+      setUser(updatedUser);
+    },
+  });
+
+  const currentTimezone = user?.timezone ?? "UTC";
+
+  const handleTimezoneChange = (timezone: string) => {
+    if (!timezone || timezone === currentTimezone) return;
+    updateMutation.mutate({ timezone });
+  };
+
+  // Offered as a hint the user acts on, never applied automatically - a
+  // returning user's saved timezone (e.g. set at signup, or deliberately
+  // different from wherever they're currently browsing from) shouldn't be
+  // silently overwritten by whatever this device reports today.
+  const showDetectedTimezoneHint =
+    !!detectedTimezone && detectedTimezone !== currentTimezone;
+
+  return {
+    timezones: data?.timezones ?? [],
+    timezonesLoading: isLoading,
+    timezonesError: isError,
+    currentTimezone,
+    detectedTimezone,
+    showDetectedTimezoneHint,
+    handleTimezoneChange,
+    isUpdating: updateMutation.isPending,
+    updateError: updateMutation.isError,
+  };
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -58,6 +58,17 @@ export interface UserPreferencesResponse {
   preferences: UserPreference[];
 }
 
+/** One IANA timezone name accepted by PATCH /me/user_settings/, with a
+ * display label (api/views.py MeViewSet.timezone_choices). */
+export interface TimezoneChoice {
+  value: string;
+  label: string;
+}
+
+export interface TimezoneChoicesResponse {
+  timezones: TimezoneChoice[];
+}
+
 /** Registration status (public, unauthenticated) */
 export interface RegistrationStatus {
   registration_open: boolean;


### PR DESCRIPTION
## Summary

Adds a timezone preference to the Account page's Preferences tab. Timezone was already a real `CustomUser` field (used to work out day rollover), editable via the existing `PATCH /me/user_settings/` — only a picker UI was missing.

- New `GET /me/timezone_choices/` action on `MeViewSet`, returning `{value, label}` pairs sourced from `zoneinfo.available_timezones()` via `timezone_field.choices.standard()`, for a friendly sorted list instead of ~400 raw IANA strings.
- Frontend: `TimezoneSelect`, a searchable accessible combobox (aria-combobox/listbox pattern, following `EntitySearchInput`'s conventions), wired into the Account page via `useTimezonePreference`, which reads/writes through the existing `AuthContext` user rather than a new query hook.
- Offers a "Use detected timezone (X)" hint (from `Intl.DateTimeFormat`) without ever auto-applying it — the user always confirms.

## Testing

- Backend: new tests for `timezone_choices` (auth required, value/label pairs, every returned value accepted by `user_settings`) and for updating/rejecting an invalid timezone via `user_settings`.
- Frontend: `TimezoneSelect.test.tsx` (8 tests) covering open/filter/select/keyboard nav/disabled state, plus a regression test for a stale-closure bug found during manual testing (see below). `Account.test.tsx` extended with 3 tests for the new Timezone section.

## Bug fixed along the way

Manual testing surfaced a bug where a selected timezone reverted to UTC on blur: `TimezoneSelect`'s outside-click handler was subscribed with an empty effect dependency array, so it permanently captured the mount-time `closeDropdown` closure — and with it the mount-time `selectedLabel` ("UTC") — reverting every later selection back to UTC. Fixed by memoizing the handlers with `useCallback` (matching `useEntitySearchInput`'s `onDismiss` pattern) and depending the effect on the current `closeDropdown`. Verified by reverting to the buggy code and confirming the new regression test fails as reported, then restoring the fix.
